### PR TITLE
Update YesSql to 6.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,11 +65,11 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
-    <PackageVersion Include="YesSql" Version="5.4.7" />
-    <PackageVersion Include="YesSql.Abstractions" Version="5.4.7" />
-    <PackageVersion Include="YesSql.Core" Version="5.4.7" />
-    <PackageVersion Include="YesSql.Filters.Abstractions" Version="5.4.7" />
-    <PackageVersion Include="YesSql.Filters.Query" Version="5.4.7" />
+    <PackageVersion Include="YesSql" Version="6.0.0" />
+    <PackageVersion Include="YesSql.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="YesSql.Core" Version="6.0.0" />
+    <PackageVersion Include="YesSql.Filters.Abstractions" Version="6.0.0" />
+    <PackageVersion Include="YesSql.Filters.Query" Version="6.0.0" />
     <PackageVersion Include="ZString" Version="2.6.0" />
   </ItemGroup>
   <ItemGroup>
@@ -119,7 +119,5 @@
   <ItemGroup>
     <!-- Transitive Packages -->
     <PackageVersion Include="MessagePack" Version="3.1.7" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/AuditTrailManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/AuditTrailManager.cs
@@ -103,7 +103,7 @@ public class AuditTrailManager : IAuditTrailManager
 
         await _auditTrailEventHandlers.InvokeAsync((handler, context, auditTrailEvent) => handler.AlterAsync(context, auditTrailEvent), createContext, auditTrailEvent, _logger);
 
-        await _session.SaveAsync(auditTrailEvent, AuditTrailEvent.Collection);
+        await _session.SaveAsync(auditTrailEvent, collection: AuditTrailEvent.Collection);
     }
     public Task<AuditTrailEvent> GetEventAsync(string eventId) =>
         _session.Query<AuditTrailEvent, AuditTrailEventIndex>(collection: AuditTrailEvent.Collection)

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/CorrelationIdFilterNode.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/CorrelationIdFilterNode.cs
@@ -1,4 +1,4 @@
-using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Nodes;
 
 namespace OrchardCore.AuditTrail.Services;
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/DefaultContentLocalizationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/DefaultContentLocalizationManager.cs
@@ -52,15 +52,15 @@ public class DefaultContentLocalizationManager : IContentLocalizationManager
                 .FirstOrDefaultAsync();
     }
 
-    public Task<IEnumerable<ContentItem>> GetItemsForSetAsync(string localizationSet)
+    public async Task<IEnumerable<ContentItem>> GetItemsForSetAsync(string localizationSet)
     {
-        return _session.Query<ContentItem, LocalizedContentItemIndex>(i => (i.Published || i.Latest) && i.LocalizationSet == localizationSet).ListAsync();
+        return await _session.Query<ContentItem, LocalizedContentItemIndex>(i => (i.Published || i.Latest) && i.LocalizationSet == localizationSet).ListAsync();
     }
 
-    public Task<IEnumerable<ContentItem>> GetItemsForSetsAsync(IEnumerable<string> localizationSets, string culture)
+    public async Task<IEnumerable<ContentItem>> GetItemsForSetsAsync(IEnumerable<string> localizationSets, string culture)
     {
         var invariantCulture = culture.ToLowerInvariant();
-        return _session.Query<ContentItem, LocalizedContentItemIndex>(i => (i.Published || i.Latest) && i.LocalizationSet.IsIn(localizationSets) && i.Culture == invariantCulture).ListAsync();
+        return await _session.Query<ContentItem, LocalizedContentItemIndex>(i => (i.Published || i.Latest) && i.LocalizationSet.IsIn(localizationSets) && i.Culture == invariantCulture).ListAsync();
     }
 
     public async Task<ContentItem> LocalizeAsync(ContentItem content, string targetCulture)

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Services/LocalizationEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Services/LocalizationEntries.cs
@@ -164,7 +164,7 @@ public class LocalizationEntries : ILocalizationEntries
                 RemoveEntries(entriesToRemove);
                 AddEntries(entriesToAdd);
 
