### PR TITLE
Change Robots Endpoint Registration to Support Rate Limiting

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Seo/Services/RobotsMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Services/RobotsMiddleware.cs
@@ -7,7 +7,7 @@ using OrchardCore.Modules.FileProviders;
 
 namespace OrchardCore.Seo.Services;
 
-public class RobotsMiddleware
+public sealed class RobotsMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly IStaticFileProvider _staticFileProvider;

--- a/src/OrchardCore.Modules/OrchardCore.Seo/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Startup.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
@@ -9,6 +10,7 @@ using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
+using OrchardCore.Modules.FileProviders;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Seo.Drivers;
@@ -44,6 +46,19 @@ public sealed class Startup : StartupBase
 
     public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
     {
-        app.UseMiddleware<RobotsMiddleware>();
+        var path = "/" + SeoConstants.RobotsFileName;
+
+        routes.Map(path, RequestDelegate);
+        routes.Map($"{path}/{{**robotsPath}}", RequestDelegate);
+    }
+
+    private static Task RequestDelegate(HttpContext context)
+    {
+        var middleware = new RobotsMiddleware(
+            static _ => Task.CompletedTask,
+            context.RequestServices.GetRequiredService<IStaticFileProvider>(),
+            context.RequestServices.GetServices<IRobotsProvider>());
+
+        return middleware.Invoke(context);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Seo/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
@@ -10,7 +9,6 @@ using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
-using OrchardCore.Modules.FileProviders;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Seo.Drivers;
@@ -46,19 +44,13 @@ public sealed class Startup : StartupBase
 
     public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
     {
+        var pipeline = routes.CreateApplicationBuilder()
+            .UseMiddleware<RobotsMiddleware>()
+            .Build();
+
         var path = "/" + SeoConstants.RobotsFileName;
 
-        routes.Map(path, RequestDelegate);
-        routes.Map($"{path}/{{**robotsPath}}", RequestDelegate);
-    }
-
-    private static Task RequestDelegate(HttpContext context)
-    {
-        var middleware = new RobotsMiddleware(
-            static _ => Task.CompletedTask,
-            context.RequestServices.GetRequiredService<IStaticFileProvider>(),
-            context.RequestServices.GetServices<IRobotsProvider>());
-
-        return middleware.Invoke(context);
+        routes.Map(path, pipeline);
+        routes.Map($"{path}/{{**robotsPath}}", pipeline);
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/RateLimiterMiddlewareTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/RateLimiterMiddlewareTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,12 +10,16 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using OrchardCore.Entities;
 using OrchardCore.Modules;
+using OrchardCore.Modules.FileProviders;
 using OrchardCore.RateLimits;
 using OrchardCore.RateLimits.Core;
 using OrchardCore.RateLimits.Models;
 using OrchardCore.RateLimits.Services;
+using OrchardCore.Seo;
+using OrchardCore.Seo.Services;
 
 namespace OrchardCore.Tests.Modules.OrchardCore.RateLimits;
 
@@ -145,6 +150,28 @@ public class RateLimiterMiddlewareTests
         Assert.Equal("other-tenant-response", await otherTenantResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 
+    [Fact]
+    public async Task ShouldApplyEndpointSpecificPoliciesToRobotsTxt()
+    {
+        using var host = await CreateSeoHostAsync(
+            [
+                CreateEndpointFixedWindowPolicy("Robots", "/robots.txt", 1, 60),
+            ],
+            TestContext.Current.CancellationToken);
+
+        var client = host.GetTestClient();
+
+        var firstRobotsResponse = await client.GetAsync("/robots.txt", TestContext.Current.CancellationToken);
+        var secondRobotsResponse = await client.GetAsync("/robots.txt", TestContext.Current.CancellationToken);
+        var otherResponse = await client.GetAsync("/other", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, firstRobotsResponse.StatusCode);
+        Assert.Equal("User-agent: *\nDisallow:\n", (await firstRobotsResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)).Replace("\r\n", "\n"));
+        Assert.Equal(HttpStatusCode.TooManyRequests, secondRobotsResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, otherResponse.StatusCode);
+        Assert.Equal("other-response", await otherResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
     private static async Task<IHost> CreateHostAsync(
         string staticAssetPath,
         Action<RateLimitsOptions> configureRouteLimits,
@@ -196,6 +223,51 @@ public class RateLimiterMiddlewareTests
                             .WithRateLimitGroups("tenant-authentication", "tenant-shared");
                         endpoints.MapGet("/tenant/other", () => Results.Text("other-tenant-response"))
                             .WithName("OtherTenantRoute");
+                    });
+                });
+            });
+
+        return await builder.StartAsync(cancellationToken);
+    }
+
+    private static async Task<IHost> CreateSeoHostAsync(
+        IEnumerable<RateLimitPolicy> enabledPolicies,
+        CancellationToken cancellationToken)
+    {
+        var seoStartup = new global::OrchardCore.Seo.Startup();
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddRateLimiter();
+                    services.AddTransient<IConfigureOptions<RateLimiterOptions>, RateLimiterOptionsConfigurations>();
+                    services.AddSingleton(CreatePolicyStore(enabledPolicies ?? []));
+                    services.AddSingleton(new FixedWindowRateLimiterSource(Mock.Of<IStringLocalizer<FixedWindowRateLimiterSource>>()));
+                    services.AddSingleton(new SlidingWindowRateLimiterSource(Mock.Of<IStringLocalizer<SlidingWindowRateLimiterSource>>()));
+                    services.AddSingleton(new ConcurrencyRateLimiterSource(Mock.Of<IStringLocalizer<ConcurrencyRateLimiterSource>>()));
+                    services.AddSingleton(new TokenBucketRateLimiterSource(Mock.Of<IStringLocalizer<TokenBucketRateLimiterSource>>()));
+                    services.AddKeyedSingleton<IRateLimiterSource>(FixedWindowRateLimiterSource.SourceName, static (sp, _) => sp.GetRequiredService<FixedWindowRateLimiterSource>());
+                    services.AddKeyedSingleton<IRateLimiterSource>(SlidingWindowRateLimiterSource.SourceName, static (sp, _) => sp.GetRequiredService<SlidingWindowRateLimiterSource>());
+                    services.AddKeyedSingleton<IRateLimiterSource>(ConcurrencyRateLimiterSource.SourceName, static (sp, _) => sp.GetRequiredService<ConcurrencyRateLimiterSource>());
+                    services.AddKeyedSingleton<IRateLimiterSource>(TokenBucketRateLimiterSource.SourceName, static (sp, _) => sp.GetRequiredService<TokenBucketRateLimiterSource>());
+                    services.AddSingleton<IStaticFileProvider>(new TestStaticFileProvider());
+                    services.AddSingleton<IRobotsProvider>(new TestRobotsProvider());
+                });
+
+                webBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+
+                    var routes = (IEndpointRouteBuilder)app.Properties["__EndpointRouteBuilder"];
+                    seoStartup.Configure(app, routes, app.ApplicationServices);
+
+                    app.UseRateLimiter();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapGet("/other", () => Results.Text("other-response"));
                     });
                 });
             });
