### PR TITLE
Fix migrated inline scripts not initializing when loaded after DOMContentLoaded

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
@@ -100,7 +100,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Views/AliasPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Views/AliasPartSettings.Edit.cshtml
@@ -29,7 +29,15 @@
 
 <script at="Foot">
     //<![CDATA[
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailSettings.Edit.cshtml
@@ -77,7 +77,15 @@
 </section>
 
 <script at="Foot" type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll('.check-all-container').forEach(function (container) {
             var master = container.querySelector('input[type="checkbox"].check-all-master');
             var slaves = container.querySelectorAll('.check-all-slave input[type="checkbox"]:not(:disabled)');

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePartSettings.Edit.cshtml
@@ -103,7 +103,15 @@
 
 <script at="Foot">
     //<![CDATA[
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerFieldSettings.Edit.cshtml
@@ -95,7 +95,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function() {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function() {
         var sources = document.getElementsByName('@Html.NameFor(x => x.Source)');
         var contentTypesContainer = document.getElementById('ContentTypesContainer');
         var stereotypeContainer = document.getElementById('StereotypesContainer');
@@ -123,7 +131,7 @@
 
 <script at="Foot">
     //<![CDATA[
-    document.addEventListener('DOMContentLoaded', function () {
+    onDocumentReady(function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.TitlePattern)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -31,7 +31,15 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
     @* When the field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
         if (optionsTextArea) {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldTrumbowygEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldTrumbowygEditorSettings.Edit.cshtml
@@ -23,7 +23,15 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
@@ -45,7 +45,15 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Text)');
         // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -92,7 +92,15 @@
             }
         };
 
-        document.addEventListener('DOMContentLoaded', function () {
+        function onDocumentReady(callback) {
+            if (document.readyState !== 'loading') {
+                callback();
+            } else {
+                document.addEventListener('DOMContentLoaded', callback);
+            }
+        }
+
+        onDocumentReady(function () {
             var closeConnectWarning = document.getElementById('close-connect-warning');
             if (closeConnectWarning) {
                 closeConnectWarning.addEventListener('click', function () {

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/PreviewPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/PreviewPartSettings.Edit.cshtml
@@ -20,7 +20,15 @@
 
 <script at="Foot">
     //<![CDATA[
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditField.cshtml
@@ -111,7 +111,15 @@
 
 <script at="Foot">
     //<![CDATA[
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll('.field-editor').forEach(function (element) {
             element.style.display = 'none';
         });

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditTypePart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditTypePart.cshtml
@@ -110,7 +110,15 @@
 
 <script at="Foot">
     //<![CDATA[
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll('.type-part-editor').forEach(function (element) {
             element.style.display = 'none';
         });

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ContentDefinitionDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ContentDefinitionDeploymentStep.Fields.Edit.cshtml
@@ -113,7 +113,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll("[data-reversetoggle]").forEach(function (element) {
             element.addEventListener("click", function () {
                 var state = this.checked;

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ReplaceContentDefinitionDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Items/ReplaceContentDefinitionDeploymentStep.Fields.Edit.cshtml
@@ -113,7 +113,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll("[data-reversetoggle]").forEach(function (element) {
             element.addEventListener("click", function () {
                 var state = this.checked;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Contents-BulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Contents-BulkActions.cshtml
@@ -13,7 +13,15 @@
 }
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll(".dropdown-menu .dropdown-item").forEach(function (item) {
             if (!item.dataset.action) {
                 return;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.cshtml
@@ -52,7 +52,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         const submitFilterButton = document.querySelector("[name='submit.Filter']");
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Download/Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Download/Display.cshtml
@@ -40,7 +40,15 @@
 </form>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.ContentItemJson)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/FullTextAspectSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/FullTextAspectSettings.Edit.cshtml
@@ -62,7 +62,15 @@
     </div>
 </div>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.FullTextTemplate)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ActionDeploymentPlan.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ActionDeploymentPlan.Modal.cshtml
@@ -44,7 +44,15 @@
     </zone>
 
     <script at="Foot">
-        document.addEventListener('DOMContentLoaded', function () {
+        function onDocumentReady(callback) {
+            if (document.readyState !== 'loading') {
+                callback();
+            } else {
+                document.addEventListener('DOMContentLoaded', callback);
+            }
+        }
+
+        onDocumentReady(function () {
             var modal = document.getElementById('modalAddToDeploymentPlanActionDeploymentPlan');
             modal?.addEventListener('show.bs.modal', function (event) {
                 var button = event.relatedTarget;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-Button-ContentsBulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-Button-ContentsBulkActions.cshtml
@@ -1,6 +1,14 @@
 <a id="addToDeploymentPlanBulkActions" class="dropdown-item" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to add these items to a deployment plan?"]">@T["Add to deployment plan"]</a>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.getElementById('addToDeploymentPlanBulkActions')?.addEventListener('click', function () {
             if (document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked").length > 1) {
                 var data = { ...this.dataset };

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ContentsBulkActionsDeploymentPlan.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/AddToDeploymentPlan-ContentsBulkActionsDeploymentPlan.Modal.cshtml
@@ -39,7 +39,15 @@
 </zone>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.getElementById('modalAddToDeploymentPlanContentsBulkActionsDeploymentPlan')?.addEventListener('show.bs.modal', function () {
             var itemIds = document.querySelectorAll("input[type='checkbox'][name='itemIds']:checked");
             if (itemIds.length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesAdminNode.Fields.TreeEdit.cshtml
@@ -137,7 +137,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         switchContentTypesCheckBoxes();
 
         document.getElementById('ContentTypesAdminNode_ShowAll')?.addEventListener('change', function () {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.Edit.cshtml
@@ -215,7 +215,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         function showElement(element) {
             if (element) {
                 element.style.display = 'block';

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/CreateContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/CreateContentTask.Fields.Edit.cshtml
@@ -39,7 +39,15 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-document.addEventListener('DOMContentLoaded', function () {
+function onDocumentReady(callback) {
+    if (document.readyState !== 'loading') {
+        callback();
+    } else {
+        document.addEventListener('DOMContentLoaded', callback);
+    }
+}
+
+onDocumentReady(function () {
     var editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.ContentProperties)'), {
         autoRefresh: true,
         lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/Download-Button-Actions.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/Download-Button-Actions.SummaryAdmin.cshtml
@@ -30,7 +30,15 @@ else
 }
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         function toggleDropdown(element) {
             var dropdownMenu = element.closest(".dropdown-menu");
             var dropdownToggle = dropdownMenu?.previousElementSibling;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ActionDeploymentTarget.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ActionDeploymentTarget.Modal.cshtml
@@ -43,7 +43,15 @@
     </zone>
 
     <script at="Foot">
-        document.addEventListener('DOMContentLoaded', function () {
+        function onDocumentReady(callback) {
+            if (document.readyState !== 'loading') {
+                callback();
+            } else {
+                document.addEventListener('DOMContentLoaded', callback);
+            }
+        }
+
+        onDocumentReady(function () {
             var modal = document.getElementById('modalExportContentToDeploymentTargetActionTarget');
             modal?.addEventListener('show.bs.modal', function (event) {
                 var button = event.relatedTarget;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-Button-ContentsBulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-Button-ContentsBulkActions.cshtml
@@ -1,7 +1,15 @@
 <a id="exportContentToDeploymentTargetBulkActions" class="dropdown-item" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to export these items?"]">@T["Export to deployment target"]</a>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var exportButton = document.getElementById('exportContentToDeploymentTargetBulkActions');
 
         if (!exportButton) {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ContentsBulkActionsDeploymentTarget.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ExportContentToDeploymentTarget-ContentsBulkActionsDeploymentTarget.Modal.cshtml
@@ -40,7 +40,15 @@
 </zone>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var modalElement = document.getElementById('modalExportContentToDeploymentTargetContentBulkActionsTarget');
 
         if (!modalElement) {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UpdateContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UpdateContentTask.Fields.Edit.cshtml
@@ -39,7 +39,15 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-document.addEventListener('DOMContentLoaded', function () {
+function onDocumentReady(callback) {
+    if (document.readyState !== 'loading') {
+        callback();
+    } else {
+        document.addEventListener('DOMContentLoaded', callback);
+    }
+}
+
+onDocumentReady(function () {
     var editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.ContentProperties)'), {
         autoRefresh: true,
         lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/Views/Items/CustomSettingsDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/Views/Items/CustomSettingsDeploymentStep.Fields.Edit.cshtml
@@ -48,7 +48,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll("[data-reversetoggle]").forEach(function (toggle) {
             toggle.addEventListener("click", function () {
                 var state = this.checked;

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
@@ -94,7 +94,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
@@ -88,7 +88,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
@@ -159,7 +159,15 @@
         });
     }
 
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var modalSteps = document.getElementById('modalSteps');
         var searchBox = document.getElementById('search-box');
         var deploymentStepCategories = document.getElementById('deployment-step-categories');

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
@@ -86,7 +86,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Json.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Json.cshtml
@@ -23,7 +23,15 @@
 </form>
 
 <script at="Foot">
-document.addEventListener('DOMContentLoaded', function () {
+function onDocumentReady(callback) {
+    if (document.readyState !== 'loading') {
+        callback();
+    } else {
+        document.addEventListener('DOMContentLoaded', callback);
+    }
+}
+
+onDocumentReady(function () {
     var textArea = document.getElementById('@Html.IdFor(x => x.Json)');
 
     var editor = CodeMirror.fromTextArea(textArea, {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/DeploymentPlanDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/DeploymentPlanDeploymentStep.Fields.Edit.cshtml
@@ -48,7 +48,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll("[data-reversetoggle]").forEach(function (toggle) {
             toggle.addEventListener("click", function () {
                 var state = this.checked;

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
@@ -19,7 +19,15 @@
 </div>
 
 <script at="Foot" asp-name="jsonrecipe-editor" depends-on="monaco, admin">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/Admin/IndexInfo.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/Admin/IndexInfo.cshtml
@@ -18,7 +18,15 @@
 </div>
 
 <script at="Foot" asp-name="jsonrecipe-editor" depends-on="monaco, admin">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/ElasticQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Views/ElasticQuery.Edit.cshtml
@@ -33,7 +33,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
@@ -102,7 +102,15 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.HtmlBody)'), {
             lineNumbers: true,
             styleActiveLine: true,

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPart.Edit.cshtml
@@ -17,7 +17,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var textArea = document.getElementById('@Html.IdFor(x => x.Liquid)');
 
         if (textArea == null) {

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPluginPartSettings.Edit.cshtml
@@ -18,7 +18,15 @@
 </div>
 
 <script at="Foot">
-document.addEventListener('DOMContentLoaded', function () {
+function onDocumentReady(callback) {
+    if (document.readyState !== 'loading') {
+        callback();
+    } else {
+        document.addEventListener('DOMContentLoaded', callback);
+    }
+}
+
+onDocumentReady(function () {
     var textArea = document.getElementById('@Html.IdFor(x => x.Liquid)');
 
     if (textArea == null) {

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
@@ -25,7 +25,15 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
         @* When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
             if (optionsTextArea) {

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartTrumbowygSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartTrumbowygSettings.Edit.cshtml
@@ -23,7 +23,15 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Views/LiquidPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Views/LiquidPart.Edit.cshtml
@@ -22,7 +22,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var textArea = document.getElementById('@Html.IdFor(x => x.Liquid)');
 
         if (textArea == null) {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/Items/ListsAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/Items/ListsAdminNode.Fields.TreeEdit.cshtml
@@ -116,7 +116,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll('.add-parent-link-checkbox').forEach(function (checkbox) {
             checkbox.addEventListener('click', function (e) {
                 var fieldSet = e.currentTarget.closest('.add-parent-link-fieldset');

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Query.cshtml
@@ -98,7 +98,15 @@
     </div>
 }
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.Parameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/LuceneQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/LuceneQuery.Edit.cshtml
@@ -33,7 +33,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
@@ -25,7 +25,15 @@
 </div>
 
 <script at="Foot" depends-on="easymde-mediatoolbar">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var markdownElement = document.getElementById('@Html.IdFor(m => m.Markdown)');
         var isRtl = '@(culture.IsRightToLeft() ? "true" : "false")';
 

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPartWysiwygEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPartWysiwygEditorSettings.Edit.cshtml
@@ -15,7 +15,15 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownFieldWysiwygEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownFieldWysiwygEditorSettings.Edit.cshtml
@@ -15,7 +15,15 @@
 <script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Options)');
         var editor = CodeMirror.fromTextArea(optionsTextArea, {
             autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
@@ -7,7 +7,15 @@
 
 <script at="Foot">
     @* mediaApp is absolutely positioned. When a warning is shown we need to move it down to avoid overlapping. *@
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var messages = document.querySelectorAll('.message');
         if (!messages.length) { return; };
         var mediaAppInitialTop = 0;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Items/MediaDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Items/MediaDeploymentStep.Fields.Edit.cshtml
@@ -59,7 +59,15 @@
         });
     }
 
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         document.querySelectorAll("[data-reverseToggle]").forEach(function (element) {
             element.addEventListener("click", function () {
                 var state = this.checked;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Create.cshtml
@@ -125,7 +125,15 @@
 </form>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var selectedMode = document.getElementById('@Html.IdFor(x => x.SelectedMode)');
         var backgroundColor = document.getElementById('@Html.IdFor(x => x.BackgroundColor)');
         var selectedWidth = document.getElementById('@Html.IdFor(x => x.SelectedWidth)');

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Edit.cshtml
@@ -110,7 +110,15 @@
 </form>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var selectedMode = document.getElementById('@Html.IdFor(x => x.SelectedMode)');
         var backgroundColor = document.getElementById('@Html.IdFor(x => x.BackgroundColor)');
         var selectedWidth = document.getElementById('@Html.IdFor(x => x.SelectedWidth)');

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
@@ -91,7 +91,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminList.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminList.cshtml
@@ -69,7 +69,15 @@
 
 <script asp-name="bootstrap-select" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         const submitFilterButton = document.querySelector("[name='submit.Filter']");
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
@@ -242,7 +242,15 @@
 <script at="Foot" asp-name="credential-helpers"></script>
 <script at="Foot" depends-on="credential-helpers">
 
-    document.addEventListener('DOMContentLoaded', () => {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(() => {
 
         const clientIdElement = document.getElementById('@Html.IdFor(m => m.ClientId)');
         const clientSecretElement = document.getElementById('@Html.IdFor(m => m.ClientSecret)');

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
@@ -262,7 +262,15 @@
 <script at="Foot" asp-name="credential-helpers"></script>
 <script at="Foot" depends-on="credential-helpers">
 
-    document.addEventListener('DOMContentLoaded', () => {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(() => {
 
         const clientIdElement = document.getElementById('@Html.IdFor(m => m.ClientId)');
         const clientSecretElement = document.getElementById('@Html.IdFor(m => m.ClientSecret)');

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
@@ -57,7 +57,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var authority = document.getElementById('@Html.IdFor(model => model.Authority)');
         var audience = document.getElementById('@Html.IdFor(model => model.Audience)');
         var tenant = document.getElementById('@Html.IdFor(model => model.Tenant)');

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Edit.cshtml
@@ -57,7 +57,15 @@
 </form>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Nodes)');
         if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
@@ -87,7 +87,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
@@ -113,7 +113,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Query.cshtml
@@ -104,7 +104,15 @@
 }
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.DecodedQuery)'), { mode: '@MediaTypeNamesExtended.Text.PostgreSQL', lineNumbers: true, viewportMargin: Infinity });
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.Parameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
         var rawSql = document.getElementById('@Html.IdFor(m => m.RawSql)');
@@ -115,7 +123,7 @@
 </script>
 <script asp-name="monaco" at="Foot"></script>
 <script at="Foot" asp-name="jsonrecipe-editor" depends-on="monaco, admin">
-    document.addEventListener('DOMContentLoaded', function () {
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
 
             const html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Items/QueryBasedContentDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Items/QueryBasedContentDeploymentStep.Fields.Edit.cshtml
@@ -55,7 +55,15 @@
  </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(m => m.QueryParameters)'), { mode: "javascript", json: true, lineNumbers: true, viewportMargin: Infinity });
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Query.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Query.Fields.Edit.cshtml
@@ -21,7 +21,15 @@
 <script asp-name="monaco" at="Foot"></script>
 
 <script at="Foot" depends-on="monaco">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
 
             const html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/SqlQuery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/SqlQuery.Edit.cshtml
@@ -48,7 +48,15 @@
 </div>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Query)'), {
             mode: '@MediaTypeNamesExtended.Text.PostgreSQL',
             indentWithTabs: true, smartIndent: true, matchBrackets: true, lineNumbers: true, styleActiveLine: true, viewportMargin: Infinity,

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Views/Admin/Index.cshtml
@@ -80,7 +80,15 @@
     }
 </form>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var searchBox = document.getElementById('search-box');
         if (!searchBox) {
             return;

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
@@ -137,7 +137,15 @@
 </form>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var searchBox = document.getElementById('search-box');
         if (!searchBox) {
             return;

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Index.cshtml
@@ -69,7 +69,15 @@
 </form>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var searchBox = document.getElementById('search-box');
         if (!searchBox) {
             return;

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/ConditionsModal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/ConditionsModal.cshtml
@@ -33,7 +33,15 @@
 </div>
 
 <script At="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var modalConditions = document.getElementById('modalConditions');
         if (modalConditions) {
             modalConditions.addEventListener('show.bs.modal', function (event) {

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/JavascriptCondition.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/JavascriptCondition.Fields.Edit.cshtml
@@ -23,7 +23,15 @@
 
 <script at="Foot">
     //<![CDATA[
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Script)'), {
             autoRefresh: true,
             lineNumbers: true,

--- a/src/OrchardCore.Modules/OrchardCore.Seo/Views/SeoMetaPartGoogleSchema.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Views/SeoMetaPartGoogleSchema.Edit.cshtml
@@ -14,7 +14,15 @@
 <script asp-name="codemirror-addon-selection-active-line" at="Foot"></script>
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.GoogleSchema)');
         // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
@@ -92,7 +92,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
@@ -106,7 +106,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapCache/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapCache/List.cshtml
@@ -50,7 +50,15 @@
 </form>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var searchBox = document.getElementById('search-box');
 
         // On each keypress filter the list of cache entries

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
@@ -109,7 +109,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -39,7 +39,15 @@
     var previewRenderData;
     var initialized;
 
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         window.addEventListener('storage', function (ev) {
             if (ev.key == 'OrchardCore.templates:not-connected') {
                 notConnectedWarning.style.display = 'block';

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
@@ -63,7 +63,15 @@
 </form>
 
 <script asp-name="create-template" at="Foot" depends-on="liquid-intellisense monaco">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
             var settings = {
                 automaticLayout: true,
@@ -105,7 +113,7 @@
 
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    onDocumentReady(function () {
 
         function initializeTemplatePreview(element) {
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
@@ -72,7 +72,15 @@ else
 
 
 <script asp-name="edit-template" at="Foot" depends-on="liquid-intellisense monaco">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
             var settings = {
                 automaticLayout: true,
@@ -152,7 +160,7 @@ else
 </script>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    onDocumentReady(function () {
 
         function initializeTemplatePreview(element) {
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
@@ -100,7 +100,15 @@ else
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Create.cshtml
@@ -9,7 +9,15 @@
 </form>
 
 <script at="Foot" asp-name="profile-editor" depends-on="monaco, admin">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Edit.cshtml
@@ -9,7 +9,15 @@
 </form>
 
 <script at="Foot" asp-name="profile-editor" depends-on="monaco, admin">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
 
             var html = document.documentElement;

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
@@ -90,7 +90,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var actions = document.getElementById("actions");
         var items = document.getElementById("items");
         var filters = document.querySelectorAll(".filter");

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/CreateTenantTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/CreateTenantTask.Fields.Edit.cshtml
@@ -96,7 +96,15 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var editorRupTn = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.TenantNameExpression)'), {
             lineNumbers: true,
             styleActiveLine: true,

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/SetupTenantTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Items/SetupTenantTask.Fields.Edit.cshtml
@@ -93,7 +93,15 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var editorTn = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.TenantNameExpression)'), {
             lineNumbers: true,
             styleActiveLine: true,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/ExternalLoginSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/ExternalLoginSettings.Edit.cshtml
@@ -109,7 +109,15 @@ type Context = {
     }]
 }`
     var codeEditor;
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         require(['vs/editor/editor.main'], function () {
 
             const html = document.documentElement;
@@ -179,7 +187,7 @@ type Context = {
         }
     }
 
-    document.addEventListener('DOMContentLoaded', function () {
+    onDocumentReady(function () {
         var syncRolesCheckbox = document.getElementById('@Html.IdFor(x => x.UseScriptToSyncProperties)');
 
         if (syncRolesCheckbox) {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminList.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminList.cshtml
@@ -58,7 +58,15 @@
 @await DisplayAsync(Model.Pager)
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         const submitFilterButton = document.querySelector("[name='submit.Filter']");
 
         var actions = document.getElementById("actions");

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpRequestTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpRequestTask.Fields.Edit.cshtml
@@ -78,7 +78,15 @@
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
-    document.addEventListener('DOMContentLoaded', function () {
+    function onDocumentReady(callback) {
+        if (document.readyState !== 'loading') {
+            callback();
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    onDocumentReady(function () {
         var codeMirrorOptions = {
             autoRefresh: true,
             lineNumbers: true,


### PR DESCRIPTION
## Why

PR #19421 migrated inline view scripts from jQuery to vanilla JavaScript and replaced `$(function () { ... })` initializers with `document.addEventListener('DOMContentLoaded', ...)`. As reported in https://github.com/OrchardCMS/OrchardCore/pull/19421#issuecomment-4765929395, this regressed the Flows and Bag editors.

jQuery's `ready()` runs its callback immediately when the DOM is already ready. Orchard injects editors on the fly (a widget added to a Flow/Bag, content definition part and field settings, workflow and deployment activity editors) by evaluating their scripts via `$.globalEval` after the page has loaded. A bare `DOMContentLoaded` listener never fires for a script evaluated after the event, so those dynamically injected editors stopped initializing. This is the same class of problem as #11464.

## What changed

Each migrated initializer is now wrapped in a small `onDocumentReady` helper (the approach suggested by @gvkries in the thread):

```javascript
function onDocumentReady(callback) {
    if (document.readyState !== 'loading') {
        callback();
    } else {
        document.addEventListener('DOMContentLoaded', callback);
    }
}
```

When the script runs after the document is ready (the dynamic injection case) the callback executes immediately; otherwise it defers to `DOMContentLoaded`. This restores the original jQuery `ready()` semantics. The helper is defined inline per view so it works in any rendering context, matching the pattern already used by the Monaco editor views in #19421. 89 views are updated.

## Verification

Built and ran the CMS, added a `FlowPart` to a type, configured a widget field to use the CodeMirror editor, then added that widget to a Flow on the content edit page. Before the fix the editor stayed an inert textarea; after the fix the CodeMirror instance initializes when the widget is injected, with no console errors. Confirmed the `BuildEditor` response for the widget now contains the `onDocumentReady` wrapper.
