### PR TITLE
Simplify IAuditTraillIdGenerator, ISetupUserIdGenerator and ISitemapIdGenerator

### DIFF
--- a/src/OrchardCore/OrchardCore.AuditTrail.Abstractions/Services/IAuditTrailIdGenerator.cs
+++ b/src/OrchardCore/OrchardCore.AuditTrail.Abstractions/Services/IAuditTrailIdGenerator.cs
@@ -1,6 +1,5 @@
+using OrchardCore.Entities;
+
 namespace OrchardCore.AuditTrail.Services;
 
-public interface IAuditTrailIdGenerator
-{
-    string GenerateUniqueId();
-}
+public interface IAuditTrailIdGenerator : IIdGenerator;

--- a/src/OrchardCore/OrchardCore.Setup.Abstractions/OrchardCore.Setup.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Setup.Abstractions/OrchardCore.Setup.Abstractions.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj" />
+    <ProjectReference Include="..\OrchardCore.Infrastructure.Abstractions\OrchardCore.Infrastructure.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Setup.Abstractions/Services/ISetupUserIdGenerator.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Abstractions/Services/ISetupUserIdGenerator.cs
@@ -1,3 +1,5 @@
+using OrchardCore.Entities;
+
 namespace OrchardCore.Setup.Services;
 
 /// <summary>
@@ -6,13 +8,4 @@ namespace OrchardCore.Setup.Services;
 /// <remarks>Implementations may generate identifiers using different algorithms or formats. The generated
 /// identifier is intended to be unique within the context of the application or system. This interface is typically
 /// used during setup or initialization processes where a reliable, non-colliding identifier is required.</remarks>
-public interface ISetupUserIdGenerator
-{
-    /// <summary>
-    /// Generates a unique identifier string suitable for use as a key or token.
-    /// </summary>
-    /// <returns>A string containing a unique identifier. The format and length of the identifier may vary depending on the
-    /// implementation.
-    /// </returns>
-    string GenerateUniqueId();
-}
+public interface ISetupUserIdGenerator : IIdGenerator;

--- a/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/Services/ISitemapIdGenerator.cs
+++ b/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/Services/ISitemapIdGenerator.cs
@@ -1,6 +1,3 @@
 namespace OrchardCore.Sitemaps.Services;
 
-public interface ISitemapIdGenerator
-{
-    string GenerateUniqueId();
-}
+public interface ISitemapIdGenerator;

--- a/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/Services/ISitemapIdGenerator.cs
+++ b/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/Services/ISitemapIdGenerator.cs
@@ -1,3 +1,5 @@
+using OrchardCore.Entities;
+
 namespace OrchardCore.Sitemaps.Services;
 
-public interface ISitemapIdGenerator;
+public interface ISitemapIdGenerator : IIdGenerator;


### PR DESCRIPTION
While `IAuditTraillIdGenerator`, `ISetupUserIdGenerator` and `ISitemapIdGenerator` don't have special parameters in  `GenerateUniqueId()`, we could simplify by inheriting from `IIdentityGenerator`