@@ -277,5 +349,19 @@ public class RateLimiterMiddlewareTests
                 Directory.Delete(Path, recursive: true);
             }
         }
+    }
+
+    private sealed class TestStaticFileProvider : IStaticFileProvider
+    {
+        public IDirectoryContents GetDirectoryContents(string subpath) => NotFoundDirectoryContents.Singleton;
+
+        public IFileInfo GetFileInfo(string subpath) => new NotFoundFileInfo(subpath);
+
+        public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
+    }
+
+    private sealed class TestRobotsProvider : IRobotsProvider
+    {
+        public Task<string> GetContentAsync() => Task.FromResult("User-agent: *\nDisallow:");
     }
 }


### PR DESCRIPTION
This pull request refactors how the `robots.txt` endpoint is handled in the SEO module, improving its compatibility with endpoint-specific middleware such as rate limiting. It also introduces new tests to ensure that rate limiting policies can be applied specifically to `robots.txt`. The most important changes are grouped below:

### Refactoring `robots.txt` Endpoint Handling

* Changed the `RobotsMiddleware` to be a `sealed` class and updated its usage: instead of using `app.UseMiddleware<RobotsMiddleware>()`, the endpoint is now mapped directly via `IEndpointRouteBuilder.Map`, allowing endpoint-specific middleware (like rate limiting) to be applied. (`RobotsMiddleware.cs`, `Startup.cs`) [[1]](diffhunk://#diff-8b0baa14adadca9a9675179761d72f85d17b8c8f9400f8248f4790626801075cL10-R10) [[2]](diffhunk://#diff-ff7af12244212966a35ca4f5688b72a03c57075b273dd3f80d24aed02e99e710L47-R62)
* Added necessary using directives for routing and file providers to support the new endpoint mapping approach. (`Startup.cs`) [[1]](diffhunk://#diff-ff7af12244212966a35ca4f5688b72a03c57075b273dd3f80d24aed02e99e710R2) [[2]](diffhunk://#diff-ff7af12244212966a35ca4f5688b72a03c57075b273dd3f80d24aed02e99e710R13)

### Testing and Rate Limiting Integration

* Added a new test, `ShouldApplyEndpointSpecificPoliciesToRobotsTxt`, to verify that rate limiting policies can be applied specifically to the `robots.txt` endpoint. (`RateLimiterMiddlewareTests.cs`)
* Implemented a new test host setup method, `CreateSeoHostAsync`, which configures the SEO module and rate limiting for integration testing. (`RateLimiterMiddlewareTests.cs`)
* Added test implementations of `IStaticFileProvider` and `IRobotsProvider` to support the new test scenario. (`RateLimiterMiddlewareTests.cs`)
