### PR TITLE
Reduce jQuery usage in Razor view inline JavaScript

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
@@ -99,61 +99,93 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script depends-on="jQuery"  at="Foot">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+        function checkedItems() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
+        }
+
+        function setDisplay(elements, display) {
+            if (!elements) {
+                return;
             }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+
+            if (elements instanceof NodeList) {
+                elements.forEach(function (element) {
+                    element.style.display = display;
+                });
+            } else {
+                elements.style.display = display;
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
+        function displayActionsOrFilters() {
+            if (checkedItems().length > 1) {
+                setDisplay(actions, '');
+                setDisplay(filters, 'none');
+                setDisplay(selectedItems, '');
+                setDisplay(items, 'none');
+            }
+            else {
+                setDisplay(actions, 'none');
+                setDisplay(filters, '');
+                setDisplay(selectedItems, 'none');
+                setDisplay(items, '');
+            }
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (checkedItems().length > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = item.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
                         }
+                    });
+                }
+            });
+        });
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (item) {
+                    if (item !== selectAllCtrl) {
+                        item.checked = selectAllCtrl.checked;
                     }
                 });
-            }
+
+                selectedItems.textContent = checkedItems().length + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
+        }
+
+        itemsCheckboxes.forEach(function (item) {
+            item.addEventListener("click", function () {
+                var itemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']").length;
+                var selectedItemsCount = checkedItems().length;
+
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
+                }
+
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
-
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
-
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
-
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
-
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
-    })
+    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Views/AliasPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Views/AliasPartSettings.Edit.cshtml
@@ -27,9 +27,9 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jquery">
+<script at="Foot">
     //<![CDATA[
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailSettings.Edit.cshtml
@@ -77,24 +77,33 @@
 </section>
 
 <script at="Foot" type="text/javascript">
-    $(function () {
-        $('.check-all-container').each(function () {
-            var container = $(this);
-            var master = container.find('input[type="checkbox"].check-all-master');
-            var slaves = container.find('.check-all-slave input[type="checkbox"]:not(:disabled)');
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.check-all-container').forEach(function (container) {
+            var master = container.querySelector('input[type="checkbox"].check-all-master');
+            var slaves = container.querySelectorAll('.check-all-slave input[type="checkbox"]:not(:disabled)');
 
-            var updateMaster = function () {
-                var allChecked = slaves.filter(':not(:checked)').length == 0;
-                master.prop('checked', allChecked);
+            if (!master) {
+                return;
             }
 
-            master.on('change', function () {
-                var isChecked = $(this).is(':checked');
-                slaves.prop('checked', isChecked);
+            var updateMaster = function () {
+                var allChecked = Array.from(slaves).filter(function (slave) {
+                    return !slave.checked;
+                }).length == 0;
+                master.checked = allChecked;
+            }
+
+            master.addEventListener('change', function () {
+                var isChecked = this.checked;
+                slaves.forEach(function (slave) {
+                    slave.checked = isChecked;
+                });
             });
 
-            slaves.on('change', function () {
-                updateMaster();
+            slaves.forEach(function (slave) {
+                slave.addEventListener('change', function () {
+                    updateMaster();
+                });
             });
 
             updateMaster();

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePart.Edit.cshtml
@@ -120,12 +120,15 @@
 
 @if (Model.Settings.AllowDisabled)
 {
-    <script at="Foot" depends-on="jquery">
-        $('#@Html.IdFor(i => i.Disabled)').change(function (e) {
-            var checked = $(e.target).prop('checked');
-            $('.autoroute-disabled').each(function () {
-                checked ? $(this).hide() : $(this).show();
+    <script at="Foot">
+        var disabledElement = document.getElementById('@Html.IdFor(i => i.Disabled)');
+        if (disabledElement) {
+            disabledElement.addEventListener('change', function (e) {
+                var checked = e.target.checked;
+                document.querySelectorAll('.autoroute-disabled').forEach(function (element) {
+                    element.style.display = checked ? 'none' : '';
+                });
             });
-        });
+        }
     </script>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePartSettings.Edit.cshtml
@@ -101,9 +101,9 @@
     </div>
 </fieldset>
 
-<script at="Foot" depends-on="jquery">
+<script at="Foot">
     //<![CDATA[
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
             autoRefresh: true,
             lineNumbers: true,
@@ -112,11 +112,14 @@
             mode: { name: "liquid" },
         });
     });
-    $('#@Html.IdFor(i => i.ManageContainedItemRoutes)').change(function (e) {
-        var checked = $(e.target).prop('checked');
-        $('.manage-contained-item-routes').each(function () {
-            checked ? $(this).show() : $(this).hide();
+    var manageContainedItemRoutesElement = document.getElementById('@Html.IdFor(i => i.ManageContainedItemRoutes)');
+    if (manageContainedItemRoutesElement) {
+        manageContainedItemRoutesElement.addEventListener('change', function (e) {
+            var checked = e.target.checked;
+            document.querySelectorAll('.manage-contained-item-routes').forEach(function (element) {
+                element.style.display = checked ? '' : 'none';
+            });
         });
-    });
+    }
                                                             //]]>
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerFieldSettings.Edit.cshtml
@@ -121,9 +121,9 @@
     });
 </script>
 
-<script at="Foot" depends-on="jquery">
+<script at="Foot">
     //<![CDATA[
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.TitlePattern)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
@@ -65,7 +65,7 @@
 
             editor.getModel().onDidChangeContent((event) => {
                 textArea.value = editor.getValue();
-                $(document).trigger('contentpreview:render');
+                document.dispatchEvent(new Event('contentpreview:render'));
             });
 
             const shortcodesAction = {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -31,7 +31,7 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
     @* When the field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
         if (optionsTextArea) {
@@ -49,7 +49,7 @@
 
             editor.on('change', function (cmEditor) {
                 cmEditor.save();
-                $(document).trigger('contentpreview:render');
+                document.dispatchEvent(new Event('contentpreview:render'));
             });
         }
     });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldTrumbowygEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldTrumbowygEditorSettings.Edit.cshtml
@@ -23,7 +23,7 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -48,7 +48,10 @@
         {
         <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)'); </text>
         }
-        $('#' + id).val(value);
+        var element = document.getElementById(id);
+        if (element) {
+            element.value = value;
+        }
     }
 
     function numericFieldRangeSync(id, value) {
@@ -57,6 +60,9 @@
         <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)'); </text>
         }
         value = (Number(value) || 0);
-        $('#' + id).val(value);
+        var element = document.getElementById(id);
+        if (element) {
+            element.value = value;
+        }
     }
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -57,7 +57,10 @@
 <script at="Foot">
 
     var slider = document.getElementById('@(id)-nouislider');
-    var serverDecimalSeparator = $("<textarea/>").html('@serverDecimalSeparator').val()
+    var input = document.getElementById('@(id)');
+    var serverDecimalSeparatorDecoder = document.createElement('textarea');
+    serverDecimalSeparatorDecoder.innerHTML = '@serverDecimalSeparator';
+    var serverDecimalSeparator = serverDecimalSeparatorDecoder.value;
 
     noUiSlider.create(slider, {
         start: [@min],
@@ -78,16 +81,20 @@
         {
             <text>value = value.replace('@(javascriptDecimalSeparator)', serverDecimalSeparator); </text>
         }
-        $('#@(id)').val(value);
+        if (input) {
+            input.value = value;
+        }
     });
 
-    $('#@(id)').on('keyup', function () {
-        let value = this.value;
+    if (input) {
+        input.addEventListener('keyup', function () {
+            let value = this.value;
     @if (javascriptDecimalSeparator != serverDecimalSeparator)
     {
         <text>value = value.replace(serverDecimalSeparator, '@(javascriptDecimalSeparator)'); </text>
     }
-        slider.noUiSlider.set(Number(value) || 0);
-    });
+            slider.noUiSlider.set(Number(value) || 0);
+        });
+    }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
@@ -48,7 +48,12 @@
 <script asp-name="numericFieldSpinner" at="Foot">
 
     function numericFieldSpinner(id, scale, step, min, max) {
-        let value = $('#' + id).val();
+        let element = document.getElementById(id);
+        if (!element) {
+            return;
+        }
+
+        let value = element.value;
     @if (javascriptDecimalSeparator != serverDecimalSeparator)
     {
         <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)'); </text>
@@ -61,7 +66,7 @@
     {
         <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)'); </text>
     }
-            $('#' + id).val(value);
+            element.value = value;
     }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
@@ -45,7 +45,7 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Text)');
         // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {
@@ -61,7 +61,7 @@
 
             editor.on('change', function (cmEditor) {
                 cmEditor.save();
-                $(document).trigger('contentpreview:render');
+                document.dispatchEvent(new Event('contentpreview:render'));
             });
         }
     });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
@@ -79,7 +79,7 @@
             });
             editor.getModel().onDidChangeContent((event) => {
                 textArea.value = editor.getValue();
-                $(document).trigger('contentpreview:render');
+                document.dispatchEvent(new Event('contentpreview:render'));
             });
         });
     });

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -3,8 +3,6 @@
     var previewId = ViewContext.RouteData.Values["id"];
 }
 
-<script asp-name="jQuery" at="Foot"></script>
-
 <iframe id="iframe-a" title="preview" style="position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999990;"></iframe>
 <iframe id="iframe-b" title="preview-staging" style="position:fixed; top:0; left:0; bottom:0; right:0; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999989;"></iframe>
 
@@ -94,13 +92,20 @@
             }
         };
 
-        $(function () {
-            $('#close-connect-warning').on('click', function () {
-                $('#notConnectedWarning').hide();
-            });
-            $('#close-server-warning').on('click', function () {
-                $('#serverErrorWarning').hide();
-            });
+        document.addEventListener('DOMContentLoaded', function () {
+            var closeConnectWarning = document.getElementById('close-connect-warning');
+            if (closeConnectWarning) {
+                closeConnectWarning.addEventListener('click', function () {
+                    document.getElementById('notConnectedWarning').style.display = 'none';
+                });
+            }
+
+            var closeServerWarning = document.getElementById('close-server-warning');
+            if (closeServerWarning) {
+                closeServerWarning.addEventListener('click', function () {
+                    document.getElementById('serverErrorWarning').style.display = 'none';
+                });
+            }
 
             // Signal the editor that the preview window is ready to receive updates.
             channel.postMessage({ type: 'ready' });

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/PreviewPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/PreviewPartSettings.Edit.cshtml
@@ -18,9 +18,9 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jquery">
+<script at="Foot">
     //<![CDATA[
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditField.cshtml
@@ -111,28 +111,52 @@
 
 <script at="Foot">
     //<![CDATA[
-    $(function () {
-        $('.field-editor').hide();
-        $('#field-editor-container').show();
-        var fieldEditorSelect = $('#field-editor-select');
-        if (fieldEditorSelect.length > 0) {
-            $('.field-editor-' + fieldEditorSelect.val().toLowerCase()).show();
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.field-editor').forEach(function (element) {
+            element.style.display = 'none';
+        });
+        var fieldEditorContainer = document.getElementById('field-editor-container');
+        if (fieldEditorContainer) {
+            fieldEditorContainer.style.display = '';
+        }
 
-            fieldEditorSelect.change(function () {
-                $('.field-editor').hide();
-                $('.field-editor-' + fieldEditorSelect.val().toLowerCase()).show();
+        var fieldEditorSelect = document.getElementById('field-editor-select');
+        if (fieldEditorSelect) {
+            document.querySelectorAll('.field-editor-' + fieldEditorSelect.value.toLowerCase()).forEach(function (element) {
+                element.style.display = '';
+            });
+
+            fieldEditorSelect.addEventListener('change', function () {
+                document.querySelectorAll('.field-editor').forEach(function (element) {
+                    element.style.display = 'none';
+                });
+                document.querySelectorAll('.field-editor-' + fieldEditorSelect.value.toLowerCase()).forEach(function (element) {
+                    element.style.display = '';
+                });
             });
         }
 
-        $('.field-display').hide();
-        $('#field-display-container').show();
-        var fieldDisplaySelect = $('#field-display-select');
-        if (fieldDisplaySelect.length > 0) {
-            $('.field-display-' + fieldDisplaySelect.val().toLowerCase()).show();
+        document.querySelectorAll('.field-display').forEach(function (element) {
+            element.style.display = 'none';
+        });
+        var fieldDisplayContainer = document.getElementById('field-display-container');
+        if (fieldDisplayContainer) {
+            fieldDisplayContainer.style.display = '';
+        }
 
-            fieldDisplaySelect.change(function () {
-                $('.field-display').hide();
-                $('.field-display-' + fieldDisplaySelect.val().toLowerCase()).show();
+        var fieldDisplaySelect = document.getElementById('field-display-select');
+        if (fieldDisplaySelect) {
+            document.querySelectorAll('.field-display-' + fieldDisplaySelect.value.toLowerCase()).forEach(function (element) {
+                element.style.display = '';
+            });
+
+            fieldDisplaySelect.addEventListener('change', function () {
+                document.querySelectorAll('.field-display').forEach(function (element) {
+                    element.style.display = 'none';
+                });
+                document.querySelectorAll('.field-display-' + fieldDisplaySelect.value.toLowerCase()).forEach(function (element) {
+                    element.style.display = '';
+                });
             });
         }
     });

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditTypePart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditTypePart.cshtml
@@ -110,29 +110,52 @@
 
 <script at="Foot">
     //<![CDATA[
-    $(function () {
-        $('.type-part-editor').hide();
-        $('#type-part-editor-container').show();
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.type-part-editor').forEach(function (element) {
+            element.style.display = 'none';
+        });
+        var typePartEditorContainer = document.getElementById('type-part-editor-container');
+        if (typePartEditorContainer) {
+            typePartEditorContainer.style.display = '';
+        }
 
-        var typePartEditorSelect = $('#type-part-editor-select');
-        if (typePartEditorSelect.length > 0) {
-            $('.type-part-editor-' + typePartEditorSelect.val().toLowerCase()).show();
+        var typePartEditorSelect = document.getElementById('type-part-editor-select');
+        if (typePartEditorSelect) {
+            document.querySelectorAll('.type-part-editor-' + typePartEditorSelect.value.toLowerCase()).forEach(function (element) {
+                element.style.display = '';
+            });
 
-            typePartEditorSelect.change(function () {
-                $('.type-part-editor').hide();
-                $('.type-part-editor-' + typePartEditorSelect.val().toLowerCase()).show();
+            typePartEditorSelect.addEventListener('change', function () {
+                document.querySelectorAll('.type-part-editor').forEach(function (element) {
+                    element.style.display = 'none';
+                });
+                document.querySelectorAll('.type-part-editor-' + typePartEditorSelect.value.toLowerCase()).forEach(function (element) {
+                    element.style.display = '';
+                });
             });
         }
 
-        $('.type-part-display').hide();
-        $('#type-part-display-container').show();
-        var typePartDisplaySelect = $('#type-part-display-select');
-        if (typePartDisplaySelect.length > 0) {
-            $('.type-part-display-' + typePartDisplaySelect.val().toLowerCase()).show();
+        document.querySelectorAll('.type-part-display').forEach(function (element) {
+            element.style.display = 'none';
+        });
+        var typePartDisplayContainer = document.getElementById('type-part-display-container');
+        if (typePartDisplayContainer) {
+            typePartDisplayContainer.style.display = '';
+        }
 
-            typePartDisplaySelect.change(function () {
-                $('.type-part-display').hide();
-                $('.type-part-display-' + typePartDisplaySelect.val().toLowerCase()).show();
+        var typePartDisplaySelect = document.getElementById('type-part-display-select');
+        if (typePartDisplaySelect) {
+            document.querySelectorAll('.type-part-display-' + typePartDisplaySelect.value.toLowerCase()).forEach(function (element) {
+                element.style.display = '';
+            });
+
+            typePartDisplaySelect.addEventListener('change', function () {
+                document.querySelectorAll('.type-part-display').forEach(function (element) {
+                    element.style.display = 'none';
+                });
+                document.querySelectorAll('.type-part-display-' + typePartDisplaySelect.value.toLowerCase()).forEach(function (element) {
+                    element.style.display = '';
+                });
             });
         }
     });

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ContentDefinitionDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ContentDefinitionDeploymentStep.Fields.Edit.cshtml
@@ -113,35 +113,70 @@
 </div>
 
 <script at="Foot">
-    $(function () {
-        $("[data-reversetoggle]").on("click", function () {
-            var state = this.checked;
-            if (state) {
-                $($(this).attr("data-reversetoggle")).collapse('hide');
-            } else {
-                $($(this).attr("data-reversetoggle")).collapse('show');
-            }
-        });
-        $("[data-checkbox]").on("click", function () {
-            var state = this.checked;
-            $($(this).attr("data-checkbox"))
-                .prop("checked", state);
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll("[data-reversetoggle]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-reversetoggle");
+
+                if (!selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    var collapse = bootstrap.Collapse.getOrCreateInstance(target);
+                    if (state) {
+                        collapse.hide();
+                    } else {
+                        collapse.show();
+                    }
+                });
+            });
         });
 
-        $("[data-checkboxChecked]").on("click", function () {
-            var state = this.checked;
-            if (state) {
-                $($(this).attr("data-checkboxChecked"))
-                    .prop("checked", state);
-            }
+        document.querySelectorAll("[data-checkbox]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-checkbox");
+
+                if (!selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    target.checked = state;
+                });
+            });
         });
 
-        $("[data-checkboxUnchecked]").on("click", function () {
-            var state = this.checked;
-            if (!state) {
-                $($(this).attr("data-checkboxUnchecked"))
-                    .prop("checked", state);
-            }
+        document.querySelectorAll("[data-checkboxchecked]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-checkboxchecked");
+
+                if (!state || !selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    target.checked = state;
+                });
+            });
+        });
+
+        document.querySelectorAll("[data-checkboxunchecked]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-checkboxunchecked");
+
+                if (state || !selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    target.checked = state;
+                });
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ReplaceContentDefinitionDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ReplaceContentDefinitionDeploymentStep.Fields.Edit.cshtml
@@ -113,39 +113,74 @@
 </div>
 
 <script at="Foot">
-    $(function () {
-        $("[data-reversetoggle]").on("click", function () {
-            var state = this.checked;
-            if (state) {
-                $($(this).attr("data-reversetoggle")).collapse('hide');
-            } else {
-                $($(this).attr("data-reversetoggle")).collapse('show');
-            }
-        });
-        $("[data-checkbox]").on("click", function () {
-            var state = this.checked;
-            $($(this).attr("data-checkbox"))
-                .prop("checked", state);
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll("[data-reversetoggle]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-reversetoggle");
+
+                if (!selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    var collapse = bootstrap.Collapse.getOrCreateInstance(target);
+                    if (state) {
+                        collapse.hide();
+                    } else {
+                        collapse.show();
+                    }
+                });
+            });
         });
 
-        $("[data-checkboxChecked]").on("click", function () {
-            var state = this.checked;
-            if (state) {
-                $($(this).attr("data-checkboxChecked"))
-                    .prop("checked", state);
-            }
+        document.querySelectorAll("[data-checkbox]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-checkbox");
+
+                if (!selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    target.checked = state;
+                });
+            });
         });
 
-        $("[data-checkboxUnchecked]").on("click", function () {
-            var state = this.checked;
-            if (!state) {
-                $($(this).attr("data-checkboxUnchecked"))
-                    .prop("checked", state);
-            }
+        document.querySelectorAll("[data-checkboxchecked]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-checkboxchecked");
+
+                if (!state || !selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    target.checked = state;
+                });
+            });
+        });
+
+        document.querySelectorAll("[data-checkboxunchecked]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                var selector = this.getAttribute("data-checkboxunchecked");
+
+                if (state || !selector) {
+                    return;
+                }
+
+                document.querySelectorAll(selector).forEach(function (target) {
+                    target.checked = state;
+                });
+            });
         });
     });
 </script>
 
-<script at="Foot" depends-on="jQuery" asp-name="test">
+<script at="Foot" asp-name="test">
     console.log('test');
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Contents-BulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Contents-BulkActions.cshtml
@@ -13,21 +13,29 @@
 }
 
 <script at="Foot">
-    $(function () {
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
             }
+
+            item.addEventListener("click", function () {
+                if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                    var data = { ...this.dataset };
+                    confirmDialog({
+                        ...data, callback: function (r) {
+                            if (r) {
+                                var bulkAction = document.querySelector("[name='Options.BulkAction']");
+                                if (bulkAction) {
+                                    bulkAction.value = data.action;
+                                }
+
+                                document.querySelector("[name='submit.BulkAction']")?.click();
+                            }
+                        }
+                    });
+                }
+            });
         });
-    })
+    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.cshtml
@@ -51,66 +51,107 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
         const submitFilterButton = document.querySelector("[name='submit.Filter']");
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
     @* This applies to all filter selectpickers on page. Add .nosubmit to not submit *@
         document.querySelectorAll('.selectpicker:not(.nosubmit)').forEach((element) => {
             element.addEventListener('changed.bs.select', () => submitFilterButton?.click());
         });
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        function selectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
             }
+
+            item.addEventListener("click", function () {
+                if (selectedItemsCount() > 1) {
+                    var data = { ...this.dataset };
+                    confirmDialog({
+                        ...data, callback: function (r) {
+                            if (r) {
+                                var bulkAction = document.querySelector("[name='Options.BulkAction']");
+                                if (bulkAction) {
+                                    bulkAction.value = data.action;
+                                }
+
+                                document.querySelector("[name='submit.BulkAction']")?.click();
+                            }
+                        }
+                    });
+                }
+            });
         });
+
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (selectedItemsCount() > 1) {
+                if (actions) {
+                    actions.style.display = '';
+                }
+                filters.forEach(function (filter) {
+                    filter.style.display = 'none';
+                });
+                if (selectedItems) {
+                    selectedItems.style.display = '';
+                }
+                if (items) {
+                    items.style.display = 'none';
+                }
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                if (actions) {
+                    actions.style.display = 'none';
+                }
+                filters.forEach(function (filter) {
+                    filter.style.display = '';
+                });
+                if (selectedItems) {
+                    selectedItems.style.display = 'none';
+                }
+                if (items) {
+                    items.style.display = '';
+                }
             }
         }
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
+        selectAllCtrl?.addEventListener("click", function () {
+            itemsCheckboxes.forEach(function (checkbox) {
+                if (checkbox !== selectAllCtrl) {
+                    checkbox.checked = selectAllCtrl.checked;
+                }
+            });
+            if (selectedItems) {
+                selectedItems.textContent = selectedItemsCount() + ' @T["selected"]';
+            }
             displayActionsOrFilters();
         });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var checkedItemsCount = selectedItemsCount();
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = checkedItemsCount == itemsCount;
+                    selectAllCtrl.indeterminate = checkedItemsCount > 0 && checkedItemsCount < itemsCount;
+                }
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                if (selectedItems) {
+                    selectedItems.textContent = checkedItemsCount + ' @T["selected"]';
+                }
+                displayActionsOrFilters();
+            });
         });
