### PR TITLE
Pre-register YesSql document types to fix KeyNotFoundException on early reads

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentTypes.Editors;
+using OrchardCore.Data;
 using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Modules;
@@ -7,6 +8,7 @@ using OrchardCore.Navigation;
 using OrchardCore.Recipes;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Templates.Deployment;
+using OrchardCore.Templates.Models;
 using OrchardCore.Templates.Recipes;
 using OrchardCore.Templates.Services;
 using OrchardCore.Templates.Settings;
@@ -18,6 +20,11 @@ public sealed class Startup : StartupBase
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
+
+        // 'TemplatesDocument' is stored in the shared document table and can be loaded by id during
+        // an early request (e.g. the login page), so its type is pre-registered with the store to
+        // avoid a 'KeyNotFoundException' when YesSql resolves the row's persisted type name.
+        services.AddDocumentType<TemplatesDocument>();
 
         services.AddScoped<IShapeBindingResolver, TemplatesShapeBindingResolver>();
         services.AddScoped<PreviewTemplatesProvider>();
@@ -43,6 +50,8 @@ public sealed class AdminTemplatesStartup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
+        services.AddDocumentType<AdminTemplatesDocument>();
+
         services.AddScoped<IShapeBindingResolver, AdminTemplatesShapeBindingResolver>();
         services.AddScoped<AdminPreviewTemplatesProvider>();
         services.AddNavigationProvider<AdminTemplatesAdminMenu>();

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/DocumentTypeOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/DocumentTypeOptions.cs
@@ -1,0 +1,21 @@
+namespace OrchardCore.Data;
+
+/// <summary>
+/// Holds the CLR types that must be pre-registered with the store when a tenant is created.
+/// </summary>
+/// <remarks>
+/// YesSql resolves the CLR type of a stored row from its persisted type name through a reverse
+/// lookup that is only populated lazily, the first time a given type is saved or queried by its
+/// exact type within a process. A by-id or polymorphic read (e.g. <c>GetAsync&lt;T&gt;(ids)</c>)
+/// has no type filter, so it can load a row whose type has not been touched yet and fail with a
+/// <see cref="KeyNotFoundException"/>. A module that stores such a type registers it here, for
+/// example with <c>services.AddDocumentType&lt;TemplatesDocument&gt;()</c>, so the reverse lookup
+/// always succeeds.
+/// </remarks>
+public class DocumentTypeOptions
+{
+    /// <summary>
+    /// Gets the CLR types to pre-register with the store.
+    /// </summary>
+    public HashSet<Type> Types { get; } = [];
+}

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/ServiceCollectionExtensions.cs
@@ -39,4 +39,32 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Pre-registers a document type with the store so that YesSql can resolve its persisted type
+    /// name during a by-id or polymorphic read, even before that type has first been saved or
+    /// queried in the current process. Call this from a module's <c>ConfigureServices</c> for every
+    /// type it stores but may load through a base type or by id.
+    /// </summary>
+    /// <typeparam name="TDocument">The document type to pre-register.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    public static IServiceCollection AddDocumentType<TDocument>(this IServiceCollection services)
+        => services.AddDocumentType(typeof(TDocument));
+
+    /// <summary>
+    /// Pre-registers a document type with the store so that YesSql can resolve its persisted type
+    /// name during a by-id or polymorphic read, even before that type has first been saved or
+    /// queried in the current process. Call this from a module's <c>ConfigureServices</c> for every
+    /// type it stores but may load through a base type or by id.
+    /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+    /// <param name="documentType">The document type to pre-register.</param>
+    public static IServiceCollection AddDocumentType(this IServiceCollection services, Type documentType)
+    {
+        ArgumentNullException.ThrowIfNull(documentType);
+
+        services.Configure<DocumentTypeOptions>(options => options.Types.Add(documentType));
+
+        return services;
+    }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -114,6 +114,13 @@ public static class OrchardCoreBuilderExtensions
 
                 store.RegisterIndexes(indexes);
 
+                // Pre-register the CLR types that modules have declared through 'AddDocumentType'
+                // so that YesSql can resolve a row's persisted type name even before that type has
+                // first been saved or queried in the current process. Without this, a by-id or
+                // polymorphic read (e.g. 'GetAsync<T>(ids)') that loads a row of a not-yet-touched
+                // type would fail with a 'KeyNotFoundException'.
+                RegisterDocumentTypes(store, sp);
+
                 return store;
             });
 
