### PR TITLE
Log login failures for external users without a local account

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
@@ -183,7 +183,8 @@ public sealed class ExternalAuthenticationsController : AccountBaseController
         if (settings.DisableNewRegistrations)
         {
             await _notifier.ErrorAsync(H["New registrations are disabled for this site."]);
-            await _loginFormEvents.InvokeAsync((e) => e.LoggingInFailedAsync("External User"), _logger);
+
+            await _loginFormEvents.InvokeAsync(e => e.LoggingInFailedAsync("External User"), _logger);
 
             return RedirectToLogin(returnUrl);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
@@ -183,6 +183,7 @@ public sealed class ExternalAuthenticationsController : AccountBaseController
         if (settings.DisableNewRegistrations)
         {
             await _notifier.ErrorAsync(H["New registrations are disabled for this site."]);
+            await _loginFormEvents.InvokeAsync((e) => e.LoggingInFailedAsync("External User"), _logger);
 
             return RedirectToLogin(returnUrl);
         }


### PR DESCRIPTION
Implements #19463 

When a user signs in using an external identity provider but is blocked because they haven't been provisioned in OrchardCore and automatic registration of external users is disabled, an audit trail event is recorded:

<img width="658" height="73" alt="image" src="https://github.com/user-attachments/assets/60c792a9-34f9-4d5a-b551-84f581d8bcc3" />

That audit trail event can be extended with an event handler to include additional information, e.g.

<img width="953" height="149" alt="image" src="https://github.com/user-attachments/assets/9f42a379-4ccd-4708-96a9-c9b5760caeb5" />