-                _lastIndexId = indexes.LastOrDefault()?.Id ?? 0;
+                _lastIndexId = indexes.Count > 0 ? indexes[indexes.Count - 1].Id : 0;
                 _stateIdentifier = state.Identifier;
             }
         }
@@ -203,7 +203,7 @@ public class LocalizationEntries : ILocalizationEntries
 
                 AddEntries(entries);
 
-                _lastIndexId = indexes.LastOrDefault()?.Id ?? 0;
+                _lastIndexId = indexes.Count > 0 ? indexes[indexes.Count - 1].Id : 0;
                 _stateIdentifier = state.Identifier;
 
                 _initialized = true;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/ContentTypeFilterNode.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/ContentTypeFilterNode.cs
@@ -1,4 +1,4 @@
-using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Nodes;
 
 namespace OrchardCore.Contents.Services;
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListQueryService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListQueryService.cs
@@ -5,7 +5,7 @@ using OrchardCore.Contents.ViewModels;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.Modules;
 using YesSql;
-using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Nodes;
 
 namespace OrchardCore.Contents.Services;
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/StereotypeFilterNode.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/StereotypeFilterNode.cs
@@ -1,4 +1,4 @@
-using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Nodes;
 
 namespace OrchardCore.Contents.Services;
 

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerService.cs
@@ -29,10 +29,10 @@ public class LayerService : ILayerService
     /// </summary>
     public Task<LayersDocument> GetLayersAsync() => _documentManager.GetOrCreateImmutableAsync();
 
-    public Task<IEnumerable<ContentItem>> GetLayerWidgetsAsync(
+    public async Task<IEnumerable<ContentItem>> GetLayerWidgetsAsync(
         Expression<Func<ContentItemIndex, bool>> predicate)
     {
-        return _session
+        return await _session
             .Query<ContentItem, LayerMetadataIndex>()
             .With(predicate)
             .ListAsync();

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Helpers/ListQueryHelpers.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Helpers/ListQueryHelpers.cs
@@ -16,9 +16,9 @@ internal static class ListQueryHelpers
                 .CountAsync();
     }
 
-    internal static Task<IEnumerable<ContentItem>> QueryListItemsAsync(ISession session, string listContentItemId, Expression<Func<ContentItemIndex, bool>> itemPredicate = null)
+    internal static async Task<IEnumerable<ContentItem>> QueryListItemsAsync(ISession session, string listContentItemId, Expression<Func<ContentItemIndex, bool>> itemPredicate = null)
     {
-        return session.Query<ContentItem>()
+        return await session.Query<ContentItem>()
                 .With<ContainedPartIndex>(x => x.ListContentItemId == listContentItemId)
                 .OrderBy(o => o.Order)
                 .ThenBy(o => o.Id)

--- a/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
@@ -229,7 +229,7 @@ public sealed class SearchController : Controller
 
         pager.After = null;
 
-        if (containedItems.Count() == pager.PageSize + 1)
+        if (containedItems.Count == pager.PageSize + 1)
         {
             pager.After = (size - 1).ToString();
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListQueryService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListQueryService.cs
@@ -5,7 +5,7 @@ using OrchardCore.Modules;
 using OrchardCore.Users.Models;
 using OrchardCore.Users.ViewModels;
 using YesSql;
-using YesSql.Filters.Abstractions.Nodes;
+using YesSql.Filters.Nodes;
 
 namespace OrchardCore.Users.Services;
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Services/WorkflowInstanceRouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Services/WorkflowInstanceRouteEntries.cs
@@ -29,7 +29,7 @@ internal sealed class WorkflowInstanceRouteEntries : WorkflowRouteEntries<Workfl
                 .Take(pageSize)
                 .ListAsync();
 
-            if (!pendingWorkflows.Any())
+            if (pendingWorkflows.Count == 0)
             {
                 break;
             }
@@ -41,7 +41,7 @@ internal sealed class WorkflowInstanceRouteEntries : WorkflowRouteEntries<Workfl
 
             AddEntries(document, workflowRouteEntries);
 
-            if (pendingWorkflows.Count() < pageSize)
+            if (pendingWorkflows.Count < pageSize)
             {
                 break;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowStore.cs
@@ -30,7 +30,7 @@ public class WorkflowStore : IWorkflowStore
         return (await _session.Query<Workflow, WorkflowBlockingActivitiesIndex>(x => x.WorkflowTypeId == workflowTypeId).FirstOrDefaultAsync()) != null;
     }
 
-    public Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId = null, int? skip = null, int? take = null)
+    public async Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId = null, int? skip = null, int? take = null)
     {
         var query = (IQuery<Workflow>)FilterByWorkflowTypeId(_session.Query<Workflow, WorkflowIndex>(), workflowTypeId)
             .OrderByDescending(x => x.CreatedUtc);
@@ -45,12 +45,12 @@ public class WorkflowStore : IWorkflowStore
             query = query.Take(take.Value);
         }
 
-        return query.ListAsync();
+        return await query.ListAsync();
     }
 