@@ -178,6 +185,24 @@ public static class OrchardCoreBuilderExtensions
         });
 
         return builder;
+    }
+
+    private static void RegisterDocumentTypes(IStore store, IServiceProvider sp)
+    {
+        var documentTypeOptions = sp.GetService<IOptions<DocumentTypeOptions>>()?.Value;
+        if (documentTypeOptions is null)
+        {
+            return;
+        }
+
+        var typeNames = store.TypeNames;
+
+        // Reading the forward 'Type -> name' mapping also populates the reverse 'name -> Type'
+        // lookup that a read relies on to resolve a row's persisted type name.
+        foreach (var type in documentTypeOptions.Types)
+        {
+            _ = typeNames[type];
+        }
     }
 
     private static YesSql.Configuration GetStoreConfiguration(IServiceProvider sp, YesSqlOptions yesSqlOptions, DatabaseTableOptions databaseTableOptions)

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -38,6 +38,16 @@ No breaking changes.
 
 ## Change Log
 
+### Document Type Pre-Registration
+
+A module can now pre-register a CLR type with the store so that YesSql can resolve a stored row's persisted type name during a by-id or polymorphic read, even before that type has first been saved or queried in the current process. Previously, YesSql resolved a stored row's type from its persisted type name through a reverse lookup that was only populated lazily, the first time a given type was saved or queried by its exact type within a process. A by-id read (for example the Workflows HTTP activity filter loading workflow types by id on an early request such as the login page) has no type filter, so it could load a row of a type that had not been touched yet and fail with a `KeyNotFoundException`.
+
+Register such a type from a module's `ConfigureServices` so the reverse lookup always succeeds:
+
+```csharp
+services.AddDocumentType<TemplatesDocument>();
+```
+
 ### File Upload Security
 
 Orchard Core now provides a file upload event pipeline for securing user-uploaded files before they are stored:

