### PR TITLE
Bump global.json SDK to 10.0.200 for Roslyn 5.3 source generator

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "comment": "We only update the version manually with major SDK updates to keep using any more recent SDK version possible. See https://github.com/OrchardCMS/OrchardCore/pull/17808.",
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.200",
     "rollForward": "latestMajor"
   },
   "test": {


### PR DESCRIPTION
## Why

After #19087 merged, `OrchardCore.Tests.DisplayManagement.ShapeFactoryTests` started failing locally on 5 of its 14 tests. The strongly typed `CreateAsync<TModel>` / display-driver `Initialize<TModel>` shapes were coming back as Castle proxies (`DynamicProxyGenAssembly2`) instead of the expected source-generated `IShape` wrapper types.

## Root cause

The new `ShapeFactoryGenerator` references `Microsoft.CodeAnalysis.CSharp` 5.3.0, so the generator is compiled against Roslyn 5.3. But `global.json` still pinned the `10.0.1xx` SDK band, whose in-box compiler is Roslyn 5.0. The compiler refuses to load an analyzer built against a newer Roslyn and emits `warning CS9057`, silently disabling the generator. With no generated wrappers/interceptors emitted, `ShapeFactoryExtensions` falls back to the Castle proxy path, and the tests asserting the generated path fail.

## Fix

Pin the minimum SDK to `10.0.200`. The SDK-to-Roslyn mapping for .NET 10 is:

| SDK band | In-box Roslyn |
|---|---|
| 10.0.1xx | 5.0 |
| **10.0.2xx** | **5.3** |
| 10.0.3xx | 5.6 |
| 10.0.4xx | 5.9 |

`10.0.2xx` is the first band shipping Roslyn 5.3, which matches the pinned analyzer package. `rollForward: latestMajor` is kept, so newer SDKs continue to work.

## Verification

With SDK 10.0.301 installed, the test project rebuilds with `0 warnings` (the `CS9057` generator-disabled warning is gone) and all 14 `ShapeFactoryTests` pass.