-    public Task<IEnumerable<Workflow>> ListAsync(IEnumerable<string> workflowTypeIds)
+    public async Task<IEnumerable<Workflow>> ListAsync(IEnumerable<string> workflowTypeIds)
     {
-        return _session.Query<Workflow, WorkflowIndex>(x => x.WorkflowTypeId.IsIn(workflowTypeIds)).ListAsync();
+        return await _session.Query<Workflow, WorkflowIndex>(x => x.WorkflowTypeId.IsIn(workflowTypeIds)).ListAsync();
     }
 
     public Task<Workflow> GetAsync(long id)
@@ -63,9 +63,9 @@ public class WorkflowStore : IWorkflowStore
         return _session.Query<Workflow, WorkflowBlockingActivitiesIndex>(x => x.WorkflowId == workflowId).FirstOrDefaultAsync();
     }
 
-    public Task<IEnumerable<Workflow>> GetAsync(IEnumerable<string> workflowIds)
+    public async Task<IEnumerable<Workflow>> GetAsync(IEnumerable<string> workflowIds)
     {
-        return _session.Query<Workflow, WorkflowBlockingActivitiesIndex>(x => x.WorkflowId.IsIn(workflowIds)).ListAsync();
+        return await _session.Query<Workflow, WorkflowBlockingActivitiesIndex>(x => x.WorkflowId.IsIn(workflowIds)).ListAsync();
     }
 
     public Task<IEnumerable<Workflow>> GetAsync(IEnumerable<long> ids)
@@ -73,16 +73,16 @@ public class WorkflowStore : IWorkflowStore
         return _session.GetAsync<Workflow>(ids.ToArray());
     }
 
-    public Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, IEnumerable<string> blockingActivityIds)
+    public async Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, IEnumerable<string> blockingActivityIds)
     {
-        return _session
+        return await _session
             .Query<Workflow, WorkflowBlockingActivitiesIndex>(index =>
                 index.WorkflowTypeId == workflowTypeId &&
                 index.ActivityId.IsIn(blockingActivityIds))
             .ListAsync();
     }
 
-    public Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, string activityName, string correlationId = null, bool isAlwaysCorrelated = false)
+    public async Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, string activityName, string correlationId = null, bool isAlwaysCorrelated = false)
     {
         var query = _session.Query<Workflow, WorkflowBlockingActivitiesIndex>();
 
@@ -95,10 +95,10 @@ public class WorkflowStore : IWorkflowStore
             query = query.Where(index => index.WorkflowTypeId == workflowTypeId && index.ActivityName == activityName && index.WorkflowCorrelationId == (correlationId ?? ""));
         }
 
-        return query.ListAsync();
+        return await query.ListAsync();
     }
 
-    public Task<IEnumerable<Workflow>> ListByActivityNameAsync(string activityName, string correlationId = null, bool isAlwaysCorrelated = false)
+    public async Task<IEnumerable<Workflow>> ListByActivityNameAsync(string activityName, string correlationId = null, bool isAlwaysCorrelated = false)
     {
         var query = _session.Query<Workflow, WorkflowBlockingActivitiesIndex>();
 
@@ -111,7 +111,7 @@ public class WorkflowStore : IWorkflowStore
             query = query.Where(index => index.ActivityName == activityName && index.WorkflowCorrelationId == (correlationId ?? ""));
         }
 