--- a/test/OrchardCore.Tests/Data/DocumentTypeRegistrationTests.cs
+++ b/test/OrchardCore.Tests/Data/DocumentTypeRegistrationTests.cs
@@ -1,0 +1,135 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Data;
+using OrchardCore.Data.Documents;
+using YesSql;
+using YesSql.Provider.Sqlite;
+
+namespace OrchardCore.Tests.Data;
+
+public class DocumentTypeRegistrationTests
+{
+    [Fact]
+    public void AddDocumentTypeRegistersTheTypeInTheOptions()
+    {
+        var services = new ServiceCollection();
+
+        services.AddDocumentType<SampleDocumentA>();
+
+        var options = services.BuildServiceProvider().GetRequiredService<IOptions<DocumentTypeOptions>>().Value;
+
+        Assert.Contains(typeof(SampleDocumentA), options.Types);
+    }
+
+    [Fact]
+    public async Task ReadingByIdThrowsWhenTheRowTypeIsNotRegistered()
+    {
+        var tempFilename = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var id = await SaveSampleDocumentAAsync(tempFilename);
+
+            // A brand-new store has an empty type cache, like after an application restart.
+            var store = await CreateStoreAsync(tempFilename);
+
+            await using var session = store.CreateSession();
+
+            // A by-id read has no type filter, so it loads the 'SampleDocumentA' row even though
+            // 'SampleDocumentB' was requested. The row type was never registered in this process.
+            await Assert.ThrowsAsync<KeyNotFoundException>(
+                () => session.GetAsync<SampleDocumentB>([id], cancellationToken: TestContext.Current.CancellationToken));
+
+            store.Dispose();
+        }
+        finally
+        {
+            DeleteTempFile(tempFilename);
+        }
+    }
+
+    [Fact]
+    public async Task ReadingByIdDoesNotThrowWhenTheRowTypeIsPreRegistered()
+    {
+        var tempFilename = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            var id = await SaveSampleDocumentAAsync(tempFilename);
+
+            var store = await CreateStoreAsync(tempFilename);
+
+            // Pre-register the document type, as done at store creation from the registered
+            // 'DocumentTypeOptions', so the reverse lookup of the persisted type name succeeds.
+            _ = store.TypeNames[typeof(SampleDocumentA)];
+
+            await using var session = store.CreateSession();
+
+            var result = await session.GetAsync<SampleDocumentB>([id], cancellationToken: TestContext.Current.CancellationToken);
+
+            // The row is a 'SampleDocumentA' which is not assignable to 'SampleDocumentB', so it is
+            // simply filtered out instead of crashing the read.
+            Assert.Empty(result);
+
+            store.Dispose();
+        }
+        finally
+        {
+            DeleteTempFile(tempFilename);
+        }
+    }
+
+    private static async Task<long> SaveSampleDocumentAAsync(string tempFilename)
+    {
+        var store = await CreateStoreAsync(tempFilename);
+
+        long id;
+        await using (var session = store.CreateSession())
+        {
+            var document = new SampleDocumentA { Name = "sample" };
+            await session.SaveAsync(document);
+            await session.SaveChangesAsync();
+            id = document.Id;
+        }
+
+        store.Dispose();
+
+        return id;
+    }
+
+    private static Task<IStore> CreateStoreAsync(string tempFilename)
+        => StoreFactory.CreateAndInitializeAsync(
+            new Configuration().UseSqLite($"Data Source={tempFilename};Cache=Shared"));
+
+    private static void DeleteTempFile(string tempFilename)
+    {
+        if (File.Exists(tempFilename))
+        {
+            try
+            {
+                File.Delete(tempFilename);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    public sealed class SampleDocumentA : IDocument
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Identifier { get; set; }
+
+        public bool IsReadOnly { get; set; }
+    }
+
+    public sealed class SampleDocumentB : IDocument
+    {
+        public long Id { get; set; }
+
+        public string Identifier { get; set; }
+
+        public bool IsReadOnly { get; set; }
+    }
+}


### PR DESCRIPTION
## Why

A by-id or polymorphic read in YesSql (for example `GetAsync<T>(ids)`) has no type filter, so it can load a row whose CLR type has not yet been saved or queried in the current process. When that happens, YesSql cannot resolve the row's persisted type name and throws a `KeyNotFoundException`. This reproduces on a fresh process: visiting the login page runs the Workflows HTTP activity filter, which loads workflow types by id, and a `TemplatesDocument` row in the shared document table crashes the request with:

```
System.Collections.Generic.KeyNotFoundException: The given key 'OrchardCore.Templates.Models.TemplatesDocument, OrchardCore.Templates' was not present in the dictionary.
   at YesSql.Services.TypeService.get_Item(String s)
   at YesSql.Session.Get[T](...)
   at OrchardCore.Workflows.Http.Filters.WorkflowActionFilter.ProcessWorkflowsAsync(...)
```

The reverse `name -> Type` lookup in YesSql is populated lazily, the first time a given type is saved or queried by its exact type. Until then, any read that resolves that row's type name fails.

## Approach

Modules now explicitly declare the document types they store but may load by id or through a base type, and those types are pre-registered with the store when a tenant is created. This removes the timing dependency so the reverse lookup always succeeds.

- `DocumentTypeOptions` (in `OrchardCore.Data.Abstractions`) holds the set of types to pre-register.
- `services.AddDocumentType<T>()` / `AddDocumentType(Type)` lets a module opt in from its `ConfigureServices`, mirroring the existing `StoreCollectionOptions` pattern used for collections.
- At store creation, the store factory reads `IOptions<DocumentTypeOptions>` and touches `store.TypeNames[type]` for each registered type, which populates the reverse lookup.
- The `OrchardCore.Templates` module registers `TemplatesDocument` (main feature) and `AdminTemplatesDocument` (AdminTemplates feature), directly fixing the reported login crash.

This is an intentional, per-module registration rather than reflection-based assembly scanning, so only the types a module actually needs are registered.

## Notes for reviewers

- Other modules that store document types loadable by id can opt in the same way with `services.AddDocumentType<T>()`.
- A complementary upstream change in YesSql (sebastienros/YesSql#718) makes `TypeService` throw a descriptive `TypeResolutionException` instead of a bare `KeyNotFoundException` when a type name is genuinely unresolvable. This OrchardCore fix works against the currently shipped YesSql and does not depend on that PR merging.
- Tests cover the options registration plus the by-id read behavior (throws when unregistered, succeeds and filters out the row when pre-registered).

Fixes: #19453