-    })
+    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Download/Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Download/Display.cshtml
@@ -40,7 +40,7 @@
 </form>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.ContentItemJson)'), {
             autoRefresh: true,
             lineNumbers: true,
@@ -49,12 +49,13 @@
             mode: { name: "javascript" },
         });
 
-        $('#json-copy-to-clipboard').on('click', function () {
-            var $temp = $("<textarea>");
-            $("body").append($temp);
-            $temp.val($('#@Html.IdFor(x => x.ContentItemJson)').text()).select();
+        document.getElementById('json-copy-to-clipboard')?.addEventListener('click', function () {
+            var temp = document.createElement("textarea");
+            document.body.appendChild(temp);
+            temp.value = document.getElementById('@Html.IdFor(x => x.ContentItemJson)')?.textContent || '';
+            temp.select();
             document.execCommand("copy");
-            $temp.remove();
-        })
+            temp.remove();
+        });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/FullTextAspectSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/FullTextAspectSettings.Edit.cshtml
@@ -61,8 +61,8 @@
         </div>
     </div>
 </div>
-<script at="Foot" depends-on="jquery">
-    $(function() {
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.FullTextTemplate)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ActionDeploymentPlan.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ActionDeploymentPlan.Modal.cshtml
@@ -43,33 +43,50 @@
         </div>
     </zone>
 
-    <script at="Foot" depends-on="jQuery">
-        $(function () {
-            $('#modalAddToDeploymentPlanActionDeploymentPlan').on('show.bs.modal', function (event) {
-                var button = $(event.relatedTarget) // Button that triggered the modal
-                var contentItemId = button.data('content-item-id');
+    <script at="Foot">
+        document.addEventListener('DOMContentLoaded', function () {
+            var modal = document.getElementById('modalAddToDeploymentPlanActionDeploymentPlan');
+            modal?.addEventListener('show.bs.modal', function (event) {
+                var button = event.relatedTarget;
+                var contentItemId = button?.dataset.contentItemId;
 
-                $('.add-to-deployment-plan').one('click', function () {
-                    var targetButton = this;
-                    var magicToken = $("input[name=__RequestVerificationToken]").first();
-                    if (magicToken) {
-                        var hrefParts = $(targetButton).data("target-url").split("?");
-                        var deployForm = $("<form action=\"" + hrefParts[0] + "\" method=\"POST\" />");
-                        deployForm.append(magicToken.clone());
+                document.querySelectorAll('.add-to-deployment-plan').forEach(function (button) {
+                    button.addEventListener('click', function () {
+                        var targetButton = this;
+                        var magicToken = document.querySelector("input[name=__RequestVerificationToken]");
+                        var hrefParts = targetButton.dataset.targetUrl.split("?");
+                        var deployForm = document.createElement("form");
+                        deployForm.action = hrefParts[0];
+                        deployForm.method = "POST";
+
+                        if (magicToken) {
+                            deployForm.appendChild(magicToken.cloneNode(true));
+                        }
+
                         if (hrefParts.length > 1) {
                             var queryParts = hrefParts[1].split("&");
                             for (var i = 0; i < queryParts.length; i++) {
                                 var queryPartKVP = queryParts[i].split("=");
                                 //trusting hrefs in the page here
-                                deployForm.append($("<input type=\"hidden\" name=\"" + decodeURIComponent(queryPartKVP[0]) + "\" value=\"" + decodeURIComponent(queryPartKVP[1]) + "\" />"));
+                                var input = document.createElement("input");
+                                input.type = "hidden";
+                                input.name = decodeURIComponent(queryPartKVP[0]);
+                                input.value = decodeURIComponent(queryPartKVP[1]);
+                                deployForm.appendChild(input);
                             }
                         }
-                        deployForm.append($("<input type=\"hidden\" name=\"contentItemId\" + value=\"" + contentItemId + "\"/>"));
-                        $("body").append(deployForm);
+
+                        var contentItemInput = document.createElement("input");
+                        contentItemInput.type = "hidden";
+                        contentItemInput.name = "contentItemId";
+                        contentItemInput.value = contentItemId;
+                        deployForm.appendChild(contentItemInput);
+
+                        document.body.appendChild(deployForm);
                         deployForm.submit();
-                    }
-                })
-            })
+                    }, { once: true });
+                });
+            });
         });
     </script>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-Button-ContentsBulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-Button-ContentsBulkActions.cshtml
@@ -1,14 +1,17 @@
 <a id="addToDeploymentPlanBulkActions" class="dropdown-item" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to add these items to a deployment plan?"]">@T["Add to deployment plan"]</a>
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        $('#addToDeploymentPlanBulkActions').on('click', function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        document.getElementById('addToDeploymentPlanBulkActions')?.addEventListener('click', function () {
+            if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                var data = { ...this.dataset };
                 confirmDialog({
-                    ...$this.data(), callback: function (r) {
+                    ...data, callback: function (r) {
                         if (r) {
-                            var modal = new bootstrap.Modal($('#modalAddToDeploymentPlanContentsBulkActionsDeploymentPlan'));
-                            modal.show();
+                            var modalElement = document.getElementById('modalAddToDeploymentPlanContentsBulkActionsDeploymentPlan');
+                            if (modalElement) {
+                                var modal = new bootstrap.Modal(modalElement);
+                                modal.show();
+                            }
                         }
                     }
                 });

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ContentsBulkActionsDeploymentPlan.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ContentsBulkActionsDeploymentPlan.Modal.cshtml
@@ -38,34 +38,50 @@
     </div>
 </zone>
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        $('#modalAddToDeploymentPlanContentsBulkActionsDeploymentPlan').on('show.bs.modal', function () {
-            var itemIds = $(":checkbox[name='itemIds']:checked");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        document.getElementById('modalAddToDeploymentPlanContentsBulkActionsDeploymentPlan')?.addEventListener('show.bs.modal', function () {
+            var itemIds = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
             if (itemIds.length > 1) {
-                $('.add-to-deployment-plan-bulk-actions').one('click', function () {
-                    var targetButton = this;
-                    var magicToken = $("input[name=__RequestVerificationToken]").first();
-                    if (magicToken) {
-                        var hrefParts = $(targetButton).data("target-url").split("?");
-                        var deployForm = $("<form action=\"" + hrefParts[0] + "\" method=\"POST\" />");
-                        deployForm.append(magicToken.clone());
+                document.querySelectorAll('.add-to-deployment-plan-bulk-actions').forEach(function (button) {
+                    button.addEventListener('click', function () {
+                        var targetButton = this;
+                        var magicToken = document.querySelector("input[name=__RequestVerificationToken]");
+                        var hrefParts = targetButton.dataset.targetUrl.split("?");
+                        var deployForm = document.createElement("form");
+                        deployForm.action = hrefParts[0];
+                        deployForm.method = "POST";
+
+                        if (magicToken) {
+                            deployForm.appendChild(magicToken.cloneNode(true));
+                        }
+
                         if (hrefParts.length > 1) {
                             var queryParts = hrefParts[1].split("&");
                             for (var i = 0; i < queryParts.length; i++) {
                                 var queryPartKVP = queryParts[i].split("=");
                                 //trusting hrefs in the page here
-                                deployForm.append($("<input type=\"hidden\" name=\"" + decodeURIComponent(queryPartKVP[0]) + "\" value=\"" + decodeURIComponent(queryPartKVP[1]) + "\" />"));
+                                var input = document.createElement("input");
+                                input.type = "hidden";
+                                input.name = decodeURIComponent(queryPartKVP[0]);
+                                input.value = decodeURIComponent(queryPartKVP[1]);
+                                deployForm.appendChild(input);
                             }
                         }
+
                         for (var i = 0; i < itemIds.length; i++) {
-                            deployForm.append($("<input type=\"hidden\" name=\"itemIds[" + i + "]\" + value=\"" + itemIds[i].value + "\"/>"));
+                            var itemInput = document.createElement("input");
+                            itemInput.type = "hidden";
+                            itemInput.name = "itemIds[" + i + "]";
+                            itemInput.value = itemIds[i].value;
+                            deployForm.appendChild(itemInput);
                         }
-                        $("body").append(deployForm);
+
+                        document.body.appendChild(deployForm);
                         deployForm.submit();
-                    }
-                })
+                    }, { once: true });
+                });
             }
-        })
+        });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesAdminNode.Fields.TreeEdit.cshtml
@@ -136,44 +136,73 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jquery">
-    $(function () {
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
         switchContentTypesCheckBoxes();
 
-        $('#ContentTypesAdminNode_ShowAll').change(function () {
+        document.getElementById('ContentTypesAdminNode_ShowAll')?.addEventListener('change', function () {
             switchContentTypesCheckBoxes();
         });
 
-        function switchContentTypesCheckBoxes() {
-            var showAll = $('#ContentTypesAdminNode_ShowAll').prop('checked');
-
-            if (showAll) {
-                $('#show-all-card').show();
-                $('#show-selected-card').hide();
-            } else {
-                $('#show-all-card').hide();
-                $('#show-selected-card').show();
+        function showElement(element) {
+            if (element) {
+                element.style.display = 'block';
             }
         }
 
-        $('.content-type-checkbox').on('click', function (e) {
-            var listItem = $(e.target).closest('.list-group-item');
+        function hideElement(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
 
-            var selected = $(e.target).prop('checked');
-            selected ? listItem.removeClass('disabled-content-type') : listItem.addClass('disabled-content-type');
+        function switchContentTypesCheckBoxes() {
+            var showAll = document.getElementById('ContentTypesAdminNode_ShowAll')?.checked;
+            var showAllCard = document.getElementById('show-all-card');
+            var showSelectedCard = document.getElementById('show-selected-card');
 
+            if (showAll) {
+                showElement(showAllCard);
+                hideElement(showSelectedCard);
+            } else {
+                hideElement(showAllCard);
+                showElement(showSelectedCard);
+            }
+        }
+
+        document.querySelectorAll('.content-type-checkbox').forEach(function (checkbox) {
+            checkbox.addEventListener('click', function (e) {
+                var listItem = e.target.closest('.list-group-item');
+                var selected = e.target.checked;
+
+                if (selected) {
+                    listItem?.classList.remove('disabled-content-type');
+                } else {
+                    listItem?.classList.add('disabled-content-type');
+                }
+            });
         });
 
-        $('.icon-picker-trigger').on('click', function (e) {
-
-            var node = $(e.target).data('related-node');
-            iconPickerVue.show(node, 'sample-icon-' + node);
+        document.querySelectorAll('.icon-picker-trigger').forEach(function (button) {
+            button.addEventListener('click', function () {
+                var node = this.dataset.relatedNode;
+                iconPickerVue.show(node, 'sample-icon-' + node);
+            });
         });
 
-        $('button.remove-icon').on('click', function (e) {
-            var node = $(e.target).data('related-node');
-            $('#' + node).val('');
-            $('#sample-icon-' + node).replaceWith('<i id="sample-icon-' + node + '" class=" "></i>'); // changing the class is not enough.
+        document.querySelectorAll('button.remove-icon').forEach(function (button) {
+            button.addEventListener('click', function () {
+                var node = this.dataset.relatedNode;
+                var input = document.getElementById(node);
+                if (input) {
+                    input.value = '';
+                }
+
+                var sampleIcon = document.getElementById('sample-icon-' + node);
+                if (sampleIcon) {
+                    sampleIcon.outerHTML = '<i id="sample-icon-' + node + '" class=" "></i>'; // changing the class is not enough.
+                }
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.Edit.cshtml
@@ -214,73 +214,89 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jquery">
-    $(function () {
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        function showElement(element) {
+            if (element) {
+                element.style.display = 'block';
+            }
+        }
+
+        function hideElement(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
         function switchContentTypesCheckBoxes() {
-            var indexAll = $('#ContentTypesSitemapSource_IndexAll').prop('checked');
-            var limitItems = $('#ContentTypesSitemapSource_LimitItems').prop('checked');
+            var indexAll = document.getElementById('ContentTypesSitemapSource_IndexAll')?.checked;
+            var limitItems = document.getElementById('ContentTypesSitemapSource_LimitItems')?.checked;
             if (indexAll) {
-                $('#index-all-row').show();
-                $('#index-selected-row').hide();
-                $('#index-limit-row').hide();
-                $('#ContentTypesSitemapSource_LimitItems_Container').hide();
+                showElement(document.getElementById('index-all-row'));
+                hideElement(document.getElementById('index-selected-row'));
+                hideElement(document.getElementById('index-limit-row'));
+                hideElement(document.getElementById('ContentTypesSitemapSource_LimitItems_Container'));
             } else {
-                $('#index-all-row').hide();
-                $('#ContentTypesSitemapSource_LimitItems_Container').show();
+                hideElement(document.getElementById('index-all-row'));
+                showElement(document.getElementById('ContentTypesSitemapSource_LimitItems_Container'));
                 if (limitItems) {
-                    $('#index-selected-row').hide();
-                    $('#index-limit-row').show();
+                    hideElement(document.getElementById('index-selected-row'));
+                    showElement(document.getElementById('index-limit-row'));
                 } else {
-                    $('#index-selected-row').show();
-                    $('#index-limit-row').hide();
+                    showElement(document.getElementById('index-selected-row'));
+                    hideElement(document.getElementById('index-limit-row'));
                 }
             }
         }
 
-        $('.content-type-checkbox').on('click', function (e) {
-            var listItem = $(e.target).closest('.list-group-item');
+        document.querySelectorAll('.content-type-checkbox').forEach(function (checkbox) {
+            checkbox.addEventListener('click', function (e) {
+                var listItem = e.target.closest('.list-group-item');
+                var selected = e.target.checked;
 
-            var selected = $(e.target).prop('checked');
-            $(listItem).find('select, input:not(.content-type-checkbox)').each(function () {
-                if (selected) {
-                    $(this).prop('readonly', false)
-                    $(this).prop('disabled', false);
-                } else {
-                    $(this).prop('readonly', true);
-                    $(this).prop('disabled', true);
-                }
+                listItem?.querySelectorAll('select, input:not(.content-type-checkbox)').forEach(function (element) {
+                    if (selected) {
+                        element.readOnly = false;
+                        element.disabled = false;
+                    } else {
+                        element.readOnly = true;
+                        element.disabled = true;
+                    }
+                });
             });
         });
 
-        $('.content-type-radio').on('click', function (e) {
-            var selectedContentType = $(e.target).val();
+        document.querySelectorAll('.content-type-radio').forEach(function (radio) {
+            radio.addEventListener('click', function (e) {
+                var selectedContentType = e.target.value;
 
-            $('#index-limit-row .list-group-item').each(function () {
-                var contentType = $(this).find('.content-type-radio').first().val();
-                if (contentType === selectedContentType) {
-                    $(this).find('select, input:not(.content-type-radio)').each(function () {
-                        $(this).prop('readonly', false);
-                    });
-                    $(this).find('select').each(function () {
-                        $(this).prop('disabled', false);
-                    });
-                } else {
-                    $(this).find('input:not(.content-type-radio)').each(function () {
-                        $(this).prop('readonly', true);
-                    });
+                document.querySelectorAll('#index-limit-row .list-group-item').forEach(function (listItem) {
+                    var contentType = listItem.querySelector('.content-type-radio')?.value;
+                    if (contentType === selectedContentType) {
+                        listItem.querySelectorAll('select, input:not(.content-type-radio)').forEach(function (element) {
+                            element.readOnly = false;
+                        });
+                        listItem.querySelectorAll('select').forEach(function (element) {
+                            element.disabled = false;
+                        });
+                    } else {
+                        listItem.querySelectorAll('input:not(.content-type-radio)').forEach(function (element) {
+                            element.readOnly = true;
+                        });
 
-                    $(this).find('select').each(function () {
-                        $(this).prop('disabled', true);
-                    });
-                }
+                        listItem.querySelectorAll('select').forEach(function (element) {
+                            element.disabled = true;
+                        });
+                    }
+                });
             });
         });
 
-        $('#ContentTypesSitemapSource_IndexAll').change(function () {
+        document.getElementById('ContentTypesSitemapSource_IndexAll')?.addEventListener('change', function () {
             switchContentTypesCheckBoxes();
         });
 
-        $('#ContentTypesSitemapSource_LimitItems').change(function () {
+        document.getElementById('ContentTypesSitemapSource_LimitItems')?.addEventListener('change', function () {
             switchContentTypesCheckBoxes();
         });
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/CreateContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/CreateContentTask.Fields.Edit.cshtml
@@ -39,7 +39,7 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-$(function () {
+document.addEventListener('DOMContentLoaded', function () {
     var editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.ContentProperties)'), {
         autoRefresh: true,
         lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/Download-Button-Actions.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/Download-Button-Actions.SummaryAdmin.cshtml
@@ -30,17 +30,25 @@ else
 }
 
 <script at="Foot">
-    $(function () {
-        $('#@exportDraftId').on('click', function () {
-            $(this).closest(".dropdown-menu").prev().dropdown("toggle");
+    document.addEventListener('DOMContentLoaded', function () {
+        function toggleDropdown(element) {
+            var dropdownMenu = element.closest(".dropdown-menu");
+            var dropdownToggle = dropdownMenu?.previousElementSibling;
+            if (dropdownToggle) {
+                bootstrap.Dropdown.getOrCreateInstance(dropdownToggle).toggle();
+            }
+        }
+
+        document.getElementById('@exportDraftId')?.addEventListener('click', function () {
+            toggleDropdown(this);
         });
 
-        $('#@exportPublishedId').on('click', function () {
-            $(this).closest(".dropdown-menu").prev().dropdown("toggle");
+        document.getElementById('@exportPublishedId')?.addEventListener('click', function () {
+            toggleDropdown(this);
         });
 
-        $('#@exportId').on('click', function () {
-            $(this).closest(".dropdown-menu").prev().dropdown("toggle");
+        document.getElementById('@exportId')?.addEventListener('click', function () {
+            toggleDropdown(this);
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ActionDeploymentTarget.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ActionDeploymentTarget.Modal.cshtml
@@ -42,37 +42,59 @@
         </div>
     </zone>
 
-    <script at="Foot" depends-on="jQuery">
-        $(function () {
-            $('#modalExportContentToDeploymentTargetActionTarget').on('show.bs.modal', function (event) {
-                var button = $(event.relatedTarget) // Button that triggered the modal
-                var contentItemId = button.data('content-item-id');
-                var latest = button.data('latest');
+    <script at="Foot">
+        document.addEventListener('DOMContentLoaded', function () {
+            var modal = document.getElementById('modalExportContentToDeploymentTargetActionTarget');
+            modal?.addEventListener('show.bs.modal', function (event) {
+                var button = event.relatedTarget;
+                var contentItemId = button?.dataset.contentItemId;
+                var latest = button?.dataset.latest;
 
-                $('.export-to-deployment-target').one('click', function () {
-                    var targetButton = this;
-                    var magicToken = $("input[name=__RequestVerificationToken]").first();
-                    if (magicToken) {
-                        var hrefParts = $(targetButton).data("target-url").split("?");
-                        var exportForm = $("<form action=\"" + hrefParts[0] + "\" method=\"POST\" />");
-                        exportForm.append(magicToken.clone());
+                document.querySelectorAll('.export-to-deployment-target').forEach(function (button) {
+                    button.addEventListener('click', function () {
+                        var targetButton = this;
+                        var magicToken = document.querySelector("input[name=__RequestVerificationToken]");
+                        var hrefParts = targetButton.dataset.targetUrl.split("?");
+                        var exportForm = document.createElement("form");
+                        exportForm.action = hrefParts[0];
+                        exportForm.method = "POST";
+
+                        if (magicToken) {
+                            exportForm.appendChild(magicToken.cloneNode(true));
+                        }
+
                         if (hrefParts.length > 1) {
                             var queryParts = hrefParts[1].split("&");
                             for (var i = 0; i < queryParts.length; i++) {
                                 var queryPartKVP = queryParts[i].split("=");
                                 //trusting hrefs in the page here
-                                exportForm.append($("<input type=\"hidden\" name=\"" + decodeURIComponent(queryPartKVP[0]) + "\" value=\"" + decodeURIComponent(queryPartKVP[1]) + "\" />"));
+                                var input = document.createElement("input");
+                                input.type = "hidden";
+                                input.name = decodeURIComponent(queryPartKVP[0]);
+                                input.value = decodeURIComponent(queryPartKVP[1]);
+                                exportForm.appendChild(input);
                             }
                         }
-                        exportForm.append($("<input type=\"hidden\" name=\"ExportContentToDeploymentTarget.ContentItemId\" + value=\"" + contentItemId + "\"/>"));
+
+                        var contentItemInput = document.createElement("input");
+                        contentItemInput.type = "hidden";
+                        contentItemInput.name = "ExportContentToDeploymentTarget.ContentItemId";
+                        contentItemInput.value = contentItemId;
+                        exportForm.appendChild(contentItemInput);
+
                         if (latest) {
-                            exportForm.append($("<input type=\"hidden\" name=\"ExportContentToDeploymentTarget.Latest\" + value=\"" + latest + "\"/>"));
+                            var latestInput = document.createElement("input");
+                            latestInput.type = "hidden";
+                            latestInput.name = "ExportContentToDeploymentTarget.Latest";
+                            latestInput.value = latest;
+                            exportForm.appendChild(latestInput);
                         }
-                        $("body").append(exportForm);
+
+                        document.body.appendChild(exportForm);
                         exportForm.submit();
-                    }
-                })
-            })
+                    }, { once: true });
+                });
+            });
         });
     </script>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-Button-ContentsBulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-Button-ContentsBulkActions.cshtml
@@ -1,15 +1,20 @@
 <a id="exportContentToDeploymentTargetBulkActions" class="dropdown-item" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to export these items?"]">@T["Export to deployment target"]</a>
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        $('#exportContentToDeploymentTargetBulkActions').on('click', function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var exportButton = document.getElementById('exportContentToDeploymentTargetBulkActions');
+
+        if (!exportButton) {
+            return;
+        }
+
+        exportButton.addEventListener('click', function () {
+            if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
                 confirmDialog({
-                    ...$this.data(), callback: function (r) {
+                    ...this.dataset, callback: function (r) {
                         if (r) {
                             console.log('t')
-                            var modal = new bootstrap.Modal($('#modalExportContentToDeploymentTargetContentBulkActionsTarget'));
+                            var modal = new bootstrap.Modal(document.getElementById('modalExportContentToDeploymentTargetContentBulkActionsTarget'));
                             modal.show();
                         }
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ContentsBulkActionsDeploymentTarget.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ContentsBulkActionsDeploymentTarget.Modal.cshtml
@@ -39,34 +39,52 @@
     </div>
 </zone>
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        $('#modalExportContentToDeploymentTargetContentBulkActionsTarget').on('show.bs.modal', function () {
-            var itemIds = $(":checkbox[name='itemIds']:checked");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var modalElement = document.getElementById('modalExportContentToDeploymentTargetContentBulkActionsTarget');
+
+        if (!modalElement) {
+            return;
+        }
+
+        modalElement.addEventListener('show.bs.modal', function () {
+            var itemIds = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
             if (itemIds.length > 1) {
-                $('.export-to-deployment-target-bulk-actions').one('click', function () {
-                    var targetButton = this;
-                    var magicToken = $("input[name=__RequestVerificationToken]").first();
-                    if (magicToken) {
-                        var hrefParts = $(targetButton).data("target-url").split("?");
-                        var exportForm = $("<form action=\"" + hrefParts[0] + "\" method=\"POST\" />");
-                        exportForm.append(magicToken.clone());
-                        if (hrefParts.length > 1) {
-                            var queryParts = hrefParts[1].split("&");
-                            for (var i = 0; i < queryParts.length; i++) {
-                                var queryPartKVP = queryParts[i].split("=");
-                                //trusting hrefs in the page here
-                                exportForm.append($("<input type=\"hidden\" name=\"" + decodeURIComponent(queryPartKVP[0]) + "\" value=\"" + decodeURIComponent(queryPartKVP[1]) + "\" />"));
+                document.querySelectorAll('.export-to-deployment-target-bulk-actions').forEach(function (button) {
+                    button.addEventListener('click', function () {
+                        var targetButton = this;
+                        var magicToken = document.querySelector("input[name=__RequestVerificationToken]");
+                        if (magicToken) {
+                            var hrefParts = targetButton.dataset.targetUrl.split("?");
+                            var exportForm = document.createElement('form');
+                            exportForm.action = hrefParts[0];
+                            exportForm.method = 'POST';
+                            exportForm.appendChild(magicToken.cloneNode(true));
+                            if (hrefParts.length > 1) {
+                                var queryParts = hrefParts[1].split("&");
+                                for (var i = 0; i < queryParts.length; i++) {
+                                    var queryPartKVP = queryParts[i].split("=");
+                                    //trusting hrefs in the page here
+                                    var queryInput = document.createElement('input');
+                                    queryInput.type = 'hidden';
+                                    queryInput.name = decodeURIComponent(queryPartKVP[0]);
+                                    queryInput.value = decodeURIComponent(queryPartKVP[1]);
+                                    exportForm.appendChild(queryInput);
+                                }
                             }
+                            for (var i = 0; i < itemIds.length; i++) {
+                                var itemInput = document.createElement('input');
+                                itemInput.type = 'hidden';
+                                itemInput.name = "ExportContentToDeploymentTarget.ItemIds[" + i + "]";
+                                itemInput.value = itemIds[i].value;
+                                exportForm.appendChild(itemInput);
+                            }
+                            document.body.appendChild(exportForm);
+                            exportForm.submit();
                         }
-                        for (var i = 0; i < itemIds.length; i++) {
-                            exportForm.append($("<input type=\"hidden\" name=\"ExportContentToDeploymentTarget.ItemIds[" + i + "]\" + value=\"" + itemIds[i].value + "\"/>"));
-                        }
-                        $("body").append(exportForm);
-                        exportForm.submit();
-                    }
-                })
+                    }, { once: true });
+                });
             }
-        })
+        });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UpdateContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UpdateContentTask.Fields.Edit.cshtml
@@ -39,7 +39,7 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-$(function () {
+document.addEventListener('DOMContentLoaded', function () {
     var editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.ContentProperties)'), {
         autoRefresh: true,
         lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/Views/Items/CustomSettingsDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/Views/Items/CustomSettingsDeploymentStep.Fields.Edit.cshtml
@@ -48,14 +48,19 @@
 </div>
 
 <script at="Foot">
-    $(function () {
-        $("[data-reversetoggle]").on("click", function () {
-            var state = this.checked;
-            if (state) {
-                $($(this).attr("data-reversetoggle")).collapse('hide');
-            } else {
-                $($(this).attr("data-reversetoggle")).collapse('show');
-            }
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll("[data-reversetoggle]").forEach(function (toggle) {
+            toggle.addEventListener("click", function () {
+                var state = this.checked;
+                document.querySelectorAll(this.getAttribute("data-reversetoggle")).forEach(function (target) {
+                    var collapse = bootstrap.Collapse.getOrCreateInstance(target, { toggle: false });
+                    if (state) {
+                        collapse.hide();
+                    } else {
+                        collapse.show();
+                    }
+                });
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
@@ -93,61 +93,88 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script depends-on="jQuery" at="Foot">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
-            }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+        function getSelectedItemCheckboxes() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
+        }
+
+        function show(element) {
+            if (element) {
+                element.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function displayActionsOrFilters() {
+            if (getSelectedItemCheckboxes().length > 1) {
+                show(actions);
+                filters.forEach(hide);
+                show(selectedItems);
+                hide(items);
+            }
+            else {
+                hide(actions);
+                filters.forEach(show);
+                hide(selectedItems);
+                show(items);
+            }
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (getSelectedItemCheckboxes().length > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = item.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
                         }
+                    });
+                }
+            });
+        });
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
                     }
                 });
-            }
-        });
+                selectedItems.textContent = getSelectedItemCheckboxes().length + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
+        }
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var selectedItemsCount = getSelectedItemCheckboxes().length;
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+                selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
-
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
@@ -87,61 +87,88 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script depends-on="jQuery" at="Foot">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
-            }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+        function getSelectedItemCheckboxes() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
+        }
+
+        function show(element) {
+            if (element) {
+                element.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function displayActionsOrFilters() {
+            if (getSelectedItemCheckboxes().length > 1) {
+                show(actions);
+                filters.forEach(hide);
+                show(selectedItems);
+                hide(items);
+            }
+            else {
+                hide(actions);
+                filters.forEach(show);
+                hide(selectedItems);
+                show(items);
+            }
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (getSelectedItemCheckboxes().length > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = item.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
                         }
+                    });
+                }
+            });
+        });
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
                     }
                 });
-            }
-        });
+                selectedItems.textContent = getSelectedItemCheckboxes().length + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
+        }
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var selectedItemsCount = getSelectedItemCheckboxes().length;
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+                selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
-
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
@@ -140,53 +140,78 @@
 </div>
 <script at="Foot">
     function getDeploymentStepCategory() {
-        return $('#deployment-step-categories .nav-link.active').data('category') || 'all';
+        var activeCategory = document.querySelector('#deployment-step-categories .nav-link.active');
+
+        return activeCategory ? activeCategory.dataset.category || 'all' : 'all';
     }
 
     function filterDeploymentSteps() {
-        var search = replaceDiacritics(String($('#search-box').val() || '').toLowerCase());
+        var searchBox = document.getElementById('search-box');
+        var search = replaceDiacritics(String(searchBox ? searchBox.value || '' : '').toLowerCase());
         var selectedCategory = getDeploymentStepCategory();
 
-        $('.deployment-step-item').each(function () {
-            var card = $(this);
-            var cardText = replaceDiacritics(card.text().toLowerCase());
+        document.querySelectorAll('.deployment-step-item').forEach(function (card) {
+            var cardText = replaceDiacritics(card.textContent.toLowerCase());
             var matchesSearch = search === '' || cardText.indexOf(search) > -1;
-            var matchesCategory = selectedCategory === 'all' || card.data('category') === selectedCategory;
+            var matchesCategory = selectedCategory === 'all' || card.dataset.category === selectedCategory;
 
-            card.toggle(matchesSearch && matchesCategory);
+            card.style.display = matchesSearch && matchesCategory ? '' : 'none';
         });
     }
 
-    $(document).ready(function () {
-        $('#modalSteps').on('shown.bs.modal', function () {
-            $('#search-box').trigger('focus');
-            filterDeploymentSteps();
-        });
+    document.addEventListener('DOMContentLoaded', function () {
+        var modalSteps = document.getElementById('modalSteps');
+        var searchBox = document.getElementById('search-box');
+        var deploymentStepCategories = document.getElementById('deployment-step-categories');
 
-        $('#modalSteps').on('hidden.bs.modal', function () {
-            $('#search-box').val('');
-            $('#deployment-step-categories .nav-link').removeClass('active');
-            $('#deployment-step-categories .nav-link[data-category="all"]').addClass('active');
-            filterDeploymentSteps();
-        });
+        if (modalSteps) {
+            modalSteps.addEventListener('shown.bs.modal', function () {
+                if (searchBox) {
+                    searchBox.focus();
+                }
+                filterDeploymentSteps();
+            });
+
+            modalSteps.addEventListener('hidden.bs.modal', function () {
+                if (searchBox) {
+                    searchBox.value = '';
+                }
+                document.querySelectorAll('#deployment-step-categories .nav-link').forEach(function (link) {
+                    link.classList.remove('active');
+                });
+                var allCategory = document.querySelector('#deployment-step-categories .nav-link[data-category="all"]');
+                if (allCategory) {
+                    allCategory.classList.add('active');
+                }
+                filterDeploymentSteps();
+            });
+        }
+
+        if (searchBox) {
+            searchBox.addEventListener('input', function () {
+                filterDeploymentSteps();
+            });
+        }
+
+        if (deploymentStepCategories) {
+            deploymentStepCategories.addEventListener('click', function (e) {
+                var link = e.target.closest('.nav-link');
+
+                if (!link || !deploymentStepCategories.contains(link)) {
+                    return;
+                }
+
+                e.preventDefault();
+                document.querySelectorAll('#deployment-step-categories .nav-link').forEach(function (navLink) {
+                    navLink.classList.remove('active');
+                });
+                link.classList.add('active');
+                filterDeploymentSteps();
+            });
+        }
     });
 
     function replaceDiacritics(str) {
         return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
     }
-
-    $(function () {
-        var searchBox = $('#search-box');
-
-        searchBox.on('input', function () {
-            filterDeploymentSteps();
-        });
-
-        $('#deployment-step-categories').on('click', '.nav-link', function (e) {
-            e.preventDefault();
-            $('#deployment-step-categories .nav-link').removeClass('active');
-            $(this).addClass('active');
-            filterDeploymentSteps();
-        });
-    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
@@ -85,61 +85,88 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
-            }
-        });
+        function getSelectedItemCheckboxes() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
+        }
 
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
-            }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+        function show(element) {
+            if (element) {
+                element.style.display = '';
             }
         }
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function displayActionsOrFilters() {
+            if (getSelectedItemCheckboxes().length > 1) {
+                show(actions);
+                filters.forEach(hide);
+                show(selectedItems);
+                hide(items);
+            }
+            else {
+                hide(actions);
+                filters.forEach(show);
+                hide(selectedItems);
+                show(items);
+            }
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (getSelectedItemCheckboxes().length > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = item.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
+                        }
+                    });
+                }
+            });
         });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
+                    }
+                });
+                selectedItems.textContent = getSelectedItemCheckboxes().length + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
+        }
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var selectedItemsCount = getSelectedItemCheckboxes().length;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
+
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Json.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Json.cshtml
@@ -23,7 +23,7 @@
 </form>
 
 <script at="Foot">
-$(function () {
+document.addEventListener('DOMContentLoaded', function () {
     var textArea = document.getElementById('@Html.IdFor(x => x.Json)');
 
     var editor = CodeMirror.fromTextArea(textArea, {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/DeploymentPlanDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/DeploymentPlanDeploymentStep.Fields.Edit.cshtml
@@ -48,14 +48,19 @@
 </div>
 
 <script at="Foot">
-    $(function () {
-        $("[data-reversetoggle]").on("click", function () {
-            var state = this.checked;
-            if (state) {
-                $($(this).attr("data-reversetoggle")).collapse('hide');
-            } else {
-                $($(this).attr("data-reversetoggle")).collapse('show');
-            }
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll("[data-reversetoggle]").forEach(function (toggle) {
+            toggle.addEventListener("click", function () {
+                var state = this.checked;
+                document.querySelectorAll(this.getAttribute("data-reversetoggle")).forEach(function (target) {
+                    var collapse = bootstrap.Collapse.getOrCreateInstance(target, { toggle: false });
+                    if (state) {
+                        collapse.hide();
+                    } else {
+                        collapse.show();
+                    }
+                });
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
@@ -19,7 +19,7 @@
 </div>
 
 <script at="Foot" asp-name="jsonrecipe-editor" depends-on="monaco, admin">
-    $(document).ready(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/Admin/IndexInfo.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/Admin/IndexInfo.cshtml
@@ -18,7 +18,7 @@
 </div>
 
 <script at="Foot" asp-name="jsonrecipe-editor" depends-on="monaco, admin">
-    $(document).ready(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/ElasticQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/ElasticQuery.Edit.cshtml
@@ -33,7 +33,7 @@
 </div>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
@@ -102,7 +102,7 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.HtmlBody)'), {
             lineNumbers: true,
             styleActiveLine: true,
@@ -117,26 +117,49 @@
         });
         changeBodyFormat();
 
-        $('select').on('change', function () {
-            changeBodyFormat();
+        document.querySelectorAll('select').forEach(function (select) {
+            select.addEventListener('change', function () {
+                changeBodyFormat();
+            });
         });
     });
 
     function changeBodyFormat() {
-        var selectedValue = $('select').val();
+        var select = document.querySelector('select');
+
+        if (!select) {
+            return;
+        }
+
+        var selectedValue = select.value;
+        var textBodyDiv = document.getElementById('textBodyDiv');
+        var htmlBodyDiv = document.getElementById('htmlBodyDiv');
+
         switch (selectedValue) {
             case '@MailMessageBodyFormat.All':
-                $('#textBodyDiv').removeClass('d-none');
-                $('#htmlBodyDiv').removeClass('d-none');
+                removeClass(textBodyDiv, 'd-none');
+                removeClass(htmlBodyDiv, 'd-none');
                 break;
             case '@MailMessageBodyFormat.Text':
-                $('#textBodyDiv').removeClass('d-none');
-                $('#htmlBodyDiv').addClass('d-none');
+                removeClass(textBodyDiv, 'd-none');
+                addClass(htmlBodyDiv, 'd-none');
                 break;
             case '@MailMessageBodyFormat.Html':
-                $('#textBodyDiv').addClass('d-none');
-                $('#htmlBodyDiv').removeClass('d-none');
+                addClass(textBodyDiv, 'd-none');
+                removeClass(htmlBodyDiv, 'd-none');
                 break;
+        }
+    }
+
+    function addClass(element, className) {
+        if (element) {
+            element.classList.add(className);
+        }
+    }
+
+    function removeClass(element, className) {
+        if (element) {
+            element.classList.remove(className);
         }
     }
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPart.Edit.cshtml
@@ -17,7 +17,7 @@
 </div>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var textArea = document.getElementById('@Html.IdFor(x => x.Liquid)');
 
         if (textArea == null) {
@@ -34,7 +34,7 @@
 
         editor.on('change', function (cmEditor) {
             cmEditor.save()
-            $(document).trigger('contentpreview:render');
+            document.dispatchEvent(new Event('contentpreview:render'));
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPartSettings.Edit.cshtml
@@ -18,7 +18,7 @@
 </div>
 
 <script at="Foot">
-$(function () {
+document.addEventListener('DOMContentLoaded', function () {
     var textArea = document.getElementById('@Html.IdFor(x => x.Liquid)');
 
     if (textArea == null) {
@@ -35,7 +35,7 @@ $(function () {
 
     editor.on('change', function(cmEditor){
         cmEditor.save();
-        $(document).trigger('contentpreview:render');
+        document.dispatchEvent(new Event('contentpreview:render'));
     });
 });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Monaco.Edit.cshtml
@@ -59,7 +59,7 @@
 
             editor.getModel().onDidChangeContent((event) => {
                 textArea.value = editor.getValue();
-                $(document).trigger('contentpreview:render');
+                document.dispatchEvent(new Event('contentpreview:render'));
             });
 
             const shortcodesAction = {

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
@@ -25,7 +25,7 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
         @* When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
             if (optionsTextArea) {
@@ -58,7 +58,7 @@
 
             editor.on('change', function (cmEditor) {
                 cmEditor.save();
-                $(document).trigger('contentpreview:render');
+                document.dispatchEvent(new Event('contentpreview:render'));
             });
         }
     });

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartTrumbowygSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartTrumbowygSettings.Edit.cshtml
@@ -23,7 +23,7 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Views/LiquidPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Views/LiquidPart.Edit.cshtml
@@ -22,7 +22,7 @@
 </div>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var textArea = document.getElementById('@Html.IdFor(x => x.Liquid)');
 
         if (textArea == null) {
@@ -39,7 +39,7 @@
 
         editor.on('change', function (cmEditor) {
             cmEditor.save();
-            $(document).trigger('contentpreview:render');
+            document.dispatchEvent(new Event('contentpreview:render'));
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/Items/ListsAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/Items/ListsAdminNode.Fields.TreeEdit.cshtml
@@ -115,24 +115,42 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jquery">
-    $(function () {
-        $('.add-parent-link-checkbox').on('click', function (e) {
-            var iconPickerFieldSet = $(e.target).closest('.add-parent-link-fieldset').siblings('.icon-picker-for-content-type');
-            var selected = $(e.target).prop('checked');
-            console.log(iconPickerFieldSet[0]);
-            selected ? iconPickerFieldSet.removeClass('collapse') : iconPickerFieldSet.addClass('collapse');
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.add-parent-link-checkbox').forEach(function (checkbox) {
+            checkbox.addEventListener('click', function (e) {
+                var fieldSet = e.currentTarget.closest('.add-parent-link-fieldset');
+                var iconPickerFieldSets = Array.from(fieldSet.parentElement.children).filter(function (element) {
+                    return element !== fieldSet && element.classList.contains('icon-picker-for-content-type');
+                });
+                var selected = e.currentTarget.checked;
+                console.log(iconPickerFieldSets[0]);
+                iconPickerFieldSets.forEach(function (iconPickerFieldSet) {
+                    selected ? iconPickerFieldSet.classList.remove('collapse') : iconPickerFieldSet.classList.add('collapse');
+                });
+            });
         });
 
-        $('.icon-picker-trigger').on('click', function (e) {
-            var node = $(e.target).data('related-node');
-            iconPickerVue.show(node, 'sample-icon-' + node);
+        document.querySelectorAll('.icon-picker-trigger').forEach(function (trigger) {
+            trigger.addEventListener('click', function (e) {
+                var node = e.currentTarget.dataset.relatedNode;
+                iconPickerVue.show(node, 'sample-icon-' + node);
+            });
         });
 
-        $('button.remove-icon').on('click', function (e) {
-            var node = $(e.target).data('related-node');
-            $('#' + node).val('');
-            $('#sample-icon-' + node).replaceWith('<i id="sample-icon-' + node + '" class=" "></i>'); // changing the class is not enough.
+        document.querySelectorAll('button.remove-icon').forEach(function (button) {
+            button.addEventListener('click', function (e) {
+                var node = e.currentTarget.dataset.relatedNode;
+                var input = document.getElementById(node);
+                if (input) {
+                    input.value = '';
+                }
+
+                var sampleIcon = document.getElementById('sample-icon-' + node);
+                if (sampleIcon) {
+                    sampleIcon.outerHTML = '<i id="sample-icon-' + node + '" class=" "></i>'; // changing the class is not enough.
+                }
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Query.cshtml
@@ -98,7 +98,7 @@
     </div>
 }
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.Parameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/LuceneQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/LuceneQuery.Edit.cshtml
@@ -33,7 +33,7 @@
 </div>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
@@ -24,8 +24,8 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jQuery, easymde-mediatoolbar">
-    $(function () {
+<script at="Foot" depends-on="easymde-mediatoolbar">
+    document.addEventListener('DOMContentLoaded', function () {
         var markdownElement = document.getElementById('@Html.IdFor(m => m.Markdown)');
         var isRtl = '@(culture.IsRightToLeft() ? "true" : "false")';
 
@@ -72,13 +72,17 @@ else
             initializeMdeShortcodeWrapper(mde);
 
             mde.codemirror.on('change', function () {
-                $(document).trigger('contentpreview:render');
+                document.dispatchEvent(new Event('contentpreview:render'));
             });
 
             if (isRtl === 'true')
             {
-                $('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
-                $('.CodeMirror').attr('style', 'text-align:right');
+                document.querySelectorAll('.editor-toolbar').forEach(function (element) {
+                    element.setAttribute('style', 'direction:rtl;text-align:right');
+                });
+                document.querySelectorAll('.CodeMirror').forEach(function (element) {
+                    element.setAttribute('style', 'text-align:right');
+                });
             }
         }
     });

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPartWysiwygEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPartWysiwygEditorSettings.Edit.cshtml
@@ -15,7 +15,7 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownFieldWysiwygEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownFieldWysiwygEditorSettings.Edit.cshtml
@@ -15,7 +15,7 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
@@ -7,24 +7,29 @@
 
 <script at="Foot">
     @* mediaApp is absolutely positioned. When a warning is shown we need to move it down to avoid overlapping. *@
-    $(function () {
-        if (!$('.message').length) { return; };
+    document.addEventListener('DOMContentLoaded', function () {
+        var messages = document.querySelectorAll('.message');
+        if (!messages.length) { return; };
         var mediaAppInitialTop = 0;
         var mediaAppLoaded = false;
 
         var repositionMediaApp = function () {
 
             var messagesHeight = 0;
-            $('.message').each(function () {
-                messagesHeight += $(this).outerHeight(true);
+            messages.forEach(function (message) {
+                var style = window.getComputedStyle(message);
+                messagesHeight += message.offsetHeight + (parseFloat(style.marginTop) || 0) + (parseFloat(style.marginBottom) || 0);
             });
 
             var newTop = mediaAppInitialTop + messagesHeight;
+            var mediaApp = document.getElementById('mediaApp');
 
-            $('#mediaApp').css('top', newTop + 'px');
+            if (mediaApp) {
+                mediaApp.style.top = newTop + 'px';
+            }
         }
 
-        $(window).on('resize', function () {
+        window.addEventListener('resize', function () {
             if (mediaAppLoaded) {
                 repositionMediaApp();
             }
@@ -32,8 +37,9 @@
 
         // before moving we need to wait until the vuejs mediaapp is loaded.
         var checkMediaAppIsLoaded = setInterval(function () {
-            if ($('#mediaApp').length) {
-                mediaAppInitialTop = $('#mediaApp').offset().top;
+            var mediaApp = document.getElementById('mediaApp');
+            if (mediaApp) {
+                mediaAppInitialTop = mediaApp.getBoundingClientRect().top + window.scrollY;
                 clearInterval(checkMediaAppIsLoaded);
                 mediaAppLoaded = true;
                 repositionMediaApp();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Items/MediaDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Items/MediaDeploymentStep.Fields.Edit.cshtml
@@ -32,34 +32,47 @@
 </div>
 
 <script at="Foot">
+    function setCollapse(element, action) {
+        if (!element) {
+            return;
+        }
+
+        bootstrap.Collapse.getOrCreateInstance(element, { toggle: false })[action]();
+    }
+
     function checkboxClicked(checkbox) {
         var path = checkbox.value;
 
-        if (checkbox.checked) {
-            $(`li[data-path='${path}']`).collapse('hide');
-        } else {
-            $(`li[data-path='${path}']`).collapse('show');
-        }
-
-        $(`input[data-parent-value='${path}']:checked`).each(function () {
-            this.checked = false;
-
-            checkboxClicked(this);
-        });
-    }
-
-    $(function () {
-        $("[data-reverseToggle]").on("click", function () {
-            var state = this.checked;
-            if (state) {
-                $($(this).attr("data-reverseToggle")).collapse('hide');
-            } else {
-                $($(this).attr("data-reverseToggle")).collapse('show');
+        document.querySelectorAll('li[data-path]').forEach(function (element) {
+            if (element.dataset.path === path) {
+                setCollapse(element, checkbox.checked ? 'hide' : 'show');
             }
         });
 
-        $("[data-parent-value]").on("click", function () {
-            checkboxClicked(this);
+        document.querySelectorAll('input[data-parent-value]:checked').forEach(function (element) {
+            if (element.dataset.parentValue !== path) {
+                return;
+            }
+
+            element.checked = false;
+            checkboxClicked(element);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll("[data-reverseToggle]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                var state = this.checked;
+                document.querySelectorAll(this.getAttribute("data-reverseToggle")).forEach(function (toggleElement) {
+                    setCollapse(toggleElement, state ? 'hide' : 'show');
+                });
+            });
+        });
+
+        document.querySelectorAll("[data-parent-value]").forEach(function (element) {
+            element.addEventListener("click", function () {
+                checkboxClicked(this);
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Create.cshtml
@@ -125,29 +125,36 @@
 </form>
 
 <script at="Foot">
-    $(function () {
-        $('#@Html.IdFor(x => x.SelectedMode)').on('change', function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var selectedMode = document.getElementById('@Html.IdFor(x => x.SelectedMode)');
+        var backgroundColor = document.getElementById('@Html.IdFor(x => x.BackgroundColor)');
+        var selectedWidth = document.getElementById('@Html.IdFor(x => x.SelectedWidth)');
+        var customWidth = document.getElementById('@Html.IdFor(x => x.CustomWidth)');
+        var selectedHeight = document.getElementById('@Html.IdFor(x => x.SelectedHeight)');
+        var customHeight = document.getElementById('@Html.IdFor(x => x.CustomHeight)');
+
+        selectedMode.addEventListener('change', function () {
             if ((this.value === '@((int)ResizeMode.Pad)') || (this.value === '@((int)ResizeMode.BoxPad)')) {
-                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.form-g').show();
+                backgroundColor.closest('.form-g').style.display = '';
             } else {
-                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.form-g').hide();
-                $('#@Html.IdFor(x => x.BackgroundColor)').val('');
+                backgroundColor.closest('.form-g').style.display = 'none';
+                backgroundColor.value = '';
             }
         });
-        $('#@Html.IdFor(x => x.SelectedWidth)').on('change', function () {
+        selectedWidth.addEventListener('change', function () {
             if (this.value === "-1") {
-                $('#@Html.IdFor(x => x.CustomWidth)').show();
+                customWidth.style.display = '';
             } else {
-                $('#@Html.IdFor(x => x.CustomWidth)').hide();
-                $('#@Html.IdFor(x => x.CustomWidth)').val(0);
+                customWidth.style.display = 'none';
+                customWidth.value = 0;
             }
         });
-        $('#@Html.IdFor(x => x.SelectedHeight)').on('change', function () {
+        selectedHeight.addEventListener('change', function () {
             if (this.value === "-1") {
-                $('#@Html.IdFor(x => x.CustomHeight)').show();
+                customHeight.style.display = '';
             } else {
-                $('#@Html.IdFor(x => x.CustomHeight)').hide();
-                $('#@Html.IdFor(x => x.CustomHeight)').val(0);
+                customHeight.style.display = 'none';
+                customHeight.value = 0;
             }
         });
     });

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Edit.cshtml
@@ -110,29 +110,36 @@
 </form>
 
 <script at="Foot">
-    $(function () {
-        $('#@Html.IdFor(x => x.SelectedMode)').on('change', function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var selectedMode = document.getElementById('@Html.IdFor(x => x.SelectedMode)');
+        var backgroundColor = document.getElementById('@Html.IdFor(x => x.BackgroundColor)');
+        var selectedWidth = document.getElementById('@Html.IdFor(x => x.SelectedWidth)');
+        var customWidth = document.getElementById('@Html.IdFor(x => x.CustomWidth)');
+        var selectedHeight = document.getElementById('@Html.IdFor(x => x.SelectedHeight)');
+        var customHeight = document.getElementById('@Html.IdFor(x => x.CustomHeight)');
+
+        selectedMode.addEventListener('change', function () {
             if ((this.value === '@((int)ResizeMode.Pad)') || (this.value === '@((int)ResizeMode.BoxPad)')) {
-                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.ocat-limited-wrapper').show();
+                backgroundColor.closest('.ocat-limited-wrapper').style.display = '';
             } else {
-                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.ocat-limited-wrapper').hide();
-                $('#@Html.IdFor(x => x.BackgroundColor)').val('');
+                backgroundColor.closest('.ocat-limited-wrapper').style.display = 'none';
+                backgroundColor.value = '';
             }
         });
-        $('#@Html.IdFor(x => x.SelectedWidth)').on('change', function () {
+        selectedWidth.addEventListener('change', function () {
             if (this.value === "-1") {
-                $('#@Html.IdFor(x => x.CustomWidth)').show();
+                customWidth.style.display = '';
             } else {
-                $('#@Html.IdFor(x => x.CustomWidth)').hide();
-                $('#@Html.IdFor(x => x.CustomWidth)').val(0);
+                customWidth.style.display = 'none';
+                customWidth.value = 0;
             }
         });
-        $('#@Html.IdFor(x => x.SelectedHeight)').on('change', function () {
+        selectedHeight.addEventListener('change', function () {
             if (this.value === "-1") {
-                $('#@Html.IdFor(x => x.CustomHeight)').show();
+                customHeight.style.display = '';
             } else {
-                $('#@Html.IdFor(x => x.CustomHeight)').hide();
-                $('#@Html.IdFor(x => x.CustomHeight)').val(0);
+                customHeight.style.display = 'none';
+                customHeight.value = 0;
             }
         });
     });

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
@@ -90,61 +90,81 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+        var checkedItems = function () {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
+        };
+        var setDisplay = function (element, show) {
+            if (element) {
+                element.style.display = show ? '' : 'none';
+            }
+        };
 
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (checkedItems().length > 1) {
+                setDisplay(actions, true);
+                filters.forEach(function (filter) { setDisplay(filter, false); });
+                setDisplay(selectedItems, true);
+                setDisplay(items, false);
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                setDisplay(actions, false);
+                filters.forEach(function (filter) { setDisplay(filter, true); });
+                setDisplay(selectedItems, false);
+                setDisplay(items, true);
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (checkedItems().length > 1) {
+                    var data = this.dataset;
+                    confirmDialog({
+                        ...data, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = data.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
                         }
+                    });
+                }
+            });
+        });
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
                     }
                 });
-            }
-        });
+                selectedItems.textContent = checkedItems().length + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+            itemsCheckboxes.forEach(function (checkbox) {
+                checkbox.addEventListener("click", function () {
+                    var itemsCount = itemsCheckboxes.length;
+                    var selectedItemsCount = checkedItems().length;
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+                    selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
-
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
-    })
+                    selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                    displayActionsOrFilters();
+                });
+            });
+        }
+    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminList.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminList.cshtml
@@ -68,66 +68,86 @@
 @await DisplayAsync(Model.Pager)
 
 <script asp-name="bootstrap-select" at="Foot"></script>
-<script at="Foot" depends-on="jQuery">
-    $(function () {
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
         const submitFilterButton = document.querySelector("[name='submit.Filter']");
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+        var checkedItems = function () {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
+        };
+        var setDisplay = function (element, show) {
+            if (element) {
+                element.style.display = show ? '' : 'none';
+            }
+        };
 
         // This applies to all filter selectpickers on page. Add .nosubmit to not submit
         document.querySelectorAll('.selectpicker:not(.nosubmit)').forEach((element) => {
             element.addEventListener('changed.bs.select', () => submitFilterButton?.click());
         });
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("#@Html.IdFor(o => o.Options.BulkAction)").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
             }
+
+            item.addEventListener("click", function () {
+                if (checkedItems().length > 1) {
+                    var data = this.dataset;
+                    confirmDialog({
+                        ...data, callback: function (r) {
+                            if (r) {
+                                document.getElementById("@Html.IdFor(o => o.Options.BulkAction)").value = data.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
+                        }
+                    });
+                }
+            });
         });
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (checkedItems().length > 1) {
+                setDisplay(actions, true);
+                filters.forEach(function (filter) { setDisplay(filter, false); });
+                setDisplay(selectedItems, true);
+                setDisplay(items, false);
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                setDisplay(actions, false);
+                filters.forEach(function (filter) { setDisplay(filter, true); });
+                setDisplay(selectedItems, false);
+                setDisplay(items, true);
             }
         }
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
+                    }
+                });
+                selectedItems.textContent = checkedItems().length + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+            itemsCheckboxes.forEach(function (checkbox) {
+                checkbox.addEventListener("click", function () {
+                    var itemsCount = itemsCheckboxes.length;
+                    var selectedItemsCount = checkedItems().length;
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                    selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
-    })
+                    selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                    displayActionsOrFilters();
+                });
+            });
+        }
+    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
@@ -275,6 +275,16 @@
 
     //<![CDATA[
     window.onload = function () {
+        function getElement(id) {
+            return document.getElementById(id);
+        }
+
+        function setCollapse(element, action) {
+            if (element) {
+                bootstrap.Collapse.getOrCreateInstance(element, { toggle: false })[action]();
+            }
+        }
+
         refreshForbiddenFlows();
         refreshClientSecret('@OpenIddictConstants.ClientTypes.Confidential');
         refreshFlows();
@@ -284,12 +294,12 @@
             @if (settings == null)
             {
                 <text>
-                    $("#AllowAuthorizationCodeFlowFieldSet").collapse("show");
-                    $("#AllowClientCredentialsFlowFieldSet").collapse("show");
-                    $("#AllowImplicitFlowFieldSet").collapse("show");
-                    $("#AllowPasswordFlowFieldSet").collapse("show");
-                    $("#AllowRefreshTokenFlowFieldSet").collapse("show");
-                    $("#AllowLogoutEndpointFieldSet").collapse("show");
+                    setCollapse(getElement("AllowAuthorizationCodeFlowFieldSet"), "show");
+                    setCollapse(getElement("AllowClientCredentialsFlowFieldSet"), "show");
+                    setCollapse(getElement("AllowImplicitFlowFieldSet"), "show");
+                    setCollapse(getElement("AllowPasswordFlowFieldSet"), "show");
+                    setCollapse(getElement("AllowRefreshTokenFlowFieldSet"), "show");
+                    setCollapse(getElement("AllowLogoutEndpointFieldSet"), "show");
                 </text>
 
             }
@@ -297,139 +307,143 @@
             {
                 if (settings.AllowAuthorizationCodeFlow)
                 {
-                    <text>$("#AllowAuthorizationCodeFlowFieldSet").collapse("show");</text>
+                    <text>setCollapse(getElement("AllowAuthorizationCodeFlowFieldSet"), "show");</text>
                 }
                 else
                 {
                     <text>
-                        $("#AllowAuthorizationCodeFlowFieldSet").collapse("hide");
-                        $("#AllowAuthorizationCodeFlow").prop("checked", false);
+                        setCollapse(getElement("AllowAuthorizationCodeFlowFieldSet"), "hide");
+                        getElement("AllowAuthorizationCodeFlow").checked = false;
                     </text>
                 }
 
                 if (settings.AllowClientCredentialsFlow)
                 {
-                    <text>$("#AllowClientCredentialsFlowFieldSet").collapse("show");</text>
+                    <text>setCollapse(getElement("AllowClientCredentialsFlowFieldSet"), "show");</text>
                 }
                 else
                 {
                     <text>
-                        $("#AllowClientCredentialsFlowFieldSet").collapse("hide");
-                        $("#AllowClientCredentialsFlow").prop("checked", false);
+                        setCollapse(getElement("AllowClientCredentialsFlowFieldSet"), "hide");
+                        getElement("AllowClientCredentialsFlow").checked = false;
                     </text>
                 }
 
                 if (settings.AllowImplicitFlow)
                 {
-                    <text>$("#AllowImplicitFlowFieldSet").collapse("show");</text>
+                    <text>setCollapse(getElement("AllowImplicitFlowFieldSet"), "show");</text>
                 }
                 else
                 {
                     <text>
-                        $("#AllowImplicitFlowFieldSet").collapse("hide");
-                        $("#AllowImplicitFlow").prop("checked", false);
+                        setCollapse(getElement("AllowImplicitFlowFieldSet"), "hide");
+                        getElement("AllowImplicitFlow").checked = false;
                     </text>
                 }
 
                 if (settings.AllowHybridFlow)
                 {
-                    <text>$("#AllowHybridFlowFieldSet").collapse("show");</text>
+                    <text>setCollapse(getElement("AllowHybridFlowFieldSet"), "show");</text>
                 }
                 else
                 {
                     <text>
-                        $("#AllowHybridFlowFieldSet").collapse("hide");
-                        $("#AllowHybridFlowFlow").prop("checked", false);
+                        setCollapse(getElement("AllowHybridFlowFieldSet"), "hide");
+                        if (getElement("AllowHybridFlowFlow")) {
+                            getElement("AllowHybridFlowFlow").checked = false;
+                        }
                     </text>
                 }
 
                 if (settings.AllowPasswordFlow)
                 {
-                    <text>$("#AllowPasswordFlowFieldSet").collapse("show");</text>
+                    <text>setCollapse(getElement("AllowPasswordFlowFieldSet"), "show");</text>
                 }
                 else
                 {
                     <text>
-                        $("#AllowPasswordFlowFieldSet").collapse("hide");
-                        $("#AllowPasswordFlow").prop("checked", false);
+                        setCollapse(getElement("AllowPasswordFlowFieldSet"), "hide");
+                        getElement("AllowPasswordFlow").checked = false;
                     </text>
                 }
 
                 if (settings.AllowRefreshTokenFlow)
                 {
-                    <text>$("#AllowRefreshTokenFlowFieldSet").collapse("show");</text>
+                    <text>setCollapse(getElement("AllowRefreshTokenFlowFieldSet"), "show");</text>
                 }
                 else
                 {
                     <text>
-                        $("#AllowRefreshTokenFlowFieldSet").collapse("hide");
-                        $("#AllowRefreshTokenFlow").prop("checked", false);
+                        setCollapse(getElement("AllowRefreshTokenFlowFieldSet"), "hide");
+                        getElement("AllowRefreshTokenFlow").checked = false;
                     </text>
                 }
 
                 if (settings.LogoutEndpointPath.HasValue)
                 {
-                    <text>$("#AllowLogoutEndpointFieldSet").collapse("show");</text>
+                    <text>setCollapse(getElement("AllowLogoutEndpointFieldSet"), "show");</text>
                 }
                 else
                 {
                     <text>
-                        $("#AllowLogoutEndpointFieldSet").collapse("hide");
-                        $("#AllowLogoutEndpointFieldSet").prop("checked", false);
+                        setCollapse(getElement("AllowLogoutEndpointFieldSet"), "hide");
+                        getElement("AllowLogoutEndpointFieldSet").checked = false;
                     </text>
                 }
             }
         }
 
-        $("#Type").change(function () {
+        getElement("Type").addEventListener('change', function () {
             refreshClientSecret();
         });
         function refreshClientSecret(defaultType) {
-            var type = $("#Type");
-            $("#ClientSecretWrapper").collapse(type.val() === '@OpenIddictConstants.ClientTypes.Confidential' ? "show" : "hide");
+            var type = getElement("Type");
+            setCollapse(getElement("ClientSecretWrapper"), type.value === '@OpenIddictConstants.ClientTypes.Confidential' ? "show" : "hide");
 
-            var allowClientCredentialsFlow = $("#AllowClientCredentialsFlow");
-            if ($("#Type").val() === '@OpenIddictConstants.ClientTypes.Confidential') {
-                allowClientCredentialsFlow.removeAttr("disabled");
+            var allowClientCredentialsFlow = getElement("AllowClientCredentialsFlow");
+            if (getElement("Type").value === '@OpenIddictConstants.ClientTypes.Confidential') {
+                allowClientCredentialsFlow.disabled = false;
             }
             else {
-                allowClientCredentialsFlow.attr('disabled', true);
-                allowClientCredentialsFlow.prop("checked", false);
+                allowClientCredentialsFlow.disabled = true;
+                allowClientCredentialsFlow.checked = false;
             }
 
-            var clientSecretHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
+            var clientSecretHints = document.querySelectorAll("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
 
-            if (defaultType === $("#Type").val())
+            if (defaultType === getElement("Type").value)
                 return;
 
-            if ($("#Type").val() === '@OpenIddictConstants.ClientTypes.Confidential') {
-                clientSecretHints.each(function () { this.innerText = this.innerText.replace("client_id, ", "client_id, client_secret, "); });
+            if (getElement("Type").value === '@OpenIddictConstants.ClientTypes.Confidential') {
+                clientSecretHints.forEach(function (element) { element.innerText = element.innerText.replace("client_id, ", "client_id, client_secret, "); });
             }
             else {
-                clientSecretHints.each(function () { this.innerText = this.innerText.replace("client_id, client_secret, ", "client_id, "); });
+                clientSecretHints.forEach(function (element) { element.innerText = element.innerText.replace("client_id, client_secret, ", "client_id, "); });
             }
         }
 
-        $("#AllowRefreshTokenFlow").change(function () {
+        getElement("AllowRefreshTokenFlow").addEventListener('change', function () {
             refreshOfflineAccessTip();
         });
 
         function refreshOfflineAccessTip(defaultValue) {
-            var offlineAccessHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint");
-            var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
-            if (defaultValue === allowRefreshTokenFlow.prop('checked'))
+            var offlineAccessHints = document.querySelectorAll("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint");
+            var allowRefreshTokenFlow = getElement("AllowRefreshTokenFlow");
+            if (defaultValue === allowRefreshTokenFlow.checked)
                 return;
 
-            if (allowRefreshTokenFlow.prop('checked')) {
-                offlineAccessHints.each(function () { this.innerText = this.innerText.replace("roles", "roles, offline_access"); });
+            if (allowRefreshTokenFlow.checked) {
+                offlineAccessHints.forEach(function (element) { element.innerText = element.innerText.replace("roles", "roles, offline_access"); });
             }
             else {
-                offlineAccessHints.each(function () { this.innerText = this.innerText.replace(", offline_access", ""); });
+                offlineAccessHints.forEach(function (element) { element.innerText = element.innerText.replace(", offline_access", ""); });
             }
         }
 
-        $("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowImplicitFlow, #AllowHybridFlow, #AllowRefreshTokenFlow").change(function () {
-            refreshFlows();
+        document.querySelectorAll("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowImplicitFlow, #AllowHybridFlow, #AllowRefreshTokenFlow").forEach(function (element) {
+            element.addEventListener('change', function () {
+                refreshFlows();
+            });
         });
 
         function refreshFlows() {
@@ -438,44 +452,46 @@
             refreshRedirectSettings();
         }
         function refreshRoleGroup() {
-            $("#RoleGroup").collapse($("#AllowClientCredentialsFlow").prop('checked') ? "show" : "hide");
+            setCollapse(getElement("RoleGroup"), getElement("AllowClientCredentialsFlow").checked ? "show" : "hide");
         }
         function refreshAllowRefreshTokenFlowVisibility() {
-            var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
+            var allowRefreshTokenFlow = getElement("AllowRefreshTokenFlow");
 
-            if ($("#AllowPasswordFlow").prop('checked') ||
-                $("#AllowAuthorizationCodeFlow").prop('checked') ||
-                $("#AllowHybridFlow").prop('checked')) {
-                allowRefreshTokenFlow.removeAttr("disabled");
+            if (getElement("AllowPasswordFlow").checked ||
+                getElement("AllowAuthorizationCodeFlow").checked ||
+                getElement("AllowHybridFlow").checked) {
+                allowRefreshTokenFlow.disabled = false;
             }
             else {
-                allowRefreshTokenFlow.attr('disabled', true);
-                allowRefreshTokenFlow.prop("checked", false);
-                $("#AllowRefreshTokenFlowRecommendedHint").collapse("hide");
+                allowRefreshTokenFlow.disabled = true;
+                allowRefreshTokenFlow.checked = false;
+                setCollapse(getElement("AllowRefreshTokenFlowRecommendedHint"), "hide");
                 refreshOfflineAccessTip();
             }
         }
         function refreshRedirectSettings() {
-            var redirectSection = $("#RedirectSection");
-            var skipConsent = $("#SkipConsent");
-            var postLogoutRedirecUris = $("#postLogoutRedirectUris")
+            var redirectSection = getElement("RedirectSection");
+            var skipConsent = getElement("SkipConsent");
+            var postLogoutRedirecUris = getElement("postLogoutRedirectUris")
 
-            if ($("#AllowImplicitFlow").prop('checked') ||
-                $("#AllowAuthorizationCodeFlow").prop('checked') ||
-                $("#AllowHybridFlow").prop('checked')) {
-                redirectSection.collapse("show");
-                if ($("#AllowLogoutEndpoint").prop('checked')) {
-                    postLogoutRedirecUris.collapse("show");
+            if (getElement("AllowImplicitFlow").checked ||
+                getElement("AllowAuthorizationCodeFlow").checked ||
+                getElement("AllowHybridFlow").checked) {
+                setCollapse(redirectSection, "show");
+                if (getElement("AllowLogoutEndpoint").checked) {
+                    setCollapse(postLogoutRedirecUris, "show");
                 }
                 else {
-                    postLogoutRedirecUris.collapse("hide");
+                    setCollapse(postLogoutRedirecUris, "hide");
                 }
             }
             else {
-                skipConsent.prop("checked", false);
-                redirectSection.collapse("hide");
-                $("#AllowLogoutEndpoint").prop('checked', false);
-                postLogoutRedirecUris.collapse("hide");
+                if (skipConsent) {
+                    skipConsent.checked = false;
+                }
+                setCollapse(redirectSection, "hide");
+                getElement("AllowLogoutEndpoint").checked = false;
+                setCollapse(postLogoutRedirecUris, "hide");
             }
         }
     };

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
@@ -295,6 +295,22 @@
 
     //<![CDATA[
     window.onload = function () {
+        function getElement(id) {
+            return document.getElementById(id);
+        }
+
+        function setDisplay(element, show) {
+            if (element) {
+                element.style.display = show ? '' : 'none';
+            }
+        }
+
+        function setCollapse(element, action) {
+            if (element) {
+                bootstrap.Collapse.getOrCreateInstance(element, { toggle: false })[action]();
+            }
+        }
+
         refreshForbiddenFlows();
         refreshClientSecret('@OpenIddictConstants.ClientTypes.Confidential');
         refreshFlows();
@@ -304,153 +320,157 @@
     @if (settings == null)
     {
         <text>
-            $("#AllowAuthorizationCodeFlowFieldSet").collapse("show");
-            $("#AllowClientCredentialsFlowFieldSet").collapse("show");
-            $("#AllowImplicitFlowFieldSet").collapse("show");
-            $("#AllowPasswordFlowFieldSet").collapse("show");
-            $("#AllowRefreshTokenFlowFieldSet").collapse("show");
-            $("#AllowLogoutEndpointFieldSet").collapse("show");
+            setCollapse(getElement("AllowAuthorizationCodeFlowFieldSet"), "show");
+            setCollapse(getElement("AllowClientCredentialsFlowFieldSet"), "show");
+            setCollapse(getElement("AllowImplicitFlowFieldSet"), "show");
+            setCollapse(getElement("AllowPasswordFlowFieldSet"), "show");
+            setCollapse(getElement("AllowRefreshTokenFlowFieldSet"), "show");
+            setCollapse(getElement("AllowLogoutEndpointFieldSet"), "show");
         </text>
     }
     else
     {
         if (settings.AllowAuthorizationCodeFlow)
         {
-            <text>$("#AllowAuthorizationCodeFlowFieldSet").collapse("show"); </text>
+            <text>setCollapse(getElement("AllowAuthorizationCodeFlowFieldSet"), "show"); </text>
         }
         else
         {
             <text>
-                $("#AllowAuthorizationCodeFlowFieldSet").collapse("hide");
-                $("#AllowAuthorizationCodeFlow").prop("checked", false);
+                setCollapse(getElement("AllowAuthorizationCodeFlowFieldSet"), "hide");
+                getElement("AllowAuthorizationCodeFlow").checked = false;
             </text>
         }
 
         if (settings.AllowClientCredentialsFlow)
         {
-            <text>$("#AllowClientCredentialsFlowFieldSet").collapse("show"); </text>
+            <text>setCollapse(getElement("AllowClientCredentialsFlowFieldSet"), "show"); </text>
         }
         else
         {
             <text>
-                $("#AllowClientCredentialsFlowFieldSet").collapse("hide");
-                $("#AllowClientCredentialsFlow").prop("checked", false);
+                setCollapse(getElement("AllowClientCredentialsFlowFieldSet"), "hide");
+                getElement("AllowClientCredentialsFlow").checked = false;
             </text>
         }
 
         if (settings.AllowImplicitFlow)
         {
-            <text>$("#AllowImplicitFlowFieldSet").collapse("show"); </text>
+            <text>setCollapse(getElement("AllowImplicitFlowFieldSet"), "show"); </text>
         }
         else
         {
             <text>
-                $("#AllowImplicitFlowFieldSet").collapse("hide");
-                $("#AllowImplicitFlow").prop("checked", false);
+                setCollapse(getElement("AllowImplicitFlowFieldSet"), "hide");
+                getElement("AllowImplicitFlow").checked = false;
             </text>
         }
 
         if (settings.AllowHybridFlow)
         {
-            <text>$("#AllowHybridFlowFieldSet").collapse("show"); </text>
+            <text>setCollapse(getElement("AllowHybridFlowFieldSet"), "show"); </text>
         }
         else
         {
             <text>
-                $("#AllowHybridFlowFieldSet").collapse("hide");
-                $("#AllowHybridFlowFlow").prop("checked", false);
+                setCollapse(getElement("AllowHybridFlowFieldSet"), "hide");
+                if (getElement("AllowHybridFlowFlow")) {
+                    getElement("AllowHybridFlowFlow").checked = false;
+                }
             </text>
         }
 
         if (settings.AllowPasswordFlow)
         {
-            <text>$("#AllowPasswordFlowFieldSet").collapse("show"); </text>
+            <text>setCollapse(getElement("AllowPasswordFlowFieldSet"), "show"); </text>
         }
         else
         {
             <text>
-                $("#AllowPasswordFlowFieldSet").collapse("hide");
-                $("#AllowPasswordFlow").prop("checked", false);
+                setCollapse(getElement("AllowPasswordFlowFieldSet"), "hide");
+                getElement("AllowPasswordFlow").checked = false;
             </text>
         }
 
         if (settings.AllowRefreshTokenFlow)
         {
-            <text>$("#AllowRefreshTokenFlowFieldSet").collapse("show"); </text>
+            <text>setCollapse(getElement("AllowRefreshTokenFlowFieldSet"), "show"); </text>
         }
         else
         {
             <text>
-                $("#AllowRefreshTokenFlowFieldSet").collapse("hide");
-                $("#AllowRefreshTokenFlow").prop("checked", false);
+                setCollapse(getElement("AllowRefreshTokenFlowFieldSet"), "hide");
+                getElement("AllowRefreshTokenFlow").checked = false;
             </text>
         }
 
         if (settings.LogoutEndpointPath.HasValue)
         {
-            <text>$("#AllowLogoutEndpointFieldSet").collapse("show"); </text>
+            <text>setCollapse(getElement("AllowLogoutEndpointFieldSet"), "show"); </text>
         }
         else
         {
             <text>
-                $("#AllowLogoutEndpointFieldSet").collapse("hide");
-                $("#AllowLogoutEndpointFieldSet").prop("checked", false);
+                setCollapse(getElement("AllowLogoutEndpointFieldSet"), "hide");
+                getElement("AllowLogoutEndpointFieldSet").checked = false;
             </text>
         }
     }
             }
 
-        $("#Type").change(function () {
+        getElement("Type").addEventListener('change', function () {
             refreshClientSecret();
         });
         function refreshClientSecret(defaultType) {
-            var type = $("#Type"), secret = $("#ClientSecret"), secretWrapper = $('#ClientSecretWrapper');
+            var type = getElement("Type"), secret = getElement("ClientSecret"), secretWrapper = getElement('ClientSecretWrapper');
 
-            var allowClientCredentialsFlow = $("#AllowClientCredentialsFlow");
-            if (type.val() === '@OpenIddictConstants.ClientTypes.Confidential') {
-                secretWrapper.show();
-                allowClientCredentialsFlow.removeAttr("disabled");
+            var allowClientCredentialsFlow = getElement("AllowClientCredentialsFlow");
+            if (type.value === '@OpenIddictConstants.ClientTypes.Confidential') {
+                setDisplay(secretWrapper, true);
+                allowClientCredentialsFlow.disabled = false;
             }
             else {
-                secret.val("");
-                secretWrapper.hide();
-                allowClientCredentialsFlow.attr('disabled', true);
-                allowClientCredentialsFlow.prop("checked", false);
+                secret.value = "";
+                setDisplay(secretWrapper, false);
+                allowClientCredentialsFlow.disabled = true;
+                allowClientCredentialsFlow.checked = false;
             }
 
-            var clientSecretHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
+            var clientSecretHints = document.querySelectorAll("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
 
-            if (defaultType === $("#Type").val())
+            if (defaultType === getElement("Type").value)
                 return;
 
-            if ($("#Type").val() === '@OpenIddictConstants.ClientTypes.Confidential') {
-                clientSecretHints.each(function () { this.innerText = this.innerText.replace("client_id, ", "client_id, client_secret, "); });
+            if (getElement("Type").value === '@OpenIddictConstants.ClientTypes.Confidential') {
+                clientSecretHints.forEach(function (element) { element.innerText = element.innerText.replace("client_id, ", "client_id, client_secret, "); });
             }
             else {
-                clientSecretHints.each(function () { this.innerText = this.innerText.replace("client_id, client_secret, ", "client_id, "); });
+                clientSecretHints.forEach(function (element) { element.innerText = element.innerText.replace("client_id, client_secret, ", "client_id, "); });
             }
         }
 
-        $("#AllowRefreshTokenFlow").change(function () {
+        getElement("AllowRefreshTokenFlow").addEventListener('change', function () {
             refreshOfflineAccessTip();
         });
 
         function refreshOfflineAccessTip(defaultValue) {
-            var offlineAccessHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint");
-            var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
-            if (defaultValue === allowRefreshTokenFlow.prop('checked'))
+            var offlineAccessHints = document.querySelectorAll("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint");
+            var allowRefreshTokenFlow = getElement("AllowRefreshTokenFlow");
+            if (defaultValue === allowRefreshTokenFlow.checked)
                 return;
 
-            if (allowRefreshTokenFlow.prop('checked')) {
-                offlineAccessHints.each(function () { this.innerText = this.innerText.replace("roles", "roles, offline_access"); });
+            if (allowRefreshTokenFlow.checked) {
+                offlineAccessHints.forEach(function (element) { element.innerText = element.innerText.replace("roles", "roles, offline_access"); });
             }
             else {
-                offlineAccessHints.each(function () { this.innerText = this.innerText.replace(", offline_access", ""); });
+                offlineAccessHints.forEach(function (element) { element.innerText = element.innerText.replace(", offline_access", ""); });
             }
         }
 
-        $("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowImplicitFlow, #AllowHybridFlow, #AllowRefreshTokenFlow").change(function () {
-            refreshFlows();
+        document.querySelectorAll("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowImplicitFlow, #AllowHybridFlow, #AllowRefreshTokenFlow").forEach(function (element) {
+            element.addEventListener('change', function () {
+                refreshFlows();
+            });
         });
 
         function refreshFlows() {
@@ -459,44 +479,46 @@
             refreshRedirectSettings();
         }
         function refreshRoleGroup() {
-            $("#RoleGroup").collapse($("#AllowClientCredentialsFlow").prop('checked') ? "show" : "hide");
+            setCollapse(getElement("RoleGroup"), getElement("AllowClientCredentialsFlow").checked ? "show" : "hide");
         }
         function refreshAllowRefreshTokenFlowVisibility() {
-            var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
+            var allowRefreshTokenFlow = getElement("AllowRefreshTokenFlow");
 
-            if ($("#AllowPasswordFlow").prop('checked') ||
-                $("#AllowAuthorizationCodeFlow").prop('checked') ||
-                $("#AllowHybridFlow").prop('checked')) {
-                allowRefreshTokenFlow.removeAttr("disabled");
+            if (getElement("AllowPasswordFlow").checked ||
+                getElement("AllowAuthorizationCodeFlow").checked ||
+                getElement("AllowHybridFlow").checked) {
+                allowRefreshTokenFlow.disabled = false;
             }
             else {
-                allowRefreshTokenFlow.attr('disabled', true);
-                allowRefreshTokenFlow.prop("checked", false);
-                $("#AllowRefreshTokenFlowRecommendedHint").collapse("hide");
+                allowRefreshTokenFlow.disabled = true;
+                allowRefreshTokenFlow.checked = false;
+                setCollapse(getElement("AllowRefreshTokenFlowRecommendedHint"), "hide");
                 refreshOfflineAccessTip();
             }
         }
         function refreshRedirectSettings() {
-            var redirectSection = $("#RedirectSection");
-            var skipConsent = $("#SkipConsent");
-            var postLogoutRedirecUris = $("#postLogoutRedirectUris")
+            var redirectSection = getElement("RedirectSection");
+            var skipConsent = getElement("SkipConsent");
+            var postLogoutRedirecUris = getElement("postLogoutRedirectUris")
 
-            if ($("#AllowImplicitFlow").prop('checked') ||
-                $("#AllowAuthorizationCodeFlow").prop('checked') ||
-                $("#AllowHybridFlow").prop('checked')) {
-                redirectSection.collapse("show");
-                if ($("#AllowLogoutEndpoint").prop('checked')) {
-                    postLogoutRedirecUris.collapse("show");
+            if (getElement("AllowImplicitFlow").checked ||
+                getElement("AllowAuthorizationCodeFlow").checked ||
+                getElement("AllowHybridFlow").checked) {
+                setCollapse(redirectSection, "show");
+                if (getElement("AllowLogoutEndpoint").checked) {
+                    setCollapse(postLogoutRedirecUris, "show");
                 }
                 else {
-                    postLogoutRedirecUris.collapse("hide");
+                    setCollapse(postLogoutRedirecUris, "hide");
                 }
             }
             else {
-                skipConsent.prop("checked", false);
-                redirectSection.collapse("hide");
-                $("#AllowLogoutEndpoint").prop('checked', false);
-                postLogoutRedirecUris.collapse("hide");
+                if (skipConsent) {
+                    skipConsent.checked = false;
+                }
+                setCollapse(redirectSection, "hide");
+                getElement("AllowLogoutEndpoint").checked = false;
+                setCollapse(postLogoutRedirecUris, "hide");
             }
         }
     };

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdClientSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdClientSettings.Edit.cshtml
@@ -270,45 +270,65 @@
 <script at="Foot">
     ////<![CDATA[
     window.onload = function () {
+        function setCollapse(element, action) {
+            if (element) {
+                bootstrap.Collapse.getOrCreateInstance(element, { toggle: false })[action]();
+            }
+        }
+
         refreshFlows();
 
-        $("#@Html.IdFor(m => m.ResponseMode), #@Html.IdFor(m => m.UseCodeFlow), #@Html.IdFor(m => m.UseCodeIdTokenFlow),#@Html.IdFor(m => m.UseCodeTokenFlow), #@Html.IdFor(m => m.UseCodeIdTokenTokenFlow), #@Html.IdFor(m => m.UseIdTokenFlow),#@Html.IdFor(m => m.UseIdTokenTokenFlow)").change(function () {
-            if (this != @Html.IdFor(m => m.ResponseMode)) {
-                $('input[type="checkbox"]').not(this).not(@Html.IdFor(m => m.StoreExternalTokens)).prop('checked', false);
-            } else {
-                $('input[type="checkbox"]').not(@Html.IdFor(m => m.UseCodeFlow)).not(@Html.IdFor(m => m.StoreExternalTokens)).prop('checked', false);
-            }
-            refreshFlows();
+        var responseModeElement = document.getElementById('@Html.IdFor(m => m.ResponseMode)');
+        var useCodeFlowElement = document.getElementById('@Html.IdFor(m => m.UseCodeFlow)');
+        var storeExternalTokensElement = document.getElementById('@Html.IdFor(m => m.StoreExternalTokens)');
+
+        document.querySelectorAll("#@Html.IdFor(m => m.ResponseMode), #@Html.IdFor(m => m.UseCodeFlow), #@Html.IdFor(m => m.UseCodeIdTokenFlow),#@Html.IdFor(m => m.UseCodeTokenFlow), #@Html.IdFor(m => m.UseCodeIdTokenTokenFlow), #@Html.IdFor(m => m.UseIdTokenFlow),#@Html.IdFor(m => m.UseIdTokenTokenFlow)").forEach(function (element) {
+            element.addEventListener('change', function () {
+                if (this !== responseModeElement) {
+                    document.querySelectorAll('input[type="checkbox"]').forEach(function (checkbox) {
+                        if (checkbox !== element && checkbox !== storeExternalTokensElement) {
+                            checkbox.checked = false;
+                        }
+                    });
+                } else {
+                    document.querySelectorAll('input[type="checkbox"]').forEach(function (checkbox) {
+                        if (checkbox !== useCodeFlowElement && checkbox !== storeExternalTokensElement) {
+                            checkbox.checked = false;
+                        }
+                    });
+                }
+                refreshFlows();
+            });
         });
         function refreshFlows(e) {
-            var useCodeFlowElement = $("#@Html.IdFor(m => m.UseCodeFlow)");
-            var useCodeIdTokenFlowElement = $("#@Html.IdFor(m => m.UseCodeIdTokenFlow)");
-            var useCodeIdTokenTokenFlowElement = $("#@Html.IdFor(m => m.UseCodeIdTokenTokenFlow)");
-            var useCodeTokenFlowElement = $("#@Html.IdFor(m => m.UseCodeTokenFlow)");
-            var useIdTokenFlowElement = $("#@Html.IdFor(m => m.UseIdTokenFlow)");
-            var useIdTokenTokenFlowElement = $("#@Html.IdFor(m => m.UseIdTokenTokenFlow)");
+            var useCodeFlowElement = document.getElementById('@Html.IdFor(m => m.UseCodeFlow)');
+            var useCodeIdTokenFlowElement = document.getElementById('@Html.IdFor(m => m.UseCodeIdTokenFlow)');
+            var useCodeIdTokenTokenFlowElement = document.getElementById('@Html.IdFor(m => m.UseCodeIdTokenTokenFlow)');
+            var useCodeTokenFlowElement = document.getElementById('@Html.IdFor(m => m.UseCodeTokenFlow)');
+            var useIdTokenFlowElement = document.getElementById('@Html.IdFor(m => m.UseIdTokenFlow)');
+            var useIdTokenTokenFlowElement = document.getElementById('@Html.IdFor(m => m.UseIdTokenTokenFlow)');
 
-            var responseModeElement = $("#@Html.IdFor(m => m.ResponseMode)");
+            var responseModeElement = document.getElementById('@Html.IdFor(m => m.ResponseMode)');
 
-            var clientSecretElement = $("#@Html.IdFor(m => m.ClientSecret)");
+            var clientSecretElement = document.getElementById('@Html.IdFor(m => m.ClientSecret)');
 
-            var queryOptionElement = $("#@OpenIdConnectResponseMode.Query");
-            if (useCodeFlowElement.prop("checked")) {
-                queryOptionElement.removeAttr("disabled");
+            var queryOptionElement = document.getElementById('@OpenIdConnectResponseMode.Query');
+            if (useCodeFlowElement.checked) {
+                queryOptionElement.disabled = false;
             } else {
-                queryOptionElement.prop("disabled", 'disabled');
-                responseModeElement.prop("value", "@OpenIdConnectResponseMode.FormPost");
+                queryOptionElement.disabled = true;
+                responseModeElement.value = "@OpenIdConnectResponseMode.FormPost";
             }
 
-            var showSecret = useCodeFlowElement.prop("checked") || useCodeIdTokenFlowElement.prop("checked") ||
-                useCodeIdTokenTokenFlowElement.prop("checked") || useCodeTokenFlowElement.prop("checked");
+            var showSecret = useCodeFlowElement.checked || useCodeIdTokenFlowElement.checked ||
+                useCodeIdTokenTokenFlowElement.checked || useCodeTokenFlowElement.checked;
 
             var clientSecretContainer = clientSecretElement.closest('.collapse');
 
             if (showSecret) {
-                clientSecretContainer.collapse("show");
+                setCollapse(clientSecretContainer, "show");
             } else {
-                clientSecretContainer.collapse("hide");
+                setCollapse(clientSecretContainer, "hide");
             }
 
         }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
@@ -423,77 +423,109 @@
 <script at="Foot">
     ////<![CDATA[
     window.onload = function () {
+        function getElement(id) {
+            return document.getElementById(id);
+        }
+
+        function setDisplay(element, show) {
+            if (element) {
+                element.style.display = show ? '' : 'none';
+            }
+        }
+
+        function setCollapse(element, action) {
+            if (element) {
+                bootstrap.Collapse.getOrCreateInstance(element, { toggle: false })[action]();
+            }
+        }
+
         refreshEncryptionCertificates();
         refreshSigningCertificates();
         refreshEndpoints();
         refreshDisableAccessTokenEncryption();
 
-        $("#@Html.IdFor(m => m.AccessTokenFormat)").change(function () {
+        getElement("@Html.IdFor(m => m.AccessTokenFormat)").addEventListener('change', function () {
             refreshDisableAccessTokenEncryption();
         });
-        $("#@Html.IdFor(m => m.EncryptionCertificateStoreLocation)").change(function () {
+        getElement("@Html.IdFor(m => m.EncryptionCertificateStoreLocation)").addEventListener('change', function () {
             refreshEncryptionCertificates();
         });
-        $("#@Html.IdFor(m => m.EncryptionCertificateStoreName)").change(function () {
+        getElement("@Html.IdFor(m => m.EncryptionCertificateStoreName)").addEventListener('change', function () {
             refreshEncryptionCertificates();
         });
-        $("#@Html.IdFor(m => m.SigningCertificateStoreLocation)").change(function () {
+        getElement("@Html.IdFor(m => m.SigningCertificateStoreLocation)").addEventListener('change', function () {
             refreshSigningCertificates();
         });
-        $("#@Html.IdFor(m => m.SigningCertificateStoreName)").change(function () {
+        getElement("@Html.IdFor(m => m.SigningCertificateStoreName)").addEventListener('change', function () {
             refreshSigningCertificates();
         });
-        $("#@Html.IdFor(m => m.EnableTokenEndpoint), #@Html.IdFor(m => m.EnableAuthorizationEndpoint), #@Html.IdFor(m => m.AllowPasswordFlow), #@Html.IdFor(m => m.AllowAuthorizationCodeFlow), #@Html.IdFor(m => m.AllowAuthorizationCodeFlow), #@Html.IdFor(m => m.AllowHybridFlow)").change(function () {
+        document.querySelectorAll("#@Html.IdFor(m => m.EnableTokenEndpoint), #@Html.IdFor(m => m.EnableAuthorizationEndpoint), #@Html.IdFor(m => m.AllowPasswordFlow), #@Html.IdFor(m => m.AllowAuthorizationCodeFlow), #@Html.IdFor(m => m.AllowAuthorizationCodeFlow), #@Html.IdFor(m => m.AllowHybridFlow)").forEach(function (element) {
+            element.addEventListener('change', function () {
             refreshEndpoints();
+            });
         });
         function refreshEncryptionCertificates() {
-            var location = $("#@Html.IdFor(m => m.EncryptionCertificateStoreLocation)"),
-                name = $("#@Html.IdFor(m => m.EncryptionCertificateStoreName)"),
-                thumbprint = $("#@Html.IdFor(m => m.EncryptionCertificateThumbprint)");
+            var location = getElement("@Html.IdFor(m => m.EncryptionCertificateStoreLocation)"),
+                name = getElement("@Html.IdFor(m => m.EncryptionCertificateStoreName)"),
+                thumbprint = getElement("@Html.IdFor(m => m.EncryptionCertificateThumbprint)");
 
-            if (location.val()) {
-                $("#EncryptionCertificateStoreNameField").show();
+            if (location.value) {
+                setDisplay(getElement("EncryptionCertificateStoreNameField"), true);
 
-                if (name.val()) {
-                    $("#EncryptionCertificateThumbprintField").show();
-                    thumbprint.children("option[value!='']").hide();
-                    thumbprint.children("option[data-StoreLocation=" + location.val() + "][data-StoreName=" + name.val() + "]").show();
+                if (name.value) {
+                    setDisplay(getElement("EncryptionCertificateThumbprintField"), true);
+                    thumbprint.querySelectorAll("option").forEach(function (option) {
+                        if (option.value !== '') {
+                            setDisplay(option, false);
+                        }
+
+                        if (option.getAttribute("data-StoreLocation") === location.value && option.getAttribute("data-StoreName") === name.value) {
+                            setDisplay(option, true);
+                        }
+                    });
                 }
                 else {
-                    $("#EncryptionCertificateThumbprintField").hide();
-                    thumbprint.val("");
+                    setDisplay(getElement("EncryptionCertificateThumbprintField"), false);
+                    thumbprint.value = "";
                 }
             }
             else {
-                $("#EncryptionCertificateStoreNameField").hide();
-                name.val("");
-                $("#EncryptionCertificateThumbprintField").hide();
-                thumbprint.val("");
+                setDisplay(getElement("EncryptionCertificateStoreNameField"), false);
+                name.value = "";
+                setDisplay(getElement("EncryptionCertificateThumbprintField"), false);
+                thumbprint.value = "";
             }
         }
         function refreshSigningCertificates() {
-            var location = $("#@Html.IdFor(m => m.SigningCertificateStoreLocation)"),
-                name = $("#@Html.IdFor(m => m.SigningCertificateStoreName)"),
-                thumbprint = $("#@Html.IdFor(m => m.SigningCertificateThumbprint)");
+            var location = getElement("@Html.IdFor(m => m.SigningCertificateStoreLocation)"),
+                name = getElement("@Html.IdFor(m => m.SigningCertificateStoreName)"),
+                thumbprint = getElement("@Html.IdFor(m => m.SigningCertificateThumbprint)");
 
-            if (location.val()) {
-                $("#SigningCertificateStoreNameField").show();
+            if (location.value) {
+                setDisplay(getElement("SigningCertificateStoreNameField"), true);
 
-                if (name.val()) {
-                    $("#SigningCertificateThumbprintField").show();
-                    thumbprint.children("option[value!='']").hide();
-                    thumbprint.children("option[data-StoreLocation=" + location.val() + "][data-StoreName=" + name.val() + "]").show();
+                if (name.value) {
+                    setDisplay(getElement("SigningCertificateThumbprintField"), true);
+                    thumbprint.querySelectorAll("option").forEach(function (option) {
+                        if (option.value !== '') {
+                            setDisplay(option, false);
+                        }
+
+                        if (option.getAttribute("data-StoreLocation") === location.value && option.getAttribute("data-StoreName") === name.value) {
+                            setDisplay(option, true);
+                        }
+                    });
                 }
                 else {
-                    $("#SigningCertificateThumbprintField").hide();
-                    thumbprint.val("");
+                    setDisplay(getElement("SigningCertificateThumbprintField"), false);
+                    thumbprint.value = "";
                 }
             }
             else {
-                $("#SigningCertificateStoreNameField").hide();
-                name.val("");
-                $("#SigningCertificateThumbprintField").hide();
-                thumbprint.val("");
+                setDisplay(getElement("SigningCertificateStoreNameField"), false);
+                name.value = "";
+                setDisplay(getElement("SigningCertificateThumbprintField"), false);
+                thumbprint.value = "";
             }
         }
         function refreshEndpoints() {
@@ -504,68 +536,68 @@
             refreshAllowRefreshTokenFlowVisibility();
         }
         function refreshDisableAccessTokenEncryption() {
-            var accessTokenFormat = $("#@Html.IdFor(m => m.AccessTokenFormat)");
-            var disableAccessTokenEncryption = $("#@Html.IdFor(m => m.DisableAccessTokenEncryption)");
+            var accessTokenFormat = getElement("@Html.IdFor(m => m.AccessTokenFormat)");
+            var disableAccessTokenEncryption = getElement("@Html.IdFor(m => m.DisableAccessTokenEncryption)");
 
-            if (accessTokenFormat.val() === '@OpenIdServerSettings.TokenFormat.JsonWebToken') {
-                disableAccessTokenEncryption.removeAttr("disabled");
+            if (accessTokenFormat.value === '@OpenIdServerSettings.TokenFormat.JsonWebToken') {
+                disableAccessTokenEncryption.disabled = false;
             }
             else {
-                disableAccessTokenEncryption.attr('disabled', true);
-                disableAccessTokenEncryption.prop("checked", false);
+                disableAccessTokenEncryption.disabled = true;
+                disableAccessTokenEncryption.checked = false;
             }
         }
         function refreshEnableTokenEndpoint() {
-            var enableTokenEndpoint = $("#@Html.IdFor(m => m.EnableTokenEndpoint)");
-            var allowPasswordFlow = $("#@Html.IdFor(m => m.AllowPasswordFlow)");
-            var allowClientCredentialsFlow = $("#@Html.IdFor(m => m.AllowClientCredentialsFlow)");
-            if (!enableTokenEndpoint.prop("checked")) {
-                allowPasswordFlow.prop("checked", false);
-                allowClientCredentialsFlow.prop("checked", false);
+            var enableTokenEndpoint = getElement("@Html.IdFor(m => m.EnableTokenEndpoint)");
+            var allowPasswordFlow = getElement("@Html.IdFor(m => m.AllowPasswordFlow)");
+            var allowClientCredentialsFlow = getElement("@Html.IdFor(m => m.AllowClientCredentialsFlow)");
+            if (!enableTokenEndpoint.checked) {
+                allowPasswordFlow.checked = false;
+                allowClientCredentialsFlow.checked = false;
             }
-            var showOrHide = enableTokenEndpoint.prop("checked") ? "show" : "hide";
-            allowPasswordFlow.closest('.collapse').collapse(showOrHide);
-            allowClientCredentialsFlow.closest('.collapse').collapse(showOrHide);
+            var showOrHide = enableTokenEndpoint.checked ? "show" : "hide";
+            setCollapse(allowPasswordFlow.closest('.collapse'), showOrHide);
+            setCollapse(allowClientCredentialsFlow.closest('.collapse'), showOrHide);
         }
         function refreshEnableAuthorizationEndpoint() {
-            var enableAuthorizationEndpoint = $("#@Html.IdFor(m => m.EnableAuthorizationEndpoint)");
-            var allowImplicitFlow = $("#@Html.IdFor(m => m.AllowImplicitFlow)");
-            if (!enableAuthorizationEndpoint.prop("checked")) {
-                allowImplicitFlow.prop("checked", false);
+            var enableAuthorizationEndpoint = getElement("@Html.IdFor(m => m.EnableAuthorizationEndpoint)");
+            var allowImplicitFlow = getElement("@Html.IdFor(m => m.AllowImplicitFlow)");
+            if (!enableAuthorizationEndpoint.checked) {
+                allowImplicitFlow.checked = false;
             }
-            allowImplicitFlow.closest('.collapse').collapse(enableAuthorizationEndpoint.prop("checked") ? "show" : "hide");
+            setCollapse(allowImplicitFlow.closest('.collapse'), enableAuthorizationEndpoint.checked ? "show" : "hide");
         }
         function refreshAllowAuthorizationCodeFlowVisibility() {
-            var allowAuthorizationCodeFlow = $("#@Html.IdFor(m => m.AllowAuthorizationCodeFlow)");
-            if ($("#@Html.IdFor(m => m.EnableTokenEndpoint)").prop("checked") && $("#@Html.IdFor(m => m.EnableAuthorizationEndpoint)").prop("checked")) {
-                allowAuthorizationCodeFlow.closest('.collapse').collapse("show");
+            var allowAuthorizationCodeFlow = getElement("@Html.IdFor(m => m.AllowAuthorizationCodeFlow)");
+            if (getElement("@Html.IdFor(m => m.EnableTokenEndpoint)").checked && getElement("@Html.IdFor(m => m.EnableAuthorizationEndpoint)").checked) {
+                setCollapse(allowAuthorizationCodeFlow.closest('.collapse'), "show");
             }
             else {
-                allowAuthorizationCodeFlow.prop("checked", false);
-                allowAuthorizationCodeFlow.closest('.collapse').collapse("hide");
+                allowAuthorizationCodeFlow.checked = false;
+                setCollapse(allowAuthorizationCodeFlow.closest('.collapse'), "hide");
             }
         }
         function refreshAllowHybridFlowVisibility() {
-            var allowHybridFlow = $("#@Html.IdFor(m => m.AllowHybridFlow)");
-            if ($("#@Html.IdFor(m => m.EnableTokenEndpoint)").prop("checked") && $("#@Html.IdFor(m => m.EnableAuthorizationEndpoint)").prop("checked")) {
-                allowHybridFlow.closest('.collapse').collapse("show");
+            var allowHybridFlow = getElement("@Html.IdFor(m => m.AllowHybridFlow)");
+            if (getElement("@Html.IdFor(m => m.EnableTokenEndpoint)").checked && getElement("@Html.IdFor(m => m.EnableAuthorizationEndpoint)").checked) {
+                setCollapse(allowHybridFlow.closest('.collapse'), "show");
             }
             else {
-                allowHybridFlow.prop("checked", false);
-                allowHybridFlow.closest('.collapse').collapse("hide");
+                allowHybridFlow.checked = false;
+                setCollapse(allowHybridFlow.closest('.collapse'), "hide");
             }
         }
         function refreshAllowRefreshTokenFlowVisibility() {
-            var allowRefreshTokenFlow = $("#@Html.IdFor(m => m.AllowRefreshTokenFlow)");
-            if ($("#@Html.IdFor(m => m.EnableTokenEndpoint)").prop("checked")
-                && ($("#@Html.IdFor(m => m.AllowPasswordFlow)").prop("checked") ||
-                    $("#@Html.IdFor(m => m.AllowAuthorizationCodeFlow)").prop("checked") ||
-                    $("#@Html.IdFor(m => m.AllowHybridFlow)").prop("checked"))) {
-                allowRefreshTokenFlow.closest('.collapse').collapse("show");
+            var allowRefreshTokenFlow = getElement("@Html.IdFor(m => m.AllowRefreshTokenFlow)");
+            if (getElement("@Html.IdFor(m => m.EnableTokenEndpoint)").checked
+                && (getElement("@Html.IdFor(m => m.AllowPasswordFlow)").checked ||
+                    getElement("@Html.IdFor(m => m.AllowAuthorizationCodeFlow)").checked ||
+                    getElement("@Html.IdFor(m => m.AllowHybridFlow)").checked)) {
+                setCollapse(allowRefreshTokenFlow.closest('.collapse'), "show");
             }
             else {
-                allowRefreshTokenFlow.prop("checked", false);
-                allowRefreshTokenFlow.closest('.collapse').collapse("hide");
+                allowRefreshTokenFlow.checked = false;
+                setCollapse(allowRefreshTokenFlow.closest('.collapse'), "hide");
             }
         }
     };

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
@@ -57,31 +57,31 @@
 </div>
 
 <script at="Foot">
-    $(function () {
-        var authority = $('#@Html.IdFor(model => model.Authority)');
-        var audience = $('#@Html.IdFor(model => model.Audience)');
-        var tenant = $('#@Html.IdFor(model => model.Tenant)');
-        var disableTokenTypeValidation = $('#@Html.IdFor(model => model.DisableTokenTypeValidation)');
-        var authorityField = $('#AuthorityField');
-        var audienceField = $('#AudienceField');
-        var disableTokenTypeValidationField = $('#DisableTokenTypeValidationField');
+    document.addEventListener('DOMContentLoaded', function () {
+        var authority = document.getElementById('@Html.IdFor(model => model.Authority)');
+        var audience = document.getElementById('@Html.IdFor(model => model.Audience)');
+        var tenant = document.getElementById('@Html.IdFor(model => model.Tenant)');
+        var disableTokenTypeValidation = document.getElementById('@Html.IdFor(model => model.DisableTokenTypeValidation)');
+        var authorityField = document.getElementById('AuthorityField');
+        var audienceField = document.getElementById('AudienceField');
+        var disableTokenTypeValidationField = document.getElementById('DisableTokenTypeValidationField');
 
-        tenant.change(function () {
-            if (tenant.val() != '') {
-                authority.val(null);
-                authorityField.hide();
-                audience.val(null);
-                audienceField.hide();
-                disableTokenTypeValidation.val(false);
-                disableTokenTypeValidationField.hide();
+        tenant.addEventListener('change', function () {
+            if (tenant.value != '') {
+                authority.value = null;
+                authorityField.style.display = 'none';
+                audience.value = null;
+                audienceField.style.display = 'none';
+                disableTokenTypeValidation.value = false;
+                disableTokenTypeValidationField.style.display = 'none';
             }
             else {
-                authorityField.show();
-                audienceField.show();
-                disableTokenTypeValidationField.show();
+                authorityField.style.display = '';
+                audienceField.style.display = '';
+                disableTokenTypeValidationField.style.display = '';
             }
         });
 
-        tenant.trigger('change');
+        tenant.dispatchEvent(new Event('change'));
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Edit.cshtml
@@ -57,7 +57,7 @@
 </form>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Nodes)');
         if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
@@ -86,61 +86,93 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
-            }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+        function show(element) {
+            if (element) {
+                element.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function displayActionsOrFilters() {
+            if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                show(actions);
+                filters.forEach(hide);
+                show(selectedItems);
+                hide(items);
+            }
+            else {
+                hide(actions);
+                filters.forEach(show);
+                hide(selectedItems);
+                show(items);
+            }
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = item.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
                         }
+                    });
+                }
+            });
+        });
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
                     }
                 });
-            }
-        });
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+                if (selectedItems) {
+                    selectedItems.textContent = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length + ' @T["selected"]';
+                }
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+                displayActionsOrFilters();
+            });
+        }
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']").length;
+                var selectedItemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
+                }
+
+                if (selectedItems) {
+                    selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                }
+
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
@@ -112,61 +112,93 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
-            }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+        function show(element) {
+            if (element) {
+                element.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function displayActionsOrFilters() {
+            if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                show(actions);
+                filters.forEach(hide);
+                show(selectedItems);
+                hide(items);
+            }
+            else {
+                hide(actions);
+                filters.forEach(show);
+                hide(selectedItems);
+                show(items);
+            }
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = item.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
                         }
+                    });
+                }
+            });
+        });
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
                     }
                 });
-            }
-        });
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+                if (selectedItems) {
+                    selectedItems.textContent = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length + ' @T["selected"]';
+                }
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+                displayActionsOrFilters();
+            });
+        }
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']").length;
+                var selectedItemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
+                }
+
+                if (selectedItems) {
+                    selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                }
+
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Query.cshtml
@@ -105,7 +105,7 @@
 
 <script at="Foot">
     document.addEventListener('DOMContentLoaded', function () {
-        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: @MediaTypeNamesExtended.Text.PostgreSQL, lineNumbers: true, viewportMargin: Infinity });
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: '@MediaTypeNamesExtended.Text.PostgreSQL', lineNumbers: true, viewportMargin: Infinity });
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.Parameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
         var rawSql = document.getElementById('@Html.IdFor(m => m.RawSql)');
         if (rawSql) {

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Query.cshtml
@@ -104,10 +104,11 @@
 }
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: @MediaTypeNamesExtended.Text.PostgreSQL, lineNumbers: true, viewportMargin: Infinity });
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.Parameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
-        if (rawSql = document.getElementById('@Html.IdFor(m => m.RawSql)')) {
+        var rawSql = document.getElementById('@Html.IdFor(m => m.RawSql)');
+        if (rawSql) {
             CodeMirror.fromTextArea(rawSql, { mode: "@sqlmode", lineNumbers: true, readonly: true, viewportMargin: Infinity });
         }
     });

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Items/QueryBasedContentDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Items/QueryBasedContentDeploymentStep.Fields.Edit.cshtml
@@ -55,7 +55,7 @@
  </div>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.QueryParameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Query.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Query.Fields.Edit.cshtml
@@ -18,7 +18,7 @@
     <span class="hint">@T["The schema the GraphQL API will use to return results."] <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Queries/#graphql" target="_blank">@T["See documentation"]</a></span>
     </div>
 </div>
-<script asp-name="monaco" depends-on="jQuery" at="Foot"></script>
+<script asp-name="monaco" at="Foot"></script>
 
 <script at="Foot" depends-on="monaco">
     document.addEventListener('DOMContentLoaded', function () {

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/SqlQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/SqlQuery.Edit.cshtml
@@ -48,7 +48,7 @@
 </div>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), {
             mode: @MediaTypeNamesExtended.Text.PostgreSQL,
             indentWithTabs: true, smartIndent: true, matchBrackets: true, lineNumbers: true, styleActiveLine: true, viewportMargin: Infinity,

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/SqlQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/SqlQuery.Edit.cshtml
@@ -50,7 +50,7 @@
 <script at="Foot">
     document.addEventListener('DOMContentLoaded', function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), {
-            mode: @MediaTypeNamesExtended.Text.PostgreSQL,
+            mode: '@MediaTypeNamesExtended.Text.PostgreSQL',
             indentWithTabs: true, smartIndent: true, matchBrackets: true, lineNumbers: true, styleActiveLine: true, viewportMargin: Infinity,
             extraKeys: { "Ctrl-Space": "autocomplete" },
             hintOptions: {

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Views/Admin/Index.cshtml
@@ -80,32 +80,44 @@
     }
 </form>
 <script at="Foot">
-    $(function () {
-        var searchBox = $('#search-box');
+    document.addEventListener('DOMContentLoaded', function () {
+        var searchBox = document.getElementById('search-box');
+        if (!searchBox) {
+            return;
+        }
+
+        function isVisible(element) {
+            return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+        }
 
         // On each keypress filter the list of features
-        searchBox.keyup(function (e) {
-            var search = $(this).val().toLowerCase();
-            var elementsToFilter = $("[data-filter-value]");
+        searchBox.addEventListener('keyup', function (e) {
+            var search = this.value.toLowerCase();
+            var elementsToFilter = document.querySelectorAll("[data-filter-value]");
 
             // On ESC, clear the search box and display all features
             if (e.key === "Escape" || search == '') {
-                searchBox.val('');
-                elementsToFilter.toggle(true);
+                searchBox.value = '';
+                elementsToFilter.forEach(function (element) {
+                    element.style.display = '';
+                });
             }
             else {
-                elementsToFilter.each(function () {
-                    var text = $(this).data('filter-value').toLowerCase();
+                elementsToFilter.forEach(function (element) {
+                    var text = element.dataset.filterValue.toLowerCase();
                     var found = text.indexOf(search) > -1;
-                    $(this).toggle(found);
+                    element.style.display = found ? '' : 'none';
                 });
 
-                var visible = $('.recipe-group > ul > li:visible');
-                if (visible.length == 0) {
-                    $('#list-alert').removeClass("d-none");
-                }
-                else {
-                    $('#list-alert').addClass("d-none");
+                var visible = Array.from(document.querySelectorAll('.recipe-group > ul > li')).filter(isVisible);
+                var listAlert = document.getElementById('list-alert');
+                if (listAlert) {
+                    if (visible.length == 0) {
+                        listAlert.classList.remove("d-none");
+                    }
+                    else {
+                        listAlert.classList.add("d-none");
+                    }
                 }
             }
         });

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
@@ -137,34 +137,49 @@
 </form>
 
 <script at="Foot">
-    $(function () {
-        var searchBox = $('#search-box');
+    document.addEventListener('DOMContentLoaded', function () {
+        var searchBox = document.getElementById('search-box');
+        if (!searchBox) {
+            return;
+        }
+
+        function setVisible(element, visible) {
+            element.style.display = visible ? '' : 'none';
+        }
+
+        function isVisible(element) {
+            return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+        }
+
         // On each keypress filter the list of roles
-        searchBox.keyup(function (e) {
-            var search = $(this).val().toLowerCase();
+        searchBox.addEventListener('keyup', function (e) {
+            var search = this.value.toLowerCase();
 
             // On ESC, clear the search box and display all roles
             if (e.key === "Escape" || search == '') {
-                searchBox.val('');
-                $('.permissions-list').toggle(true);
-                $('.permissions-list > table > tbody > tr').toggle(true);
+                searchBox.value = '';
+                document.querySelectorAll('.permissions-list').forEach(function (list) {
+                    setVisible(list, true);
+                });
+                document.querySelectorAll('.permissions-list > table > tbody > tr').forEach(function (row) {
+                    setVisible(row, true);
+                });
             }
             else {
-                $('.permissions-list > table > tbody > tr').each(function () {
-                    var text = $(this).data('text').toLowerCase();
+                document.querySelectorAll('.permissions-list > table > tbody > tr').forEach(function (row) {
+                    var text = row.dataset.text.toLowerCase();
                     var found = text.indexOf(search) > -1;
-                    $(this).toggle(found);
+                    setVisible(row, found);
 
                     if (found) {
-                        $(this).parents('.permissions-list').toggle(true);
+                        setVisible(row.closest('.permissions-list'), true);
                     }
                 });
 
                 // Hide any section without visible permission
-                $('.permissions-list').each(function () {
-                    var list = $(this);
-                    var hasVisiblePermissions = list.find('table > tbody > tr:visible').length > 0;
-                    list.toggle(hasVisiblePermissions);
+                document.querySelectorAll('.permissions-list').forEach(function (list) {
+                    var hasVisiblePermissions = Array.from(list.querySelectorAll('table > tbody > tr')).some(isVisible);
+                    setVisible(list, hasVisiblePermissions);
                 });
             }
         });

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Index.cshtml
@@ -69,55 +69,72 @@
 </form>
 
 <script at="Foot">
-    $(function () {
-        var searchBox = $('#search-box');
+    document.addEventListener('DOMContentLoaded', function () {
+        var searchBox = document.getElementById('search-box');
+        if (!searchBox) {
+            return;
+        }
+
+        function isVisible(element) {
+            return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+        }
 
         // On Enter, edit the role if there is a single one
-        searchBox.keydown(function (e) {
+        searchBox.addEventListener('keydown', function (e) {
             if (e.key == 'Enter') {
 
                 // Edit the role if there is a single filtered element
-                var visible = $('.roles > ul > li:visible');
+                var visible = Array.from(document.querySelectorAll('.roles > ul > li')).filter(isVisible);
                 if (visible.length == 1) {
-                    window.location = visible.find('.edit').attr('href');
+                    window.location = visible[0].querySelector('.edit').getAttribute('href');
                 }
+                e.preventDefault();
+                e.stopPropagation();
                 return false;
             }
         });
 
         // On each keypress filter the list of roles
-        searchBox.keyup(function (e) {
-            var search = $(this).val().toLowerCase();
-            var elementsToFilter = $("[data-filter-value]");
+        searchBox.addEventListener('keyup', function (e) {
+            var search = this.value.toLowerCase();
+            var elementsToFilter = document.querySelectorAll("[data-filter-value]");
 
             // On ESC, clear the search box and display all roles
             if (e.key === "Escape" || search == '') {
-                searchBox.val('');
-                elementsToFilter.removeClass("d-none first-child-visible last-child-visible");
+                searchBox.value = '';
+                elementsToFilter.forEach(function (element) {
+                    element.classList.remove("d-none", "first-child-visible", "last-child-visible");
+                });
             }
             else {
-                elementsToFilter.each(function () {
-                    var text = $(this).data('filter-value').toLowerCase();
+                elementsToFilter.forEach(function (element) {
+                    var text = element.dataset.filterValue.toLowerCase();
                     var found = text.indexOf(search) > -1;
 
                     if (found) {
-                        $(this).removeClass("d-none first-child-visible last-child-visible");
+                        element.classList.remove("d-none", "first-child-visible", "last-child-visible");
                     }
                     else {
-                        $(this).addClass("d-none");
+                        element.classList.add("d-none");
                     }
                 });
 
-                elementsToFilter.filter(":not(.d-none)").first().addClass("first-child-visible");
-                elementsToFilter.filter(":not(.d-none)").last().addClass("last-child-visible");
+                var visibleElements = Array.from(elementsToFilter).filter(function (element) {
+                    return !element.classList.contains('d-none');
+                });
+
+                if (visibleElements.length > 0) {
+                    visibleElements[0].classList.add("first-child-visible");
+                    visibleElements[visibleElements.length - 1].classList.add("last-child-visible");
+                }
 
                 // We display an alert if a search is not found
-                var visible = $('.roles > ul > li:visible');
+                var visible = Array.from(document.querySelectorAll('.roles > ul > li')).filter(isVisible);
                 if (visible.length == 0) {
-                    $('#list-alert').removeClass("d-none");
+                    document.getElementById('list-alert').classList.remove("d-none");
                 }
                 else {
-                    $('#list-alert').addClass("d-none");
+                    document.getElementById('list-alert').classList.add("d-none");
                 }
             }
         });

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/ConditionsModal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/ConditionsModal.cshtml
@@ -32,50 +32,61 @@
     </div>
 </div>
 
-<script At="Foot" depends-on="jQuery">
-    $(function () {
-        $('#modalConditions').on('show.bs.modal', function (event) {
-            var button = $(event.relatedTarget) // Button that triggered the modal
-            var conditionGroupId = button.data('condition-group-id');
+<script At="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var modalConditions = document.getElementById('modalConditions');
+        if (modalConditions) {
+            modalConditions.addEventListener('show.bs.modal', function (event) {
+                var button = event.relatedTarget; // Button that triggered the modal
+                var conditionGroupId = button ? button.dataset.conditionGroupId : '';
 
-            $('.condition-thumbnail').one('click', function () {
-                var url = $(this).data("target-url") + "&conditionGroupId=" + conditionGroupId;
-                $(location).attr('href',url);
+                document.querySelectorAll('.condition-thumbnail').forEach(function (thumbnail) {
+                    thumbnail.addEventListener('click', function () {
+                        var url = this.dataset.targetUrl + "&conditionGroupId=" + conditionGroupId;
+                        window.location.href = url;
+                    }, { once: true });
+                });
             });
+
+            modalConditions.addEventListener('shown.bs.modal', function () {
+                var searchBox = document.getElementById('search-box');
+                if (searchBox) {
+                    searchBox.focus();
+                }
+            });
+        }
+
+        var searchBox = document.getElementById('search-box');
+        if (!searchBox) {
+            return;
+        }
+
+        // On each keypress filter the list of cards
+        searchBox.addEventListener('keyup', function () {
+            var search = replaceDiacritics(this.value.toLowerCase());
+            if (search == '') {
+                searchBox.value = '';
+                document.querySelectorAll('.item').forEach(function (item) {
+                    item.style.display = '';
+                });
+            }
+            else {
+                document.querySelectorAll('.item').forEach(function (item) {
+                    var titleElement;
+                    Array.from(item.children).some(function (child) {
+                        titleElement = child.firstElementChild;
+                        return !!titleElement;
+                    });
+                    var title = titleElement ? titleElement.innerHTML : '';
+                    var filter = replaceDiacritics(title.toLowerCase());
+                    var found = filter.indexOf(search) > -1;
+                    item.style.display = found ? '' : 'none';
+                });
+            }
         });
-    });
-    $(function() {
-      $('#modalConditions').on('shown.bs.modal', function() {
-        $('#search-box').trigger('focus');
-      });
     });
 
     function replaceDiacritics(str) {
         return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
     }
-
-    $(function () {
-        var searchBox = $('#search-box');
-
-        // On each keypress filter the list of cards
-        searchBox.keyup(function (e) {
-            var search = replaceDiacritics($(this).val().toLowerCase());
-            if (search == '') {
-                searchBox.val('');
-                $('.item').show();
-            }
-            else {
-                $('.item').each(function () {
-                    var filter = replaceDiacritics($(this).children().children().first().html().toLowerCase());
-                    var found = filter.indexOf(search) > -1;
-                    if (found) {
-                        $(this).show();
-                    }
-                    else {
-                        $(this).hide();
-                    }
-                });
-            }
-        });
-    })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/JavascriptCondition.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/JavascriptCondition.Fields.Edit.cshtml
@@ -21,9 +21,9 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jquery">
+<script at="Foot">
     //<![CDATA[
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Script)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Security/Views/PermissionsPolicySettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Security/Views/PermissionsPolicySettings.Edit.cshtml
@@ -167,27 +167,35 @@
 </div>
 <script>
     function changeOrigin(e, origin) {
-        var allowedOrigins = $('#' + e.name + 'AllowedOrigins');
+        var allowedOrigins = document.getElementById(e.name + 'AllowedOrigins');
+        if (!allowedOrigins) {
+            return;
+        }
 
         if (e.value == "Self") {
-            allowedOrigins.removeClass('d-none').addClass('d-block');
+            allowedOrigins.classList.remove('d-none');
+            allowedOrigins.classList.add('d-block');
 
-            if (allowedOrigins.val() != '') {
-                origin += ' ' + allowedOrigins.val().trim();
+            if (allowedOrigins.value != '') {
+                origin += ' ' + allowedOrigins.value.trim();
             }
         }
         else {
-            allowedOrigins.removeClass('d-block').addClass('d-none');
+            allowedOrigins.classList.remove('d-block');
+            allowedOrigins.classList.add('d-none');
         }
 
-        allowedOrigins.siblings().val(origin);
+        var permissionValue = allowedOrigins.parentElement.querySelector('input[type="hidden"]');
+        if (permissionValue) {
+            permissionValue.value = origin;
+        }
     }
 
     function changeAllowedOrigins(e) {
-        var permissionValue = $(e).siblings();
+        var permissionValue = e.parentElement.querySelector('input[type="hidden"]');
 
-        if (permissionValue.val().startsWith('self')) {
-            permissionValue.val('self ' + e.value.trim());
+        if (permissionValue && permissionValue.value.startsWith('self')) {
+            permissionValue.value = 'self ' + e.value.trim();
         }
     }
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Seo/Views/SeoMetaPartGoogleSchema.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Views/SeoMetaPartGoogleSchema.Edit.cshtml
@@ -14,7 +14,7 @@
 <script asp-name="codemirror-addon-selection-active-line" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.GoogleSchema)');
         // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
@@ -91,55 +91,93 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
-            }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+
+        function show(element) {
+            if (element) {
+                element.style.display = '';
             }
         }
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
+
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function displayActionsOrFilters() {
+            if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                show(actions);
+                filters.forEach(hide);
+                show(selectedItems);
+                hide(items);
+            }
+            else {
+                hide(actions);
+                filters.forEach(show);
+                hide(selectedItems);
+                show(items);
+            }
+        }
+
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
+
+            item.addEventListener("click", function () {
+                if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = item.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
                         }
+                    });
+                }
+            });
+        });
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    if (checkbox !== selectAllCtrl) {
+                        checkbox.checked = selectAllCtrl.checked;
                     }
                 });
-            }
-        });
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+
+                if (selectedItems) {
+                    selectedItems.textContent = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length + ' @T["selected"]';
+                }
+
+                displayActionsOrFilters();
+            });
+        }
+
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']").length;
+                var selectedItemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
+                }
+
+                if (selectedItems) {
+                    selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                }
+
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
@@ -114,6 +114,10 @@
         var selectedItems = document.getElementById("selected-items");
         var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
+        if (!selectAllCtrl) {
+            return;
+        }
+
         function getSelectedItemsCount() {
             return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
@@ -105,61 +105,74 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+
+        function getSelectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
 
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (getSelectedItemsCount() > 1) {
+                actions.style.display = '';
+                filters.forEach(function (filter) { filter.style.display = 'none'; });
+                selectedItems.style.display = '';
+                items.style.display = 'none';
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                actions.style.display = 'none';
+                filters.forEach(function (filter) { filter.style.display = ''; });
+                selectedItems.style.display = 'none';
+                items.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (dropdownItem) {
+            if (!dropdownItem.dataset.action) {
+                return;
             }
+
+            dropdownItem.addEventListener("click", function () {
+                if (getSelectedItemsCount() > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = dropdownItem.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
+                        }
+                    });
+                }
+            });
         });
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
+        selectAllCtrl.addEventListener("click", function () {
+            itemsCheckboxes.forEach(function (checkbox) {
+                if (checkbox !== selectAllCtrl) {
+                    checkbox.checked = selectAllCtrl.checked;
+                }
+            });
+            selectedItems.textContent = getSelectedItemsCount() + ' @T["selected"]';
             displayActionsOrFilters();
         });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var selectedItemsCount = getSelectedItemsCount();
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapCache/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapCache/List.cshtml
@@ -50,43 +50,50 @@
 </form>
 
 <script at="Foot">
-    $(function () {
-        var searchBox = $('#search-box');
+    document.addEventListener('DOMContentLoaded', function () {
+        var searchBox = document.getElementById('search-box');
 
         // On each keypress filter the list of cache entries
-        searchBox.keyup(function (e) {
-            var search = $(this).val().toLowerCase();
-            var elementsToFilter = $("[data-cacheentry]");
+        searchBox.addEventListener('keyup', function (e) {
+            var search = this.value.toLowerCase();
+            var elementsToFilter = document.querySelectorAll("[data-cacheentry]");
 
             // On ESC, clear the search box and display all cache entries
             if (e.key === "Escape" || search == '') {
-                searchBox.val('');
-                elementsToFilter.removeClass("d-none first-child-visible last-child-visible");
+                searchBox.value = '';
+                elementsToFilter.forEach(function (element) {
+                    element.classList.remove("d-none", "first-child-visible", "last-child-visible");
+                });
             }
             else {
-                $('#cache-entries > li').each(function () {
-                    var cacheEntry = $(this).data('cacheentry').toLowerCase();
+                document.querySelectorAll('#cache-entries > li').forEach(function (element) {
+                    var cacheEntry = element.dataset.cacheentry.toLowerCase();
                     var found = cacheEntry.indexOf(search) > -1;
 
                     if (found) {
-                        $(this).removeClass("d-none first-child-visible last-child-visible");
+                        element.classList.remove("d-none", "first-child-visible", "last-child-visible");
                     }
                     else {
-                        $(this).addClass("d-none");
+                        element.classList.add("d-none");
                     }
                 });
 
-                elementsToFilter.filter(":not(.d-none)").first().addClass("first-child-visible");
-                elementsToFilter.filter(":not(.d-none)").last().addClass("last-child-visible");
+                var visibleElements = Array.from(elementsToFilter).filter(function (element) {
+                    return !element.classList.contains("d-none");
+                });
+
+                if (visibleElements.length) {
+                    visibleElements[0].classList.add("first-child-visible");
+                    visibleElements[visibleElements.length - 1].classList.add("last-child-visible");
+                }
 
                 // We display an alert if a search is not found
-                var visible = $('#cache-entries > li:visible');
-                if (visible.length == 0) {
-                    $('#search-alert').removeClass("d-none");
-                    $('#none-alert').addClass("d-none");
+                if (document.querySelectorAll('#cache-entries > li:not(.d-none)').length == 0) {
+                    document.getElementById('search-alert').classList.remove("d-none");
+                    document.getElementById('none-alert').classList.add("d-none");
                 }
                 else {
-                    $('#search-alert').addClass("d-none");
+                    document.getElementById('search-alert').classList.add("d-none");
                 }
             }
         });

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
@@ -108,61 +108,74 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+
+        function getSelectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
 
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (getSelectedItemsCount() > 1) {
+                actions.style.display = '';
+                filters.forEach(function (filter) { filter.style.display = 'none'; });
+                selectedItems.style.display = '';
+                items.style.display = 'none';
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                actions.style.display = 'none';
+                filters.forEach(function (filter) { filter.style.display = ''; });
+                selectedItems.style.display = 'none';
+                items.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (dropdownItem) {
+            if (!dropdownItem.dataset.action) {
+                return;
             }
+
+            dropdownItem.addEventListener("click", function () {
+                if (getSelectedItemsCount() > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = dropdownItem.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
+                        }
+                    });
+                }
+            });
         });
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
+        selectAllCtrl.addEventListener("click", function () {
+            itemsCheckboxes.forEach(function (checkbox) {
+                if (checkbox !== selectAllCtrl) {
+                    checkbox.checked = selectAllCtrl.checked;
+                }
+            });
+            selectedItems.textContent = getSelectedItemsCount() + ' @T["selected"]';
             displayActionsOrFilters();
         });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var selectedItemsCount = getSelectedItemsCount();
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
@@ -117,6 +117,10 @@
         var selectedItems = document.getElementById("selected-items");
         var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
+        if (!selectAllCtrl) {
+            return;
+        }
+
         function getSelectedItemsCount() {
             return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapPart.Edit.cshtml
@@ -42,11 +42,11 @@
     </div>
 </div>
 
-<script at="Foot" depends-on="jquery">
-    $('#@Html.IdFor(i => i.OverrideSitemapConfig)').change(function (e) {
-        var checked = $(e.target).prop('checked');
-        $('.sitemap-form-g').each(function () {
-            checked ? $(this).show() : $(this).hide();
+<script at="Foot">
+    document.getElementById('@Html.IdFor(i => i.OverrideSitemapConfig)').addEventListener('change', function (e) {
+        var checked = e.target.checked;
+        document.querySelectorAll('.sitemap-form-g').forEach(function (element) {
+            element.style.display = checked ? '' : 'none';
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -4,7 +4,6 @@
 }
 
 <script asp-name="js-cookie" at="Foot"></script>
-<script asp-name="jQuery" at="Foot"></script>
 
 <iframe id="iframe" style="position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden;z-index:999990;">
     Your browser doesn't support iframes
@@ -28,38 +27,40 @@
 <resources type="Footer" />
 
 <script>
-    var indexPreviewUrl = $(document.getElementById('indexPreviewUrl')).data('value');
-    var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
-    var contentPreviewUrl = $(document.getElementById('contentPreviewUrl')).data('value');
+    var indexPreviewUrl = document.getElementById('indexPreviewUrl').dataset.value;
+    var renderPreviewUrl = document.getElementById('renderPreviewUrl').dataset.value;
+    var contentPreviewUrl = document.getElementById('contentPreviewUrl').dataset.value;
     var iframe = document.getElementById('iframe');
+    var notConnectedWarning = document.getElementById('notConnectedWarning');
+    var serverErrorWarning = document.getElementById('serverErrorWarning');
     var previewEventTimer = null;
     var previewRenderTimer = null;
     var previewRendering;
     var previewRenderData;
     var initialized;
 
-    $(function () {
-        $(window).on('storage', function (ev) {
+    document.addEventListener('DOMContentLoaded', function () {
+        window.addEventListener('storage', function (ev) {
             if (ev.key == 'OrchardCore.templates:not-connected') {
-                $(notConnectedWarning).show();
+                notConnectedWarning.style.display = 'block';
             }
             else if (ev.key == 'OrchardCore.templates') {
-                if (ev.originalEvent.newValue != null) {
+                if (ev.newValue != null) {
                     // Smooth event cascading
                     clearTimeout(previewEventTimer);
-                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 150);
-                    $(notConnectedWarning).hide();
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.newValue); }, 150);
+                    notConnectedWarning.style.display = 'none';
                 }
             }
         });
 
         // override default behavior of Bootstrap's. We only hide, not remove the alert.
-        $('#close-warning').on('click', function () {
-            $('#notConnectedWarning').hide();
+        document.getElementById('close-warning').addEventListener('click', function () {
+            notConnectedWarning.style.display = 'none';
         });
 
-        $('#close-server-warning').on('click', function () {
-            $('#serverErrorWarning').hide();
+        document.getElementById('close-server-warning').addEventListener('click', function () {
+            serverErrorWarning.style.display = 'none';
         });
 
         var preview = localStorage.getItem('OrchardCore.templates');
@@ -93,6 +94,12 @@
         }
     }
 
+    function toQueryString(data) {
+        return Object.keys(data).map(function (key) {
+            return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
+        }).join('&');
+    }
+
     function renderPreview(value) {
         if (previewRendering) {
             // Defer the last rendering
@@ -109,28 +116,41 @@
                 previewRendering = false;
                 return;
             }
-            formData += '&' + $.param({ 'Handle': contentPreviewUrl || "" });
+            formData += '&' + toQueryString({ 'Handle': contentPreviewUrl || "" });
 
-            $.post(renderPreviewUrl, formData)
-                .done(function (data) {
-                    if (iframe && iframe.contentWindow) {
-                        iframe.contentWindow.document.open();
-                        iframe.contentWindow.document.write(data);
-                        iframe.contentWindow.document.close();
-                        previewRenderData = data;
-                    }
-                    $(serverErrorWarning).hide();
-                })
-                .fail(function (data) {
-                    if (data.status) {
-                        var ul = $('#serverErrorWarning ul').empty();
-                        var error = 'Status code ' + data.status;
-                        console.error(error);
-                        $('<li />').text(error).appendTo(ul);
-                        $(serverErrorWarning).show();
-                    }
-                    previewRendering = false;
-                });
+            fetch(renderPreviewUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+                },
+                body: formData
+            }).then(function (response) {
+                if (!response.ok) {
+                    throw response;
+                }
+
+                return response.text();
+            }).then(function (data) {
+                if (iframe && iframe.contentWindow) {
+                    iframe.contentWindow.document.open();
+                    iframe.contentWindow.document.write(data);
+                    iframe.contentWindow.document.close();
+                    previewRenderData = data;
+                }
+                serverErrorWarning.style.display = 'none';
+            }).catch(function (data) {
+                if (data.status) {
+                    var ul = document.querySelector('#serverErrorWarning ul');
+                    ul.innerHTML = '';
+                    var error = 'Status code ' + data.status;
+                    console.error(error);
+                    var li = document.createElement('li');
+                    li.textContent = error;
+                    ul.appendChild(li);
+                    serverErrorWarning.style.display = 'block';
+                }
+                previewRendering = false;
+            });
         }
         catch (e) {
             previewRendering = false;

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
@@ -105,11 +105,17 @@
 
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
 
         function initializeTemplatePreview(element) {
 
-            var antiforgerytoken = $("[name='__RequestVerificationToken']").val();
+            var antiforgerytoken = document.querySelector("[name='__RequestVerificationToken']").value;
+
+            function toQueryString(data) {
+                return Object.keys(data).map(function (key) {
+                    return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
+                }).join('&');
+            }
 
             sendFormData = function (element) {
 
@@ -119,7 +125,7 @@
                     '__RequestVerificationToken': antiforgerytoken
                 };
                 // store the form data to pass it in the event handler
-                localStorage.setItem('OrchardCore.templates', JSON.stringify($.param(formData)));
+                localStorage.setItem('OrchardCore.templates', JSON.stringify(toQueryString(formData)));
             }
 
             window.addEventListener('storage', function (ev) {
@@ -130,9 +136,9 @@
                 sendFormData(element);
             }, false);
 
-            $(element).on('change', function () { sendFormData(element); });
+            element.addEventListener('change', function () { sendFormData(element); });
 
-            $(window).on('unload', function () {
+            window.addEventListener('unload', function () {
                 localStorage.removeItem('OrchardCore.templates');
                 // this will raise an event in the preview window to notify that the live preview is no longer active.
                 localStorage.setItem('OrchardCore.templates:not-connected', '');

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
@@ -99,9 +99,15 @@ else
             var editor = monaco.editor.create(document.getElementById('@Html.IdFor(x => x.Content)_editor'), settings);
             var textArea = document.getElementById('@Html.IdFor(x => x.Content)');
             var nameInput = document.getElementById('@Html.IdFor(x => x.Name)');
-            var antiforgerytoken = $("[name='__RequestVerificationToken']").val();
+            var antiforgerytoken = document.querySelector("[name='__RequestVerificationToken']").value;
 
             var triggerPreview = null;
+
+            function toQueryString(data) {
+                return Object.keys(data).map(function (key) {
+                    return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
+                }).join('&');
+            }
 
             sendFormData = function () {
                 var formData = {
@@ -110,7 +116,7 @@ else
                     '__RequestVerificationToken': antiforgerytoken
                 };
                 // store the form data to pass it in the event handler
-                localStorage.setItem('OrchardCore.templates', JSON.stringify($.param(formData)));
+                localStorage.setItem('OrchardCore.templates', JSON.stringify(toQueryString(formData)));
             }
 
             const triggerPreviewDelay = 1500;
@@ -146,11 +152,17 @@ else
 </script>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
 
         function initializeTemplatePreview(element) {
 
-            var antiforgerytoken = $("[name='__RequestVerificationToken']").val();
+            var antiforgerytoken = document.querySelector("[name='__RequestVerificationToken']").value;
+
+            function toQueryString(data) {
+                return Object.keys(data).map(function (key) {
+                    return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
+                }).join('&');
+            }
 
             sendFormData = function (element) {
 
@@ -160,7 +172,7 @@ else
                     '__RequestVerificationToken': antiforgerytoken
                 };
                 // store the form data to pass it in the event handler
-                localStorage.setItem('OrchardCore.templates', JSON.stringify($.param(formData)));
+                localStorage.setItem('OrchardCore.templates', JSON.stringify(toQueryString(formData)));
             }
 
             window.addEventListener('storage', function (ev) {
@@ -171,9 +183,9 @@ else
                 sendFormData(element);
             }, false);
 
-            $(element).on('propertychange', function () { if (event.propertyname == "innertext") sendFormData(element); });
+            element.addEventListener('propertychange', function (event) { if (event.propertyname == "innertext") sendFormData(element); });
 
-            $(window).on('unload', function () {
+            window.addEventListener('unload', function () {
                 localStorage.removeItem('OrchardCore.templates');
                 // this will raise an event in the preview window to notify that the live preview is no longer active.
                 localStorage.setItem('OrchardCore.templates:not-connected', '');

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
@@ -108,6 +108,10 @@ else
         var selectedItems = document.getElementById("selected-items");
         var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
+        if (!selectAllCtrl) {
+            return;
+        }
+
         function getSelectedItemsCount() {
             return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
@@ -99,61 +99,74 @@ else
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+
+        function getSelectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
 
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (getSelectedItemsCount() > 1) {
+                actions.style.display = '';
+                filters.forEach(function (filter) { filter.style.display = 'none'; });
+                selectedItems.style.display = '';
+                items.style.display = 'none';
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                actions.style.display = 'none';
+                filters.forEach(function (filter) { filter.style.display = ''; });
+                selectedItems.style.display = 'none';
+                items.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (dropdownItem) {
+            if (!dropdownItem.dataset.action) {
+                return;
             }
+
+            dropdownItem.addEventListener("click", function () {
+                if (getSelectedItemsCount() > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = dropdownItem.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
+                        }
+                    });
+                }
+            });
         });
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
+        selectAllCtrl.addEventListener("click", function () {
+            itemsCheckboxes.forEach(function (checkbox) {
+                if (checkbox !== selectAllCtrl) {
+                    checkbox.checked = selectAllCtrl.checked;
+                }
+            });
+            selectedItems.textContent = getSelectedItemsCount() + ' @T["selected"]';
             displayActionsOrFilters();
         });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var selectedItemsCount = getSelectedItemsCount();
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Create.cshtml
@@ -9,7 +9,7 @@
 </form>
 
 <script at="Foot" asp-name="profile-editor" depends-on="monaco, admin">
-    $(document).ready(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Edit.cshtml
@@ -9,7 +9,7 @@
 </form>
 
 <script at="Foot" asp-name="profile-editor" depends-on="monaco, admin">
-    $(document).ready(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
@@ -90,60 +90,73 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+
+        function getSelectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
 
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (getSelectedItemsCount() > 1) {
+                actions.style.display = '';
+                filters.forEach(function (filter) { filter.style.display = 'none'; });
+                selectedItems.style.display = '';
+                items.style.display = 'none';
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                actions.style.display = 'none';
+                filters.forEach(function (filter) { filter.style.display = ''; });
+                selectedItems.style.display = 'none';
+                items.style.display = '';
             }
         }
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (dropdownItem) {
+            if (!dropdownItem.dataset.action) {
+                return;
             }
+
+            dropdownItem.addEventListener("click", function () {
+                if (getSelectedItemsCount() > 1) {
+                    confirmDialog({
+                        ...this.dataset, callback: function (r) {
+                            if (r) {
+                                document.querySelector("[name='Options.BulkAction']").value = dropdownItem.dataset.action;
+                                document.querySelector("[name='submit.BulkAction']").click();
+                            }
+                        }
+                    });
+                }
+            });
         });
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
+        selectAllCtrl.addEventListener("click", function () {
+            itemsCheckboxes.forEach(function (checkbox) {
+                if (checkbox !== selectAllCtrl) {
+                    checkbox.checked = selectAllCtrl.checked;
+                }
+            });
+            selectedItems.textContent = getSelectedItemsCount() + ' @T["selected"]';
             displayActionsOrFilters();
         });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = itemsCheckboxes.length;
+                var selectedItemsCount = getSelectedItemsCount();
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                selectAllCtrl.checked = selectedItemsCount == itemsCount;
+                selectAllCtrl.indeterminate = selectedItemsCount > 0 && selectedItemsCount < itemsCount;
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                selectedItems.textContent = selectedItemsCount + ' @T["selected"]';
+                displayActionsOrFilters();
+            });
         });
     })
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
@@ -98,6 +98,10 @@
         var selectedItems = document.getElementById("selected-items");
         var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
 
+        if (!selectAllCtrl) {
+            return;
+        }
+
         function getSelectedItemsCount() {
             return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/CreateTenantTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/CreateTenantTask.Fields.Edit.cshtml
@@ -96,7 +96,7 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var editorRupTn = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.TenantNameExpression)'), {
             lineNumbers: true,
             styleActiveLine: true,

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/SetupTenantTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/SetupTenantTask.Fields.Edit.cshtml
@@ -93,7 +93,7 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var editorTn = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.TenantNameExpression)'), {
             lineNumbers: true,
             styleActiveLine: true,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/ExternalLoginSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/ExternalLoginSettings.Edit.cshtml
@@ -166,19 +166,25 @@ type Context = {
 <script at="Foot">
     function toggleEditorState() {
         var syncRolesCheckbox = document.getElementById('@Html.IdFor(x => x.UseScriptToSyncProperties)');
+        var editorWrappers = document.querySelectorAll("#SyncRolesScript_wrapper,#doc_editor_wrapper");
 
         if (syncRolesCheckbox.checked) {
-            $("#SyncRolesScript_wrapper,#doc_editor_wrapper").show()
-
+            editorWrappers.forEach(function (element) {
+                element.style.display = '';
+            });
         } else {
-            $("#SyncRolesScript_wrapper,#doc_editor_wrapper").hide()
+            editorWrappers.forEach(function (element) {
+                element.style.display = 'none';
+            });
         }
     }
 
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var syncRolesCheckbox = document.getElementById('@Html.IdFor(x => x.UseScriptToSyncProperties)');
 
-        syncRolesCheckbox.addEventListener("change", toggleEditorState);
-        toggleEditorState();
+        if (syncRolesCheckbox) {
+            syncRolesCheckbox.addEventListener("change", toggleEditorState);
+            toggleEditorState();
+        }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminList.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminList.cshtml
@@ -57,67 +57,110 @@
 
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function() {
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
         const submitFilterButton = document.querySelector("[name='submit.Filter']");
 
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+        var bulkActionInput = document.querySelector("[name='Options.BulkAction']");
+        var submitBulkActionButton = document.querySelector("[name='submit.BulkAction']");
+
+        function show(element) {
+            if (element) {
+                element.style.display = '';
+            }
+        }
+
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function selectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
+
+        function setBulkAction(action) {
+            if (bulkActionInput && submitBulkActionButton) {
+                bulkActionInput.value = action;
+                submitBulkActionButton.click();
+            }
+        }
 
         document.querySelectorAll('.selectpicker').forEach((element) => {
             element.addEventListener('changed.bs.select', () => submitFilterButton?.click());
         });
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    ...$this.data(), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
             }
+
+            item.addEventListener("click", function () {
+                if (selectedItemsCount() > 1) {
+                    confirmDialog({
+                        ...item.dataset, callback: function (r) {
+                            if (r) {
+                                setBulkAction(item.dataset.action);
+                            }
+                        }
+                    });
+                }
+            });
         });
 
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (selectedItemsCount() > 1) {
+                show(actions);
+                filters.forEach(function (filter) {
+                    hide(filter);
+                });
+                show(selectedItems);
+                hide(items);
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                hide(actions);
+                filters.forEach(function (filter) {
+                    show(filter);
+                });
+                hide(selectedItems);
+                show(items);
             }
         }
 
-        selectAllCtrl.click(function() {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    checkbox.checked = selectAllCtrl.checked;
+                });
+                if (selectedItems) {
+                    selectedItems.textContent = selectedItemsCount() + ' @T["selected"]';
+                }
+                displayActionsOrFilters();
+            });
+        }
 
-        itemsCheckboxes.on("click", function() {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']").length;
+                var selectedCount = selectedItemsCount();
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = selectedCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedCount > 0 && selectedCount < itemsCount;
+                }
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                if (selectedItems) {
+                    selectedItems.textContent = selectedCount + ' @T["selected"]';
+                }
+                displayActionsOrFilters();
+            });
         });
     });
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpRequestTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpRequestTask.Fields.Edit.cshtml
@@ -78,7 +78,7 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var codeMirrorOptions = {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
@@ -55,7 +55,7 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         var codeMirrorOptions = {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
@@ -134,70 +134,115 @@
     <a class="btn btn-secondary" href="@Model.ReturnUrl">@T["Back"]</a>
 </div>
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
         const submitFilterButton = document.querySelector("[name='submit.Filter']");
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+        var bulkActionInput = document.querySelector("[name='Options.BulkAction']");
+        var submitBulkActionButton = document.querySelector("[name='submit.BulkAction']");
+
+        function show(element) {
+            if (element) {
+                element.style.display = '';
+            }
+        }
+
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function selectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
+
+        function setBulkAction(action) {
+            if (bulkActionInput && submitBulkActionButton) {
+                bulkActionInput.value = action;
+                submitBulkActionButton.click();
+            }
+        }
 
         document.querySelectorAll('.selectpicker').forEach((element) => {
             element.addEventListener('changed.bs.select', () => submitFilterButton?.click());
         });
 
-        $(".filter-options input").on("change", function () {
-            $("[name='submit.Filter']").click();
+        document.querySelectorAll(".filter-options input").forEach(function (input) {
+            input.addEventListener("change", function () {
+                submitFilterButton?.click();
+            });
         });
 
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({
-                    title: $this.data('title'), message: $this.data('message'), callback: function (r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }
-                });
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
             }
+
+            item.addEventListener("click", function () {
+                if (selectedItemsCount() > 1) {
+                    confirmDialog({
+                        title: item.dataset.title, message: item.dataset.message, callback: function (r) {
+                            if (r) {
+                                setBulkAction(item.dataset.action);
+                            }
+                        }
+                    });
+                }
+            });
         });
 
         function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
+            if (selectedItemsCount() > 1) {
+                show(actions);
+                filters.forEach(function (filter) {
+                    hide(filter);
+                });
+                show(selectedItems);
+                hide(items);
             }
             else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+                hide(actions);
+                filters.forEach(function (filter) {
+                    show(filter);
+                });
+                hide(selectedItems);
+                show(items);
             }
         }
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
-        });
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    checkbox.checked = selectAllCtrl.checked;
+                });
+                if (selectedItems) {
+                    selectedItems.textContent = selectedItemsCount() + ' @T["selected"]';
+                }
+                displayActionsOrFilters();
+            });
+        }
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']").length;
+                var selectedCount = selectedItemsCount();
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = selectedCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedCount > 0 && selectedCount < itemsCount;
+                }
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+                if (selectedItems) {
+                    selectedItems.textContent = selectedCount + ' @T["selected"]';
+                }
+                displayActionsOrFilters();
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
@@ -101,73 +101,118 @@
 </form>
 @await DisplayAsync(Model.Pager)
 
-<script at="Foot" depends-on="jQuery">
-    $(function () {
-        var actions = $("#actions");
-        var items = $("#items");
-        var filters = $(".filter");
-        var selectAllCtrl = $("#select-all");
-        var selectedItems = $("#selected-items");
-        var itemsCheckboxes = $(":checkbox[name='itemIds']");
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        var actions = document.getElementById("actions");
+        var items = document.getElementById("items");
+        var filters = document.querySelectorAll(".filter");
+        var selectAllCtrl = document.getElementById("select-all");
+        var selectedItems = document.getElementById("selected-items");
+        var itemsCheckboxes = document.querySelectorAll("input[type='checkbox'][name='itemIds']");
+        var submitFilterButton = document.querySelector("[name='submit.Filter']");
+        var bulkActionInput = document.querySelector("[name='Options.BulkAction']");
+        var submitBulkActionButton = document.querySelector("[name='submit.BulkAction']");
 
-        $(".filter-options input").on("change", function () {
-            $("[name='submit.Filter']").click();
-        });
-
-        $(".dropdown-menu .dropdown-item").filter(function () {
-            return $(this).data("action");
-        }).on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                switch ($this.data("action")) {
-                    case "Delete":
-                        confirmDialog({
-                            title: $this.data('title'), message: $this.data('message'), callback: function (r) {
-                                if (r) {
-                                    $("[name='Options.BulkAction']").val($this.data("action"));
-                                    $("[name='submit.BulkAction']").click();
-                                }
-                            }
-                        });
-                        break;
-                    case "Export":
-                        $("[name='Options.BulkAction']").val($this.data("action"));
-                        $("[name='submit.BulkAction']").click();
-                        break;
-                }
-            }
-        });
-
-        function displayActionsOrFilters() {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                actions.show();
-                filters.hide();
-                selectedItems.show();
-                items.hide();
-            }
-            else {
-                actions.hide();
-                filters.show();
-                selectedItems.hide();
-                items.show();
+        function show(element) {
+            if (element) {
+                element.style.display = '';
             }
         }
 
-        selectAllCtrl.click(function () {
-            itemsCheckboxes.not(this).prop("checked", this.checked);
-            selectedItems.text($(":checkbox[name='itemIds']:checked").length + ' @T["selected"]');
-            displayActionsOrFilters();
+        function hide(element) {
+            if (element) {
+                element.style.display = 'none';
+            }
+        }
+
+        function selectedItemsCount() {
+            return document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length;
+        }
+
+        function setBulkAction(action) {
+            if (bulkActionInput && submitBulkActionButton) {
+                bulkActionInput.value = action;
+                submitBulkActionButton.click();
+            }
+        }
+
+        document.querySelectorAll(".filter-options input").forEach(function (input) {
+            input.addEventListener("change", function () {
+                submitFilterButton?.click();
+            });
         });
 
-        itemsCheckboxes.on("click", function () {
-            var itemsCount = $(":checkbox[name='itemIds']").length;
-            var selectedItemsCount = $(":checkbox[name='itemIds']:checked").length;
+        document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
+            if (!item.dataset.action) {
+                return;
+            }
 
-            selectAllCtrl.prop("checked", selectedItemsCount == itemsCount);
-            selectAllCtrl.prop("indeterminate", selectedItemsCount > 0 && selectedItemsCount < itemsCount);
+            item.addEventListener("click", function () {
+                if (selectedItemsCount() > 1) {
+                    switch (item.dataset.action) {
+                        case "Delete":
+                            confirmDialog({
+                                title: item.dataset.title, message: item.dataset.message, callback: function (r) {
+                                    if (r) {
+                                        setBulkAction(item.dataset.action);
+                                    }
+                                }
+                            });
+                            break;
+                        case "Export":
+                            setBulkAction(item.dataset.action);
+                            break;
+                    }
+                }
+            });
+        });
 
-            selectedItems.text(selectedItemsCount + ' @T["selected"]');
-            displayActionsOrFilters();
+        function displayActionsOrFilters() {
+            if (selectedItemsCount() > 1) {
+                show(actions);
+                filters.forEach(function (filter) {
+                    hide(filter);
+                });
+                show(selectedItems);
+                hide(items);
+            }
+            else {
+                hide(actions);
+                filters.forEach(function (filter) {
+                    show(filter);
+                });
+                hide(selectedItems);
+                show(items);
+            }
+        }
+
+        if (selectAllCtrl) {
+            selectAllCtrl.addEventListener("click", function () {
+                itemsCheckboxes.forEach(function (checkbox) {
+                    checkbox.checked = selectAllCtrl.checked;
+                });
+                if (selectedItems) {
+                    selectedItems.textContent = selectedItemsCount() + ' @T["selected"]';
+                }
+                displayActionsOrFilters();
+            });
+        }
+
+        itemsCheckboxes.forEach(function (checkbox) {
+            checkbox.addEventListener("click", function () {
+                var itemsCount = document.querySelectorAll("input[type='checkbox'][name='itemIds']").length;
+                var selectedCount = selectedItemsCount();
+
+                if (selectAllCtrl) {
+                    selectAllCtrl.checked = selectedCount == itemsCount;
+                    selectAllCtrl.indeterminate = selectedCount > 0 && selectedCount < itemsCount;
+                }
+
+                if (selectedItems) {
+                    selectedItems.textContent = selectedCount + ' @T["selected"]';
+                }
+                displayActionsOrFilters();
+            });
         });
     });
 </script>

--- a/src/OrchardCore.Themes/TheAdmin/Views/Navigation-admin.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Navigation-admin.cshtml
@@ -22,43 +22,51 @@
 @if (adminSettings.DisplayMenuFilter)
 {
 <script at="Foot">
-    $(document).bind('keydown', function (e) {
-        if (e.ctrlKey && e.shiftKey && e.which == 70) {
-            $('#filter').focus();
-            return false;
+    document.addEventListener('keydown', function (e) {
+        var isFilterShortcut = e.key ? e.key.toUpperCase() == 'F' : e.which == 70;
+
+        if (e.ctrlKey && e.shiftKey && isFilterShortcut) {
+            document.getElementById('filter').focus();
+            e.preventDefault();
+            e.stopPropagation();
         }
-    });
-    // custom css expression for a case-insensitive contains()
-    jQuery.expr[":"].contains = jQuery.expr.createPseudo(function (arg) {
-        return function (elem) {
-            return jQuery(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
-        };
     });
 
     function hasChild(list) {
-        var filter = $('#filter').val();
-        list.children('li').each(function () {
-            if ($(this).find("span:contains(" + filter + ")").length > 0) {
-                if ($(this).find('ul :first').length > 0) {
-                    $(this).show();
-                    hasChild($(this).find('ul :first').parent());
+        var filter = document.getElementById('filter').value.toUpperCase();
+        Array.from(list.children).filter(function (item) {
+            return item.matches('li');
+        }).forEach(function (item) {
+            var hasMatchingSpan = Array.from(item.querySelectorAll('span')).some(function (span) {
+                return span.textContent.toUpperCase().indexOf(filter) >= 0;
+            });
+
+            if (hasMatchingSpan) {
+                var firstNestedListItem = item.querySelector('ul li');
+
+                if (firstNestedListItem) {
+                    item.style.display = '';
+                    hasChild(firstNestedListItem.parentElement);
                 } else {
-                    $(this).show();
+                    item.style.display = '';
                 }
             } else {
-                $(this).hide();
+                item.style.display = 'none';
             }
         });
     };
-    $('#filter').keyup(function () {
-        var list = $('#adminMenu');
-        var filter = $('#filter').val();
+    document.getElementById('filter').addEventListener('keyup', function (e) {
+        var list = document.getElementById('adminMenu');
+        var filter = document.getElementById('filter').value;
         if (filter) {
             hasChild(list);
         } else {
-            list.find("li").show();
+            list.querySelectorAll("li").forEach(function (item) {
+                item.style.display = '';
+            });
         }
-        return false;
+        e.preventDefault();
+        e.stopPropagation();
     });
 </script>
 }


### PR DESCRIPTION
## Why

Inline `<script>` blocks across the admin Razor views relied on jQuery for simple DOM work (selectors, events, show/hide, form values, AJAX). That pulls jQuery into pages that otherwise don't need it. This PR migrates that inline JavaScript to vanilla JS so those views no longer depend on jQuery, reducing the surface that forces the jQuery resource to load.

## What changed

- Migrated inline jQuery to vanilla JavaScript in 104 admin `.cshtml` views. Typical conversions: `$('#id')` to `getElementById`, `$('.cls')` to `querySelectorAll` + `forEach`, `.on('click')` to `addEventListener`, `.val()/.prop()` to `.value/.checked`, `.show()/.hide()` to `style.display`, `.data()` to `dataset`, and `$.post/$.ajax` to `fetch`.
- Removed now-unnecessary `depends-on="jQuery"` declarations from the migrated scripts so those pages stop requesting jQuery.
- This is intentionally scoped to inline view JavaScript. No C#, no external/bundled scripts (for example `media.js`), and no asset-pipeline sources were touched.

## Not migrated (left on jQuery on purpose)

Views whose scripts depend on jQuery plugins or external jQuery-based scripts were left as-is, because migrating them would require replacing the third-party dependency itself: jQuery UI sortable/nestedSortable (Flows, Widgets, Menu, Taxonomies, AdminMenu trees, Layers, dashboard), Trumbowyg and jQuery UI datepicker editors, the fontawesome icon picker, `jquery-resizable`, and scripts that call into existing jQuery-based assets (autocomplete, audit-trail, jsdiff, media toolbar, shortcodes, leaflet field, bootstrap-select).

## Bugs found and fixed during verification

Local Playwright verification of the migrated views surfaced two real issues, both fixed here:

- **Empty-list crash (migration regression).** jQuery's `$('#select-all')` silently no-ops when the element is absent, but `getElementById('select-all').addEventListener(...)` throws when a list renders empty. Added an early guard in the four list views that were still unguarded (Templates, Sitemaps list, Sitemap index list, Tenant feature profiles), matching the guards the other list views already use.
- **`ReferenceError: text` in the SQL query editors (pre-existing, unrelated to the migration).** `mode: @MediaTypeNamesExtended.Text.PostgreSQL` rendered the MIME constant unquoted into a JS object literal. Quoted it to match the existing `"@sqlmode"` usage in the same file.

## Verification

Built and ran the CMS, then navigated the reachable migrated views with Playwright (list/index pages in their empty state, settings pages including the large OpenID server settings, and content item / content type / create-edit editors), confirming no migration-introduced console errors. Remaining console noise observed during testing came from unmodified external bundles under the webkit automation environment (a Media picker XHR flagged as cross-origin), not from these changes.