-        return query.ListAsync();
+        return await query.ListAsync();
     }
 
     public async Task SaveAsync(Workflow workflow)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowTypeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowTypeStore.cs
@@ -34,14 +34,14 @@ public class WorkflowTypeStore : IWorkflowTypeStore
         return _session.Query<WorkflowType, WorkflowTypeIndex>(x => x.WorkflowTypeId == workflowTypeId).FirstOrDefaultAsync();
     }
 
-    public Task<IEnumerable<WorkflowType>> ListAsync()
+    public async Task<IEnumerable<WorkflowType>> ListAsync()
     {
-        return _session.Query<WorkflowType, WorkflowTypeIndex>().ListAsync();
+        return await _session.Query<WorkflowType, WorkflowTypeIndex>().ListAsync();
     }
 
-    public Task<IEnumerable<WorkflowType>> GetByStartActivityAsync(string activityName)
+    public async Task<IEnumerable<WorkflowType>> GetByStartActivityAsync(string activityName)
     {
-        return _session
+        return await _session
             .Query<WorkflowType, WorkflowTypeStartActivitiesIndex>(index =>
                 index.StartActivityName == activityName &&
                 index.IsEnabled)

--- a/src/OrchardCore/OrchardCore.Autoroute.Core/Services/AutorouteEntries.cs
+++ b/src/OrchardCore/OrchardCore.Autoroute.Core/Services/AutorouteEntries.cs
@@ -187,7 +187,7 @@ public class AutorouteEntries : IAutorouteEntries
                 RemoveEntries(entriesToRemove);
                 AddEntries(entriesToAdd);
 
-                _lastIndexId = indexes.LastOrDefault()?.Id ?? 0;
+                _lastIndexId = indexes.Count > 0 ? indexes[indexes.Count - 1].Id : 0;
                 _stateIdentifier = state.Identifier;
             }
         }
@@ -223,7 +223,7 @@ public class AutorouteEntries : IAutorouteEntries
 
                 AddEntries(entries);
 
-                _lastIndexId = indexes.LastOrDefault()?.Id ?? 0;
+                _lastIndexId = indexes.Count > 0 ? indexes[indexes.Count - 1].Id : 0;
                 _stateIdentifier = state.Identifier;
 
                 _initialized = true;

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
@@ -113,7 +113,7 @@ public class ContentItemsFieldType : FieldType
         var contentItemsQuery = await FilterWhereArgumentsAsync(query, where, context, session);
         contentItemsQuery = PageQuery(contentItemsQuery, context);
 
-        var contentItems = await contentItemsQuery.ListAsync();
+        IEnumerable<ContentItem> contentItems = await contentItemsQuery.ListAsync();
 
         foreach (var filter in filters)
         {

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Removing/ShellDbTablesInfo.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Removing/ShellDbTablesInfo.cs
@@ -113,14 +113,8 @@ internal sealed class ShellDbTablesInfo : ISchemaBuilder
         return Task.CompletedTask;
     }
 
-    public ISchemaBuilder AlterIndexTable(Type indexType, Action<IAlterTableCommand> table, string collection)
-        => this;
-
     public Task AlterIndexTableAsync(Type indexType, Action<IAlterTableCommand> table, string collection)
         => Task.CompletedTask;
-
-    public ISchemaBuilder AlterTable(string name, Action<IAlterTableCommand> table)
-        => this;
 
     public Task AlterTableAsync(string name, Action<IAlterTableCommand> table)
         => Task.CompletedTask;
@@ -256,9 +250,6 @@ internal sealed class ShellDbTablesInfo : ISchemaBuilder
         }
     }
 
-    public ISchemaBuilder CreateForeignKey(string name, string srcTable, string[] srcColumns, string destTable, string[] destColumns)
-        => this;
-
     public Task CreateForeignKeyAsync(string name, string srcTable, string[] srcColumns, string destTable, string[] destColumns)
         => Task.CompletedTask;
 
@@ -288,9 +279,6 @@ internal sealed class ShellDbTablesInfo : ISchemaBuilder
 
         return Task.CompletedTask;
     }
-
-    public ISchemaBuilder CreateSchema(string schema)
-        => this;
 
     public Task CreateSchemaAsync(string schema)
         => Task.CompletedTask;

--- a/src/OrchardCore/OrchardCore.Users.Core/Razor/UserRazorHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Razor/UserRazorHelperExtensions.cs
@@ -27,9 +27,9 @@ public static class UserRazorHelperExtensions
     /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="userIds">The user ids to load.</param>
     /// <returns>A list of users with the specific ids.</returns>
-    public static Task<IEnumerable<User>> GetUsersByIdsAsync(this IOrchardHelper orchardHelper, IEnumerable<string> userIds)
+    public static async Task<IEnumerable<User>> GetUsersByIdsAsync(this IOrchardHelper orchardHelper, IEnumerable<string> userIds)
     {
         var session = orchardHelper.HttpContext.RequestServices.GetService<ISession>();
-        return session.Query<User, UserIndex>(x => x.UserId.IsIn(userIds)).ListAsync();
+        return await session.Query<User, UserIndex>(x => x.UserId.IsIn(userIds)).ListAsync();
     }
 }

--- a/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
@@ -71,7 +71,7 @@ public class BlogPostApiControllerTests
             var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
                 x.ContentType == "BlogPost").ListAsync();
 
-            Assert.Equal(2, blogPosts.Count());
+            Assert.Equal(2, blogPosts.Count);
         });
     }
 

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
@@ -33,7 +33,7 @@ public class BlogPostContentStepIdempotentTests
                 var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
                     x.ContentType == "BlogPost").ListAsync();
 
-                Assert.Equal(2, blogPosts.Count());
+                Assert.Equal(2, blogPosts.Count);
 
                 var originalVersion = blogPosts.FirstOrDefault(x => x.ContentItemVersionId == context.OriginalBlogPostVersionId);
                 Assert.False(originalVersion?.Latest);

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
@@ -33,7 +33,7 @@ public class BlogPostCreateDeploymentPlanTests
             var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
                 x.ContentType == "BlogPost").ListAsync();
 
-            Assert.Equal(2, blogPosts.Count());
+            Assert.Equal(2, blogPosts.Count);
 
             var originalVersion = blogPosts.FirstOrDefault(x => x.ContentItemVersionId == context.OriginalBlogPostVersionId);
             Assert.False(originalVersion?.Latest);
@@ -73,7 +73,7 @@ public class BlogPostCreateDeploymentPlanTests
             var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
                 x.ContentType == "BlogPost").ListAsync();
 
-            Assert.Equal(3, blogPosts.Count());
+            Assert.Equal(3, blogPosts.Count);
             var originalVersion = blogPosts.FirstOrDefault(x => x.ContentItemVersionId == context.OriginalBlogPostVersionId);
             Assert.False(originalVersion?.Latest);
             Assert.False(originalVersion?.Published);
@@ -117,7 +117,7 @@ public class BlogPostCreateDeploymentPlanTests
             var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
                 x.ContentType == "BlogPost").ListAsync();
 
-            Assert.Equal(3, blogPosts.Count());
+            Assert.Equal(3, blogPosts.Count);
 
             var originalVersion = blogPosts.FirstOrDefault(x => x.ContentItemVersionId == context.OriginalBlogPostVersionId);
             Assert.False(originalVersion?.Latest);

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
@@ -62,7 +62,7 @@ public class BlogPostUpdateDeploymentPlanTests
             var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
                 x.ContentType == "BlogPost").ListAsync();
 
-            Assert.Equal(2, blogPosts.Count());
+            Assert.Equal(2, blogPosts.Count);
 
             var mutatedVersion = blogPosts.FirstOrDefault(x => x.ContentItemVersionId == context.OriginalBlogPostVersionId);
             Assert.True(mutatedVersion?.Latest);
@@ -102,7 +102,7 @@ public class BlogPostUpdateDeploymentPlanTests
             var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
                 x.ContentType == "BlogPost").ListAsync();
 
-            Assert.Equal(2, blogPosts.Count());
+            Assert.Equal(2, blogPosts.Count);
 
             var originalVersion = blogPosts.FirstOrDefault(x => x.ContentItemVersionId == context.OriginalBlogPostVersionId);
             Assert.False(originalVersion?.Latest);

--- a/test/OrchardCore.Tests/Data/Migration/DataMigrationManagerTests.cs
+++ b/test/OrchardCore.Tests/Data/Migration/DataMigrationManagerTests.cs
@@ -281,21 +281,13 @@ public class DataMigrationManagerTests
         public Task<int> CountAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<int> CountAsync()
-            => throw new NotImplementedException();
-
         public Task<T> FirstOrDefaultAsync(CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
-
-        public Task<T> FirstOrDefaultAsync() => Task.FromResult((T)null);
+            => Task.FromResult((T)null);
 
         public string GetTypeAlias(Type t)
             => throw new NotImplementedException();
 
-        public Task<IEnumerable<T>> ListAsync(CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
-
-        public Task<IEnumerable<T>> ListAsync()
+        public Task<IReadOnlyList<T>> ListAsync(CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
         public IQuery<T> NoDuplicates()
@@ -308,9 +300,6 @@ public class DataMigrationManagerTests
             => throw new NotImplementedException();
 
         public IAsyncEnumerable<T> ToAsyncEnumerable(CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
-
-        public IAsyncEnumerable<T> ToAsyncEnumerable()
             => throw new NotImplementedException();
 
         public IQuery<T> With(Type indexType)

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
@@ -76,7 +76,7 @@ public class OpenIdAuthenticationTests
 
             Assert.Single(applications);
 
-            var application = applications.First();
+            var application = applications[0];
             Assert.True(application.ClientId == clientId);
             Assert.Contains(redirectUri, application.RedirectUris);
             Assert.Equal("implicit", application.ConsentType);
@@ -234,7 +234,7 @@ public class OpenIdAuthenticationTests
 
             Assert.Single(applications);
 
-            var application = applications.First();
+            var application = applications[0];
             Assert.True(application.ClientId == clientId);
             Assert.Contains(redirectUri, application.RedirectUris);
             Assert.Equal("implicit", application.ConsentType);


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

Updates YesSql from 5.4.7 to 6.0.0 to pick up the latest provider and API improvements. The major version brought a few breaking API changes, so this also adapts the affected source.

## Package changes

- Bump all YesSql packages (`YesSql`, `YesSql.Abstractions`, `YesSql.Core`, `YesSql.Filters.Abstractions`, `YesSql.Filters.Query`) from 5.4.7 to 6.0.0.
- Remove the now-redundant transitive pins on `Microsoft.Data.Sqlite` and `SQLitePCLRaw.lib.e_sqlite3`. YesSql 6's Sqlite provider depends on `Microsoft.Data.Sqlite.Core` and `SQLitePCLRaw.bundle_e_sqlite3` instead, so the old pins no longer apply (transitive pinning is enabled centrally).

## Breaking changes adapted

- `IQuery<T>.ListAsync()` now returns `Task<IReadOnlyList<T>>` instead of `Task<IEnumerable<T>>`. Because `Task<T>` is invariant, methods that returned the query result directly no longer compile. They are updated to `await` and return (or to type the local as `IEnumerable<T>`) so public signatures are preserved.
- The `YesSql.Filters.Abstractions.*` namespaces were flattened to `YesSql.Filters.*`. Updated the affected `using` directives (package IDs are unchanged).
- `ISession.SaveAsync` inserted a `bool checkConcurrency` parameter before `collection`. The one positional call site now uses a named `collection:` argument.
- Removed parameterless `IQuery<T>` overloads (`ListAsync()`, `FirstOrDefaultAsync()`, etc.); updated the `FakeQuery<T>` test mock accordingly.

## Testing

- Full solution builds clean (only pre-existing analyzer warnings remain).
- `DataMigrationManagerTests` pass (5/5).
- The 5 `ShapeFactoryTests` failures observed locally are pre-existing: they fail identically on the base commit with these changes stashed, and relate to source-generated shapes / Castle DynamicProxy, unrelated to YesSql.