### PR TITLE
Rename all unit tests to use Action_Condition_Result

### DIFF
--- a/.agents/skills/orchardcore-unit-test/SKILL.md
+++ b/.agents/skills/orchardcore-unit-test/SKILL.md
@@ -30,7 +30,7 @@ OrchardCore uses **xUnit v3** (Microsoft Testing Platform — test projects are 
 
 ### Step 1: Add a test class
 
-Naming: `{Subject}Tests`; methods `{Action}Should{Result}` or `{Action}_{Condition}_{Result}`.
+Naming: `{Subject}Tests`; methods `{Action}_{Condition}_{ExpectedResult}`, for example `Write_WithinLimit_Succeeds`.
 
 ```csharp
 namespace OrchardCore.Json.Nodes.Test;
@@ -40,7 +40,7 @@ public class Base64Tests
     [Theory]
     [InlineData("YTw+OmE/", "a<>:a?")]
     [InlineData("SGVsbA==", "Hell")]
-    public void DecodeToStringTest(string source, string expected)
+    public void DecodeToString_ValidBase64_ReturnsDecodedString(string source, string expected)
     {
         Assert.Equal(expected, Base64.FromUTF8Base64String(source));
     }
@@ -83,7 +83,7 @@ var httpContext = new DefaultHttpContext
 public class BlogPostApiControllerTests
 {
     [Fact]
-    public async Task ShouldCreateDraftOfExistingContentItem()
+    public async Task CreateDraft_ExistingContentItem_CreatesDraft()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();

--- a/.agents/skills/orchardcore-unit-test/references/testing.md
+++ b/.agents/skills/orchardcore-unit-test/references/testing.md
@@ -22,7 +22,7 @@ Framework: **xUnit v3** via the `xunit.v3.mtp-v2` package (versions in `Director
 ## Naming conventions
 
 - Class: `{Subject}Tests` — `Base64Tests`, `BlogPostApiControllerTests`.
-- Method: `{Action}Should{Expected}` or `{Action}_{Condition}_{Expected}` — `ShouldCreateDraftOfExistingContentItem`, `InvokeAsync_InitializedShell_SkipsSetup`.
+- Method: `{Action}_{Condition}_{ExpectedResult}` — `Write_WithinLimit_Succeeds`, `InvokeAsync_InitializedShell_SkipsSetup`.
 - Arrange–Act–Assert.
 
 ## Parameterized tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,8 @@ public class YourIndexProvider : IndexProvider<YourDocument>
 
 ### Unit Test Structure
 
+Name test methods with the `{Action}_{Condition}_{ExpectedResult}` format, for example `Write_WithinLimit_Succeeds`.
+
 ```csharp
 using Xunit;
 
@@ -326,7 +328,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.YourModule;
 public class YourServiceTests
 {
     [Fact]
-    public async Task YourMethod_ShouldDoSomething_WhenCondition()
+    public async Task YourMethod_Condition_DoesSomething()
     {
         // Arrange
         var service = new YourService();
@@ -341,7 +343,7 @@ public class YourServiceTests
     [Theory]
     [InlineData("input1", "expected1")]
     [InlineData("input2", "expected2")]
-    public void YourMethod_ShouldReturnExpected(string input, string expected)
+    public void YourMethod_Input_ReturnsExpected(string input, string expected)
     {
         // Test implementation
     }
@@ -361,7 +363,7 @@ public class YourIntegrationTests : IClassFixture<OrchardTestFixture>
     }
 
     [Fact]
-    public async Task Feature_ShouldWork()
+    public async Task Feature_DefaultRecipe_Works()
     {
         // Use _fixture to create test scenarios
     }

--- a/test/OrchardCore.Abstractions.Tests/Modules/InvokeExtensionsTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/InvokeExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Modules;
 public class InvokeExtensionsTests
 {
     [Fact]
-    public void InvokeAsync_ShouldReturnCompletedTask_WhenCallbacksCompleteSynchronously()
+    public void InvokeAsync_CallbacksCompleteSynchronously_ReturnsCompletedTask()
     {
         // Arrange
         var invoked = new List<int>();
@@ -28,7 +28,7 @@ public class InvokeExtensionsTests
     }
 
     [Fact]
-    public async Task InvokeAsync_ShouldContinueSequentially_WhenAwaitIsRequired()
+    public async Task InvokeAsync_AwaitIsRequired_ContinueSequentially()
     {
         // Arrange
         var completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -52,7 +52,7 @@ public class InvokeExtensionsTests
     }
 
     [Fact]
-    public async Task InvokeAsync_ShouldSkipNonFatalExceptions_AndCollectRemainingResults()
+    public async Task InvokeAsync_CollectRemainingResults_SkipsNonFatalExceptions()
     {
         // Arrange
         // Act

--- a/test/OrchardCore.Abstractions.Tests/Modules/StringExtensionsTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/StringExtensionsTests.cs
@@ -9,7 +9,7 @@ public class StringExtensionsTests
     [InlineData("414243", new byte[] { 0x41, 0x42, 0x43 })]
     [InlineData("48656C6C6F20576F726C64", new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64 })]
     [InlineData("", new byte[0])]
-    public void ToByteArray_ShouldConvertToByteArray(string hex, byte[] expected)
+    public void ToByteArray_Default_ConvertsToByteArray(string hex, byte[] expected)
     {
         // Arrange
 
@@ -21,7 +21,7 @@ public class StringExtensionsTests
     }
 
     [Fact]
-    public void ToByteArray_ShouldThrowException_WhenHexContainsOddNumberOfCharacters()
+    public void ToByteArray_HexContainsOddNumberOfCharacters_ThrowsException()
     {
         // Arrange
         var hex = "41424";
@@ -31,7 +31,7 @@ public class StringExtensionsTests
     }
 
     [Fact]
-    public void ToByteArray_ShouldThrowException_WhenHexIsNotValid()
+    public void ToByteArray_HexIsNotValid_ThrowsException()
     {
         // Arrange
         var hex = "GHIJK";

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/AdminNavigationTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/AdminNavigationTests.cs
@@ -13,7 +13,7 @@ public sealed class AdminNavigationTests : CmsTestBase<BlogFixture>, IClassFixtu
     public AdminNavigationTests(BlogFixture fixture) : base(fixture) { }
 
     [Fact]
-    public async Task AdminNavigationShouldNotUseAdminQueryParameter()
+    public async Task AdminNavigation_Default_NotUseAdminQueryParameter()
     {
         var page = await Fixture.CreatePageAsync();
         await page.LoginAsync();
@@ -38,7 +38,7 @@ public sealed class AdminNavigationTests : CmsTestBase<BlogFixture>, IClassFixtu
     }
 
     [Fact]
-    public async Task AdminRootShouldNotKeepPreviousMenuItemActive()
+    public async Task AdminRoot_Default_NotKeepPreviousMenuItemActive()
     {
         var page = await Fixture.CreatePageAsync();
         await page.LoginAsync();

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/AgencyTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/AgencyTests.cs
@@ -8,7 +8,7 @@ public sealed class AgencyTests : CmsTestBase<AgencyFixture>, IClassFixture<Agen
     public AgencyTests(AgencyFixture fixture) : base(fixture) { }
 
     [Fact]
-    public async Task DisplaysTheHomePageOfTheAgencyTheme()
+    public async Task DisplaysTheHomePageOfTheAgencyTheme_Default_Succeeds()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");
@@ -17,7 +17,7 @@ public sealed class AgencyTests : CmsTestBase<AgencyFixture>, IClassFixture<Agen
     }
 
     [Fact]
-    public async Task AgencyAdminLoginShouldWork()
+    public async Task AgencyAdminLogin_Default_Works()
     {
         var page = await Fixture.CreatePageAsync();
         await page.LoginAsync();

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/BlogTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/BlogTests.cs
@@ -8,7 +8,7 @@ public sealed class BlogTests : CmsTestBase<BlogFixture>, IClassFixture<BlogFixt
     public BlogTests(BlogFixture fixture) : base(fixture) { }
 
     [Fact]
-    public async Task DisplaysTheHomePageOfTheBlogRecipe()
+    public async Task DisplaysTheHomePageOfTheBlogRecipe_Default_Succeeds()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");
@@ -17,7 +17,7 @@ public sealed class BlogTests : CmsTestBase<BlogFixture>, IClassFixture<BlogFixt
     }
 
     [Fact]
-    public async Task BlogAdminLoginShouldWork()
+    public async Task BlogAdminLogin_Default_Works()
     {
         var page = await Fixture.CreatePageAsync();
         await page.LoginAsync();

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/ComingSoonTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/ComingSoonTests.cs
@@ -8,7 +8,7 @@ public sealed class ComingSoonTests : CmsTestBase<ComingSoonFixture>, IClassFixt
     public ComingSoonTests(ComingSoonFixture fixture) : base(fixture) { }
 
     [Fact]
-    public async Task DisplaysTheHomePageOfTheComingSoonTheme()
+    public async Task DisplaysTheHomePageOfTheComingSoonTheme_Default_Succeeds()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");
@@ -18,7 +18,7 @@ public sealed class ComingSoonTests : CmsTestBase<ComingSoonFixture>, IClassFixt
     }
 
     [Fact]
-    public async Task ComingSoonAdminLoginShouldWork()
+    public async Task ComingSoonAdminLogin_Default_Works()
     {
         var page = await Fixture.CreatePageAsync();
         await page.LoginAsync();

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/HeadlessTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/HeadlessTests.cs
@@ -8,7 +8,7 @@ public sealed class HeadlessTests : CmsTestBase<HeadlessFixture>, IClassFixture<
     public HeadlessTests(HeadlessFixture fixture) : base(fixture) { }
 
     [Fact]
-    public async Task DisplaysTheLoginScreenForTheHeadlessTheme()
+    public async Task DisplaysTheLoginScreenForTheHeadlessTheme_Default_Succeeds()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");
@@ -17,7 +17,7 @@ public sealed class HeadlessTests : CmsTestBase<HeadlessFixture>, IClassFixture<
     }
 
     [Fact]
-    public async Task HeadlessAdminLoginShouldWork()
+    public async Task HeadlessAdminLogin_Default_Works()
     {
         var page = await Fixture.CreatePageAsync();
         await page.LoginAsync();

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/MigrationsTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/MigrationsTests.cs
@@ -8,7 +8,7 @@ public sealed class MigrationsTests : CmsTestBase<MigrationsFixture>, IClassFixt
     public MigrationsTests(MigrationsFixture fixture) : base(fixture) { }
 
     [Fact]
-    public async Task DisplaysTheHomePageOfTheMigrationsRecipe()
+    public async Task DisplaysTheHomePageOfTheMigrationsRecipe_Default_Succeeds()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");
@@ -17,7 +17,7 @@ public sealed class MigrationsTests : CmsTestBase<MigrationsFixture>, IClassFixt
     }
 
     [Fact]
-    public async Task MigrationsAdminLoginShouldWork()
+    public async Task MigrationsAdminLogin_Default_Works()
     {
         var page = await Fixture.CreatePageAsync();
         await page.LoginAsync();

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/SaasTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/SaasTests.cs
@@ -21,7 +21,7 @@ public sealed class SaasTests : IClassFixture<SaasFixture>, IAsyncLifetime
     }
 
     [Fact]
-    public async Task DisplaysTheHomePageOfTheSaasTheme()
+    public async Task DisplaysTheHomePageOfTheSaasTheme_Default_Succeeds()
     {
         var page = await _fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync($"/{_fixture.Tenant.Prefix}");
@@ -30,7 +30,7 @@ public sealed class SaasTests : IClassFixture<SaasFixture>, IAsyncLifetime
     }
 
     [Fact]
-    public async Task SaasAdminLoginShouldWork()
+    public async Task SaasAdminLogin_Default_Works()
     {
         var page = await _fixture.CreatePageAsync();
         await page.LoginAsync($"/{_fixture.Tenant.Prefix}");
@@ -40,7 +40,7 @@ public sealed class SaasTests : IClassFixture<SaasFixture>, IAsyncLifetime
     }
 
     [Fact]
-    public async Task SaasAdminRootShouldNotKeepPreviousMenuItemActive()
+    public async Task SaasAdminRoot_Default_NotKeepPreviousMenuItemActive()
     {
         var page = await _fixture.CreatePageAsync();
         await page.LoginAsync($"/{_fixture.Tenant.Prefix}");

--- a/test/OrchardCore.Tests.Functional/Tests/Media/MediaImageTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Media/MediaImageTests.cs
@@ -13,7 +13,7 @@ public sealed class MediaImageTests : CmsTestBase<BlogFixture>, IClassFixture<Bl
     public MediaImageTests(BlogFixture fixture) : base(fixture) { }
 
     [Fact]
-    public async Task BlogPage_RendersMediaImages()
+    public async Task BlogPage_RendersMediaImages_Succeeds()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");
@@ -25,7 +25,7 @@ public sealed class MediaImageTests : CmsTestBase<BlogFixture>, IClassFixture<Bl
     }
 
     [Fact]
-    public async Task MediaEndpoint_WithSupportedWidth_ReturnsImage()
+    public async Task MediaEndpoint_SupportedWidth_ReturnsImage()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");
@@ -73,7 +73,7 @@ public sealed class MediaImageTests : CmsTestBase<BlogFixture>, IClassFixture<Bl
     }
 
     [Fact]
-    public async Task MediaImages_RenderedWithToken_ReturnValidImageResponses()
+    public async Task MediaImages_RenderedWithToken_ReturnsValidImageResponses()
     {
         var page = await Fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");

--- a/test/OrchardCore.Tests.Functional/Tests/Mvc/MvcTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Mvc/MvcTests.cs
@@ -21,7 +21,7 @@ public sealed class MvcTests : IClassFixture<MvcSetupFixture>, IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldDisplayHelloWorld()
+    public async Task Display_HelloWorld_Succeeds()
     {
         var page = await _fixture.CreatePageAsync();
         await page.GotoAndAssertOkAsync("/");

--- a/test/OrchardCore.Tests.Integration/AmazonS3/AWSS3ResizedImageCacheTests.cs
+++ b/test/OrchardCore.Tests.Integration/AmazonS3/AWSS3ResizedImageCacheTests.cs
@@ -97,7 +97,7 @@ public sealed class AWSS3ResizedImageCacheTests : IAsyncLifetime
     // ── Set / Get round-trip ─────────────────────────────────────────────────
 
     [DockerFact]
-    public async Task Set_ThenGet_JPEG_RoundTripsContentAndContentType()
+    public async Task Set_ThenGetJPEG_RoundTripsContentAndContentType()
     {
         const string body = "fake-jpeg-bytes";
         using var input = FakeImage(body);
@@ -112,7 +112,7 @@ public sealed class AWSS3ResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Set_ThenGet_PNG_ReturnsCorrectContentType()
+    public async Task Set_ThenGetPNG_ReturnsCorrectContentType()
     {
         using var input = FakeImage();
         await _cache.SetAsync("png-key", input, "image/png", TimeSpan.FromDays(1));
@@ -124,7 +124,7 @@ public sealed class AWSS3ResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Set_ThenGet_WebP_ReturnsCorrectContentType()
+    public async Task Set_ThenGetWebP_ReturnsCorrectContentType()
     {
         using var input = FakeImage();
         await _cache.SetAsync("webp-key", input, "image/webp", TimeSpan.FromDays(1));
@@ -136,7 +136,7 @@ public sealed class AWSS3ResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Set_SameKey_Overwrites_Content()
+    public async Task Set_SameKeyOverwrites_Content()
     {
         using var v1 = FakeImage("v1");
         using var v2 = FakeImage("v2");
@@ -160,7 +160,7 @@ public sealed class AWSS3ResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Clear_DeletesAllEntries()
+    public async Task Clear_Default_DeletesAllEntries()
     {
         using var a = FakeImage("a");
         using var b = FakeImage("b");
@@ -174,7 +174,7 @@ public sealed class AWSS3ResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Clear_WithBasePath_OnlyDeletesEntriesUnderThatPath()
+    public async Task Clear_BasePath_OnlyDeletesEntriesUnderThatPath()
     {
         var cacheA = CreateCache(basePath: "zone-a");
         var cacheB = CreateCache(basePath: "zone-b");

--- a/test/OrchardCore.Tests.Integration/AmazonS3/AwsFileStoreTests.cs
+++ b/test/OrchardCore.Tests.Integration/AmazonS3/AwsFileStoreTests.cs
@@ -99,14 +99,14 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     // -- File operations --
 
     [DockerFact]
-    public async Task CreateFile_ReturnsPath()
+    public async Task CreateFile_Default_ReturnsPath()
     {
         var result = await CreateTestFileAsync("folder/file.txt");
         Assert.Equal("folder/file.txt", result);
     }
 
     [DockerFact]
-    public async Task GetFileInfo_ReturnsCorrectMetadata()
+    public async Task GetFileInfo_Default_ReturnsCorrectMetadata()
     {
         var content = "hello world";
         await CreateTestFileAsync("info-test.txt", content);
@@ -128,7 +128,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task GetFileStream_ReturnsContent()
+    public async Task GetFileStream_Default_ReturnsContent()
     {
         var expected = "stream content test";
         await CreateTestFileAsync("stream-test.txt", expected);
@@ -139,7 +139,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task DeleteFile_ReturnsTrue()
+    public async Task DeleteFile_Default_ReturnsTrue()
     {
         await CreateTestFileAsync("delete-me.txt");
 
@@ -150,7 +150,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task CopyFile_CreatesNewFile()
+    public async Task CopyFile_Default_CreatesNewFile()
     {
         var content = "copy me";
         await CreateTestFileAsync("original.txt", content);
@@ -229,7 +229,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task CreateDirectory_Succeeds()
+    public async Task CreateDirectory_Default_Succeeds()
     {
         var result = await _store.TryCreateDirectoryAsync("new-dir");
 
@@ -240,7 +240,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task DeleteDirectory_WithContents_DeletesAll()
+    public async Task DeleteDirectory_Contents_DeletesAll()
     {
         await _store.TryCreateDirectoryAsync("dir-to-delete");
         await CreateTestFileAsync("dir-to-delete/file1.txt");
@@ -263,7 +263,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     // -- Move --
 
     [DockerFact]
-    public async Task MoveFile_MovesToNewPath()
+    public async Task MoveFile_Default_MovesToNewPath()
     {
         var content = "move me";
         await CreateTestFileAsync("src.txt", content);
@@ -275,7 +275,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task MoveFile_AcrossDirectories()
+    public async Task MoveFile_AcrossDirectories_Succeeds()
     {
         await _store.TryCreateDirectoryAsync("dir-a");
         await _store.TryCreateDirectoryAsync("dir-b");
@@ -290,7 +290,7 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
     // -- Directory content listing --
 
     [DockerFact]
-    public async Task GetDirectoryContent_ListsFilesAndDirs()
+    public async Task GetDirectoryContent_Default_ListsFilesAndDirs()
     {
         await CreateTestFileAsync("root-file.txt");
         await _store.TryCreateDirectoryAsync("sub-dir");

--- a/test/OrchardCore.Tests.Integration/Azure/AzureBlobResizedImageCacheTests.cs
+++ b/test/OrchardCore.Tests.Integration/Azure/AzureBlobResizedImageCacheTests.cs
@@ -86,7 +86,7 @@ public sealed class AzureBlobResizedImageCacheTests : IAsyncLifetime
     // ── Set / Get round-trip ─────────────────────────────────────────────────
 
     [DockerFact]
-    public async Task Set_ThenGet_JPEG_RoundTripsContentAndContentType()
+    public async Task Set_ThenGetJPEG_RoundTripsContentAndContentType()
     {
         const string body = "fake-jpeg-bytes";
         using var input = FakeImage(body);
@@ -101,7 +101,7 @@ public sealed class AzureBlobResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Set_ThenGet_PNG_ReturnsCorrectContentType()
+    public async Task Set_ThenGetPNG_ReturnsCorrectContentType()
     {
         using var input = FakeImage();
         await _cache.SetAsync("png-key", input, "image/png", TimeSpan.FromDays(1));
@@ -113,7 +113,7 @@ public sealed class AzureBlobResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Set_ThenGet_WebP_ReturnsCorrectContentType()
+    public async Task Set_ThenGetWebP_ReturnsCorrectContentType()
     {
         using var input = FakeImage();
         await _cache.SetAsync("webp-key", input, "image/webp", TimeSpan.FromDays(1));
@@ -125,7 +125,7 @@ public sealed class AzureBlobResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Set_SameKey_Overwrites_Content()
+    public async Task Set_SameKeyOverwrites_Content()
     {
         using var v1 = FakeImage("v1");
         using var v2 = FakeImage("v2");
@@ -149,7 +149,7 @@ public sealed class AzureBlobResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Clear_DeletesAllEntries()
+    public async Task Clear_Default_DeletesAllEntries()
     {
         using var a = FakeImage("a");
         using var b = FakeImage("b");
@@ -163,7 +163,7 @@ public sealed class AzureBlobResizedImageCacheTests : IAsyncLifetime
     }
 
     [DockerFact]
-    public async Task Clear_WithBasePath_OnlyDeletesEntriesUnderThatPath()
+    public async Task Clear_BasePath_OnlyDeletesEntriesUnderThatPath()
     {
         var cacheA = CreateCache(basePath: "zone-a");
         var cacheB = CreateCache(basePath: "zone-b");

--- a/test/OrchardCore.Tests/Abstractions/Base64Tests.cs
+++ b/test/OrchardCore.Tests/Abstractions/Base64Tests.cs
@@ -7,7 +7,7 @@ public class Base64Tests
     [InlineData("SGVsbA==", "Hell")]
     [InlineData("SGVsbG8=", "Hello")]
     [InlineData("", "")]
-    public void DecodeToStringTest(string source, string expected)
+    public void DecodeToString_Default_Succeeds(string source, string expected)
     {
         Assert.Equal(expected, Base64.FromUTF8Base64String(source));
     }
@@ -17,7 +17,7 @@ public class Base64Tests
     [InlineData("SGVsbA==", "Hell")]
     [InlineData("SGVsbG8=", "Hello")]
     [InlineData("", "")]
-    public void DecodeToStreamTest(string source, string expected)
+    public void DecodeToStream_Default_Succeeds(string source, string expected)
     {
         using var stream = Base64.DecodeToStream(source);
         using var sr = new StreamReader(stream);

--- a/test/OrchardCore.Tests/Abstractions/Json/Nodes/JArrayTests.cs
+++ b/test/OrchardCore.Tests/Abstractions/Json/Nodes/JArrayTests.cs
@@ -14,7 +14,7 @@ public class JArrayTests
 
     [Theory]
     [MemberData(nameof(MergeArrayEntries))]
-    public void MergeArrayShouldRespectJsonMergeSettings(string jsonArrayContent1, string jsonArrayContent2, JsonMergeSettings mergeSettings, string expectedJsonString)
+    public void MergeArray_Default_RespectJsonMergeSettings(string jsonArrayContent1, string jsonArrayContent2, JsonMergeSettings mergeSettings, string expectedJsonString)
     {
         // Arrange
         var array = JsonNode.Parse(jsonArrayContent1) as JsonArray;

--- a/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.ContentApiController;
 public class BlogPostApiControllerTests
 {
     [Fact]
-    public async Task ShouldCreateDraftOfExistingContentItem()
+    public async Task Create_DraftOfExistingContentItem_Succeeds()
     {
         using var context = new BlogPostApiControllerContext();
 
@@ -31,7 +31,7 @@ public class BlogPostApiControllerTests
     }
 
     [Fact]
-    public async Task ShouldCreateAndPublishExistingContentItem()
+    public async Task Create_PublishExistingContentItem_Succeeds()
     {
         using var context = new BlogPostApiControllerContext();
 
@@ -51,7 +51,7 @@ public class BlogPostApiControllerTests
     }
 
     [Fact]
-    public async Task ShouldOnlyCreateTwoContentItemRecordsForExistingContentItem()
+    public async Task Only_CreateTwoContentItemRecordsForExistingContentItem_Succeeds()
     {
         using var context = new BlogPostApiControllerContext();
 
@@ -76,7 +76,7 @@ public class BlogPostApiControllerTests
     }
 
     [Fact]
-    public async Task ShouldCreateDraftOfNewContentItem()
+    public async Task Create_DraftOfNewContentItem_Succeeds()
     {
         using var context = new BlogPostApiControllerContext();
 
@@ -132,7 +132,7 @@ public class BlogPostApiControllerTests
     }
 
     [Fact]
-    public async Task ShouldCreateAndPublishNewContentItem()
+    public async Task Create_PublishNewContentItem_Succeeds()
     {
         using var context = new BlogPostApiControllerContext();
 
@@ -189,7 +189,7 @@ public class BlogPostApiControllerTests
     }
 
     [Fact]
-    public async Task ShouldFailValidationWhenAutoroutePathIsNotUnique()
+    public async Task Fail_AutoroutePathIsNotUnique_Succeeds()
     {
         using var context = new BlogPostApiControllerContext();
 
@@ -251,7 +251,7 @@ public class BlogPostApiControllerTests
     }
 
     [Fact]
-    public async Task ShouldGenerateUniqueAutoroutePath()
+    public async Task Generate_UniqueAutoroutePath_Succeeds()
     {
         using var context = new BlogPostApiControllerContext();
 

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DefaultContentManagerTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DefaultContentManagerTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement;
 public class DefaultContentManagerTests
 {
     [Fact]
-    public async Task GetAsync_WithMultipleContentItemIds_ShouldReturnItemsInSameOrderAsInput()
+    public async Task GetAsync_MultipleContentItemIds_ReturnsItemsInSameOrderAsInput()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -56,7 +56,7 @@ public class DefaultContentManagerTests
     }
 
     [Fact]
-    public async Task GetAsync_WithDuplicateIds_ShouldReturnUniqueItemsInCorrectOrder()
+    public async Task GetAsync_DuplicateIds_ReturnsUniqueItemsInCorrectOrder()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -84,7 +84,7 @@ public class DefaultContentManagerTests
     }
 
     [Fact]
-    public async Task GetAsync_WithPartiallyExistingIds_ShouldReturnFoundItemsInCorrectOrder()
+    public async Task GetAsync_PartiallyExistingIds_ReturnsFoundItemsInCorrectOrder()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -111,7 +111,7 @@ public class DefaultContentManagerTests
     }
 
     [Fact]
-    public async Task GetAsync_WithEmptyInput_ShouldReturnEmptyResult()
+    public async Task GetAsync_EmptyInput_ReturnsEmptyResult()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -127,7 +127,7 @@ public class DefaultContentManagerTests
     }
 
     [Fact]
-    public async Task GetAsync_WithNullInput_ShouldReturnEmptyResult()
+    public async Task GetAsync_NullInput_ReturnsEmptyResult()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -143,7 +143,7 @@ public class DefaultContentManagerTests
     }
 
     [Fact]
-    public async Task GetAsync_WithVersionOptions_ShouldMaintainOrderRegardlessOfVersionRequested()
+    public async Task GetAsync_VersionOptions_MaintainOrderRegardlessOfVersionRequested()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -178,7 +178,7 @@ public class DefaultContentManagerTests
     }
 
     [Fact]
-    public async Task GetAsync_WithLargeSetOfIds_ShouldMaintainOrderAtScale()
+    public async Task GetAsync_LargeSetOfIds_MaintainOrderAtScale()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans;
 public class BlogPostContentStepIdempotentTests
 {
     [Fact]
-    public async Task ShouldProduceSameOutcomeForNewContentOnMultipleExecutions()
+    public async Task Produce_SameOutcomeForNewContentOnMultipleExecutions_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 
@@ -48,7 +48,7 @@ public class BlogPostContentStepIdempotentTests
     }
 
     [Fact]
-    public async Task ShouldProduceSameOutcomeForExistingContentItemVersionOnMultipleExecutions()
+    public async Task Produce_SameOutcomeForExistingContentItemVersionOnMultipleExecutions_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans;
 public class BlogPostCreateDeploymentPlanTests
 {
     [Fact]
-    public async Task ShouldCreateNewPublishedContentItemVersion()
+    public async Task Create_NewPublishedContentItemVersion_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 
@@ -47,7 +47,7 @@ public class BlogPostCreateDeploymentPlanTests
     }
 
     [Fact]
-    public async Task ShouldDiscardDraftThenCreateNewPublishedContentItemVersion()
+    public async Task Discard_DraftThenCreateNewPublishedContentItemVersion_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 
@@ -90,7 +90,7 @@ public class BlogPostCreateDeploymentPlanTests
     }
 
     [Fact]
-    public async Task ShouldDiscardDraftThenCreateNewDraftContentItemVersion()
+    public async Task Discard_DraftThenCreateNewDraftContentItemVersion_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 
@@ -135,7 +135,7 @@ public class BlogPostCreateDeploymentPlanTests
     }
 
     [Fact]
-    public async Task ShouldCreateNewPublishedContentItem()
+    public async Task Create_NewPublishedContentItem_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 
@@ -165,7 +165,7 @@ public class BlogPostCreateDeploymentPlanTests
     }
 
     [Fact]
-    public async Task ShouldIgnoreDuplicateContentItems()
+    public async Task Ignore_DuplicateContentItems_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans;
 public class BlogPostUpdateDeploymentPlanTests
 {
     [Fact]
-    public async Task ShouldUpdateExistingContentItemVersion()
+    public async Task Update_ExistingContentItemVersion_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 
@@ -37,7 +37,7 @@ public class BlogPostUpdateDeploymentPlanTests
     }
 
     [Fact]
-    public async Task ShouldDiscardDraftThenUpdateExistingContentItemVersion()
+    public async Task Discard_DraftThenUpdateExistingContentItemVersion_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 
@@ -75,7 +75,7 @@ public class BlogPostUpdateDeploymentPlanTests
     }
 
     [Fact]
-    public async Task ShouldUpdateDraftThenPublishExistingContentItemVersion()
+    public async Task Update_DraftThenPublishExistingContentItemVersion_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/ContentStepLuceneQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/ContentStepLuceneQueryTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans;
 public class ContentStepLuceneQueryTests
 {
     [Fact]
-    public async Task ShouldUpdateLuceneIndexesOnImport()
+    public async Task Update_LuceneIndexesOnImport_Succeeds()
     {
         using var context = new BlogPostDeploymentContext();
 

--- a/test/OrchardCore.Tests/Apis/Context/TablePrefixGeneratorTests.cs
+++ b/test/OrchardCore.Tests/Apis/Context/TablePrefixGeneratorTests.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Tests.Apis.Context;
 public class TablePrefixGeneratorTests
 {
     [Fact]
-    public async Task TenantPrefixShouldBeUnique()
+    public async Task TenantPrefix_Default_BeUnique()
     {
         var tablePrefixGenerator = new TablePrefixGenerator();
         var prefixes = new HashSet<string>();

--- a/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
@@ -13,7 +13,7 @@ public class BlogPostTests
 {
     [Fact]
 
-    public async Task ShouldListAllBlogs()
+    public async Task List_AllBlogs_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -32,7 +32,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task ShouldQueryByBlogPostAutoroutePart()
+    public async Task Query_ByBlogPostAutoroutePart_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -93,7 +93,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task WhenThePartHasTheSameNameAsTheContentTypeShouldCollapseFieldsToContentType()
+    public async Task Default_ThePartHasTheSameNameAsTheContentTypeDefaultCollapseFieldsToContentType_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -112,7 +112,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task WhenCreatingABlogPostShouldBeAbleToPopulateField()
+    public async Task Default_CreatingABlogPostDefaultBeAbleToPopulateField_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -162,7 +162,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task ShouldQueryByStatus()
+    public async Task Query_ByStatus_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();
@@ -200,7 +200,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task ShouldNotBeAbleToExecuteAnyQueriesWithoutPermission()
+    public async Task Not_BeAbleToExecuteAnyQueriesWithoutPermission_Succeeds()
     {
         using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext { UsePermissionsContext = true });
@@ -212,7 +212,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task ShouldReturnBlogsWithViewBlogContentPermission()
+    public async Task Return_BlogsWithViewBlogContentPermission_Succeeds()
     {
         using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext
@@ -237,7 +237,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task ShouldNotReturnBlogsWithViewOwnBlogContentPermission()
+    public async Task Not_ReturnBlogsWithViewOwnBlogContentPermission_Succeeds()
     {
         using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext
@@ -262,7 +262,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task ShouldNotReturnBlogsWithoutViewBlogContentPermission()
+    public async Task Not_ReturnBlogsWithoutViewBlogContentPermission_Succeeds()
     {
         using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext
@@ -286,7 +286,7 @@ public class BlogPostTests
     }
 
     [Fact]
-    public async Task ShouldQueryContainedPart()
+    public async Task Query_ContainedPart_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/GraphQL/Client/ContentTypeQueryResourceBuilderTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Client/ContentTypeQueryResourceBuilderTests.cs
@@ -7,7 +7,7 @@ public class ContentTypeQueryResourceBuilderTests
     [Theory]
     [InlineData("someContentType")]
     [InlineData("SomeContentType")]
-    public void ShouldReturnContentTypeNameAsPascalCase(string contentType)
+    public void Return_ContentTypeNameAsPascalCase_Succeeds(string contentType)
     {
         var result = new ContentTypeQueryResourceBuilder(contentType)
                         .Build();
@@ -16,7 +16,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldbeAbleToAddArgument()
+    public void Be_AbleToAddArgument_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithQueryArgument("arg", "1");
@@ -25,7 +25,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldbeAbleToAddMultipleArguments()
+    public void Be_AbleToAddMultipleArguments_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithQueryArgument("arg", "1");
@@ -35,7 +35,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldbeAbleToAddStringArgument()
+    public void Be_AbleToAddStringArgument_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithQueryStringArgument("arg", "a string");
@@ -44,7 +44,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldbeAbleToAddMultiInputArgument()
+    public void Be_AbleToAddMultiInputArgument_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithQueryArgument("arg", "a", "1");
@@ -54,7 +54,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldNotBeAbleToAddDuplicateArguments()
+    public void Not_BeAbleToAddDuplicateArguments_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithQueryArgument("arg", "a");
@@ -67,7 +67,7 @@ public class ContentTypeQueryResourceBuilderTests
     [Theory]
     [InlineData("someField")]
     [InlineData("SomeField")]
-    public void ShouldAddFieldWithNameAsPascalCase(string fieldName)
+    public void Add_FieldWithNameAsPascalCase_Succeeds(string fieldName)
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithField(fieldName);
@@ -78,7 +78,7 @@ public class ContentTypeQueryResourceBuilderTests
     [Theory]
     [InlineData("someNestedField")]
     [InlineData("SomeNestedField")]
-    public void ShouldAddNestedFieldWithNameAsPascalCase(string fieldName)
+    public void Add_NestedFieldWithNameAsPascalCase_Succeeds(string fieldName)
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithNestedField(fieldName);
@@ -87,7 +87,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldbeAbleToAddMultipleNestedFields()
+    public void Be_AbleToAddMultipleNestedFields_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithField("field");
@@ -98,7 +98,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldbeAbleToCombineNonNestedAndNestedFields()
+    public void Be_AbleToCombineNonNestedAndNestedFields_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithField("field");
@@ -108,7 +108,7 @@ public class ContentTypeQueryResourceBuilderTests
     }
 
     [Fact]
-    public void ShouldbeAbleToAddNestedFieldsMultipleLevelsDeep()
+    public void Be_AbleToAddNestedFieldsMultipleLevelsDeep_Succeeds()
     {
         var builder = new ContentTypeQueryResourceBuilder("someContentType");
         builder.WithField("field");

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
@@ -139,7 +139,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldFilterByContentItemIndex()
+    public async Task Filter_ByContentItemIndex_Succeeds()
     {
         _store.RegisterIndexes<AnimalIndexProvider>();
 
@@ -173,7 +173,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldFilterByContentItemIndexWhenSqlTablePrefixIsUsed()
+    public async Task Filter_SqlTablePrefixIsUsed_Succeeds()
     {
         _prefixedStore.RegisterIndexes<AnimalIndexProvider>();
 
@@ -214,7 +214,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     [InlineData("animal")]
     [InlineData("ANIMAL")]
     [InlineData("Animal")]
-    public async Task ShouldFilterByAliasIndexRegardlessOfInputFieldCase(string fieldName)
+    public async Task Filter_ByAliasIndexRegardlessOfInputFieldCase_Succeeds(string fieldName)
     {
         _store.RegisterIndexes<AnimalIndexProvider>();
 
@@ -252,7 +252,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldBeAbleToUseTheSameIndexForMultipleAliases()
+    public async Task Be_AbleToUseTheSameIndexForMultipleAliases_Succeeds()
     {
         _store.RegisterIndexes<AnimalIndexProvider>();
 
@@ -293,7 +293,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldFilterOnMultipleIndexesOnSameAlias()
+    public async Task Filter_MultipleIndexesOnSameAlias_Succeeds()
     {
         _store.RegisterIndexes<AnimalIndexProvider>();
         _store.RegisterIndexes<AnimalTraitsIndexProvider>();
@@ -342,7 +342,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldFilterPartsWithoutAPrefixWhenThePartHasNoPrefix()
+    public async Task Filter_ThePartHasNoPrefix_Succeeds()
     {
         _store.RegisterIndexes<AnimalIndexProvider>();
 
@@ -377,7 +377,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldFilterNestedPartInputWhenPartNameHasNoPrefix()
+    public async Task Filter_PartNameHasNoPrefix_Succeeds()
     {
         _store.RegisterIndexes<AnimalLocalizationIndexProvider>();
 
@@ -419,7 +419,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     [InlineData("animal")]
     [InlineData("ANIMAL")]
     [InlineData("Animal")]
-    public async Task ShouldFilterNestedPartInputRegardlessOfInputFieldCase(string fieldName)
+    public async Task Filter_NestedPartInputRegardlessOfInputFieldCase_Succeeds(string fieldName)
     {
         _store.RegisterIndexes<AnimalLocalizationIndexProvider>();
 
@@ -454,7 +454,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ShouldFilterByCollapsedWhereInputForCollapsedParts()
+    public async Task Filter_ByCollapsedWhereInputForCollapsedParts_Succeeds()
     {
         _store.RegisterIndexes<AnimalIndexProvider>();
 

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentManagement/ContentItemQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentManagement/ContentItemQueryTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Apis.GraphQL;
 public class ContentItemQueryTests
 {
     [Fact]
-    public async Task ShouldReturnContentItemWhenViewContentPermissionIsGranted()
+    public async Task Return_ViewContentPermissionIsGranted_Succeeds()
     {
         using var context = new SiteContext()
             .WithRecipe("Blog")
@@ -37,7 +37,7 @@ public class ContentItemQueryTests
     }
 
     [Fact]
-    public async Task ShouldNotReturnContentItemWithoutViewContentPermission()
+    public async Task Not_ReturnContentItemWithoutViewContentPermission_Succeeds()
     {
         using var context = new SiteContext()
             .WithRecipe("Blog")

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentManagement/DynamicContentTypeQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentManagement/DynamicContentTypeQueryTests.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Tests.Apis.GraphQL;
 public class DynamicContentTypeQueryTests
 {
     [Fact]
-    public async Task ShouldQueryContentFields()
+    public async Task Query_ContentFields_Succeeds()
     {
         using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
@@ -28,7 +28,7 @@ public class DynamicContentTypeQueryTests
     }
 
     [Fact]
-    public async Task ShouldQueryCollapsedContentFields()
+    public async Task Query_CollapsedContentFields_Succeeds()
     {
         using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
@@ -53,7 +53,7 @@ public class DynamicContentTypeQueryTests
     }
 
     [Fact]
-    public async Task ShouldQueryCollapsedContentFieldsWithPreventCollision()
+    public async Task Query_CollapsedContentFieldsWithPreventCollision_Succeeds()
     {
         using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
@@ -78,7 +78,7 @@ public class DynamicContentTypeQueryTests
     }
 
     [Fact]
-    public async Task ShouldQueryMultipleContentFields()
+    public async Task Query_MultipleContentFields_Succeeds()
     {
         using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
@@ -111,7 +111,7 @@ public class DynamicContentTypeQueryTests
     }
 
     [Fact]
-    public async Task ShouldOrderByCreatedUtc()
+    public async Task Order_ByCreatedUtc_Succeeds()
     {
         using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
@@ -139,7 +139,7 @@ public class DynamicContentTypeQueryTests
     }
 
     [Fact]
-    public async Task ShouldQuerySimilarNamedContentFields()
+    public async Task Query_SimilarNamedContentFields_Succeeds()
     {
         using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
@@ -170,7 +170,7 @@ public class DynamicContentTypeQueryTests
     }
 
     [Fact]
-    public async Task ShouldDistinquishMultipleNamedContentFields()
+    public async Task Distinquish_MultipleNamedContentFields_Succeeds()
     {
         using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/GraphQL/MediaFieldResizeUrlQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/MediaFieldResizeUrlQueryTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Apis.GraphQL;
 public class MediaFieldResizeUrlQueryTests
 {
     [Fact]
-    public async Task ResizeUrlShouldReturnAUrlThatServesAProcessedImage()
+    public async Task ResizeUrl_Default_ReturnsAUrlThatServesAProcessedImage()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/GraphQL/Queries/PredicateQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Queries/PredicateQueryTests.cs
@@ -23,7 +23,7 @@ public class PredicateQueryTests
     [InlineData("ListItemIndex.Value", "[ListItemIndex].[Value]")]
     [InlineData("[ListItemIndex.Value]", "[ListItemIndex.Value]")]
     [InlineData("[ListItemIndex].[Value]", "[ListItemIndex].[Value]")]
-    public void ShouldReturnQuotedColumnNameWhenAliasNotExists(string propertyPath, string expectedColumnName)
+    public void Return_AliasNotExists_Succeeds(string propertyPath, string expectedColumnName)
     {
         // Arrange
         var predicateQuery = new PredicateQuery(_configuration, []);
@@ -40,7 +40,7 @@ public class PredicateQueryTests
     [InlineData("ListItemIndexPath.ValuePath", "ListItemIndexAlias.ValueAlias", "[ListItemIndexAlias].[ValueAlias]")]
     [InlineData("ListItemIndexPath.ValuePath", "[ListItemIndexAlias.ValueAlias]", "[ListItemIndexAlias.ValueAlias]")]
     [InlineData("ListItemIndexPath.ValuePath", "[ListItemIndexAlias].[ValueAlias]", "[ListItemIndexAlias].[ValueAlias]")]
-    public void ShouldReturnQuotedAliasColumnNameWhenAliasExists(string propertyPath, string alias, string expectedColumnName)
+    public void Return_AliasExists_Succeeds(string propertyPath, string alias, string expectedColumnName)
     {
         // Arrange
         var predicateQuery = new PredicateQuery(_configuration, []);
@@ -58,7 +58,7 @@ public class PredicateQueryTests
     [InlineData("[ListItemIndex].[Value]", "[ListItemIndex].[Value]")]
     [InlineData("ListItemIndex.[Value]", "[ListItemIndex].[Value]")]
     [InlineData("[ListItemIndex].Value", "[ListItemIndex].[Value]")]
-    public void DoesNotQuoteWhenPathIsQuoted(string propertyPath, string expectedColumnName)
+    public void DoesNotQuoteWhenPathIsQuoted_Default_Succeeds(string propertyPath, string expectedColumnName)
     {
         // Arrange
         var predicateQuery = new PredicateQuery(_configuration, []);
@@ -75,7 +75,7 @@ public class PredicateQueryTests
     [InlineData("[ListItemIndex.Value]", "[ListItemIndex.Value]", "Sqlite")]
     [InlineData("[ListItemIndex.Value]", "[ListItemIndex.Value]", "SqlServer")]
     [InlineData("\"ListItemIndex.Value\"", "\"ListItemIndex.Value\"", "Postgre")]
-    public void DetectsProviderDependentQuoteChars(string propertyPath, string expectedColumnName, string dialect)
+    public void DetectsProviderDependentQuoteChars_Default_Succeeds(string propertyPath, string expectedColumnName, string dialect)
     {
         // Arrange
         var configuration = new Configuration();
@@ -119,7 +119,7 @@ public class PredicateQueryTests
     }
 
     [Fact]
-    public void ShouldReturnQuotedTableAliasAndColumnNameWhenProviderExists()
+    public void Return_ProviderExists_Succeeds()
     {
         // Arrange
         var predicateQuery = new PredicateQuery(_configuration, [new IndexPropertyProvider<ListItemIndex>()]);
@@ -135,7 +135,7 @@ public class PredicateQueryTests
     }
 
     [Fact]
-    public void ShouldReturnQuotedTableAliasAndPathWhenProviderNotExists()
+    public void Return_ProviderNotExists_Succeeds()
     {
         // Arrange
         var predicateQuery = new PredicateQuery(_configuration, []);

--- a/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Apis.GraphQL;
 public class RecentBlogPostsQueryTests
 {
     [Fact]
-    public async Task ShouldListBlogPostWhenCallingAQuery()
+    public async Task List_CallingAQuery_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/GraphQL/ValidationRules/RequiresPermissionValidationRuleTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ValidationRules/RequiresPermissionValidationRuleTests.cs
@@ -20,7 +20,7 @@ public class RequiresPermissionValidationRuleTests
     };
 
     [Fact]
-    public async Task FieldsWithNoRequirePermissionsShouldResolve()
+    public async Task FieldsWithNoRequirePermissions_Default_Resolves()
     {
         var options = BuildExecutionOptions("query { test { noPermissions } }",
                         new PermissionsContext
@@ -43,7 +43,7 @@ public class RequiresPermissionValidationRuleTests
     [Theory]
     [InlineData("permissionOne", "Fantastic Fox Loves Permission One")]
     [InlineData("permissionTwo", "Fantastic Fox Loves Permission Two")]
-    public async Task FieldsWithRequirePermissionsShouldResolveWhenUserHasPermissions(string fieldName, string expectedFieldValue)
+    public async Task FieldsWithRequirePermissions_UserHasPermissions_Resolves(string fieldName, string expectedFieldValue)
     {
         var options = BuildExecutionOptions($"query {{ test {{{fieldName}}} }}",
                         new PermissionsContext
@@ -65,7 +65,7 @@ public class RequiresPermissionValidationRuleTests
     }
 
     [Fact]
-    public async Task FieldsWithRequirePermissionsShouldNotResolveWhenUserDoesntHavePermissions()
+    public async Task FieldsWithRequirePermissions_UserDoesntHavePermissions_DoesNotResolve()
     {
         var options = BuildExecutionOptions("query { test { permissionOne } }",
             new PermissionsContext
@@ -81,7 +81,7 @@ public class RequiresPermissionValidationRuleTests
     }
 
     [Fact]
-    public async Task FieldsWithMultipleRequirePermissionsShouldResolveWhenUserHasAllPermissions()
+    public async Task FieldsWithMultipleRequirePermissions_UserHasAllPermissions_Resolves()
     {
         var options = BuildExecutionOptions("query { test { permissionMultiple  } }",
                         new PermissionsContext

--- a/test/OrchardCore.Tests/Apis/Lucene/LuceneQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/Lucene/LuceneQueryTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Apis.Lucene;
 public class LuceneQueryTests
 {
     [Fact]
-    public async Task BoostingTitleShouldHaveTitlesContainingOrchardAppearFirst()
+    public async Task BoostingTitle_Default_HaveTitlesContainingOrchardAppearFirst()
     {
         using var context = new LuceneContext();
         await context.InitializeAsync();
@@ -46,7 +46,7 @@ public class LuceneQueryTests
     }
 
     [Fact]
-    public async Task BoostingBodyShouldHaveTitlesNotContainingOrchardAppearFirst()
+    public async Task BoostingBody_Default_HaveTitlesNotContainingOrchardAppearFirst()
     {
         using var context = new LuceneContext();
         await context.InitializeAsync();
@@ -81,7 +81,7 @@ public class LuceneQueryTests
     }
 
     [Fact]
-    public async Task SimpleQueryWildcardHasResults()
+    public async Task SimpleQueryWildcardHasResults_Default_Succeeds()
     {
         using var context = new LuceneContext();
         await context.InitializeAsync();
@@ -120,7 +120,7 @@ public class LuceneQueryTests
     }
 
     [Fact]
-    public async Task TwoWildcardQueriesWithBoostHasResults()
+    public async Task TwoWildcardQueriesWithBoostHasResults_Default_Succeeds()
     {
         using (var context = new LuceneContext())
         {
@@ -175,7 +175,7 @@ public class LuceneQueryTests
     }
 
     [Fact]
-    public async Task LuceneQueryTemplateWithSpecialCharactersShouldNotThrowError()
+    public async Task LuceneQueryTemplateWithSpecialCharacters_Default_DoesNotThrowError()
     {
         using var context = new LuceneContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/Media/MediaImageProcessingTests.cs
+++ b/test/OrchardCore.Tests/Apis/Media/MediaImageProcessingTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Apis.Media;
 public class MediaImageProcessingTests
 {
     [Fact]
-    public async Task ResizesImage_WithValidToken()
+    public async Task ResizesImage_ValidToken_Succeeds()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();
@@ -28,7 +28,7 @@ public class MediaImageProcessingTests
     }
 
     [Fact]
-    public async Task ConvertsFormat_WithValidToken()
+    public async Task ConvertsFormat_ValidToken_Succeeds()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();
@@ -43,7 +43,7 @@ public class MediaImageProcessingTests
     }
 
     [Fact]
-    public async Task ServesOriginal_WithInvalidToken()
+    public async Task ServesOriginal_InvalidToken_Succeeds()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();
@@ -60,7 +60,7 @@ public class MediaImageProcessingTests
     }
 
     [Fact]
-    public async Task ResizesImage_WithVersionAndToken()
+    public async Task ResizesImage_VersionAndToken_Succeeds()
     {
         // Regression guard: a "v" cache-buster must not be part of the HMAC, so a versioned and
         // tokenized URL must still be processed instead of silently serving the original.
@@ -79,7 +79,7 @@ public class MediaImageProcessingTests
     }
 
     [Fact]
-    public async Task ConcurrentFirstHits_AllSucceed()
+    public async Task ConcurrentFirstHits_AllSucceed_Succeeds()
     {
         // Regression guard for the cache stampede: many concurrent first-hit requests for the same
         // resized image must all succeed (atomic temp-file + rename), with no IOExceptions and no

--- a/test/OrchardCore.Tests/Commands/CommandHandlerDescriptorBuilderTests.cs
+++ b/test/OrchardCore.Tests/Commands/CommandHandlerDescriptorBuilderTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Commands;
 public class CommandHandlerDescriptorBuilderTests
 {
     [Fact]
-    public void BuilderShouldCreateDescriptor()
+    public void Builder_Default_CreatesDescriptor()
     {
         var builder = new CommandHandlerDescriptorBuilder();
         var descriptor = builder.Build(typeof(MyCommand));
@@ -50,7 +50,7 @@ public class CommandHandlerDescriptorBuilderTests
     }
 
     [Fact]
-    public void BuilderShouldReturnPublicMethodsOnly()
+    public void Builder_Default_ReturnsPublicMethodsOnly()
     {
         var builder = new CommandHandlerDescriptorBuilder();
         var descriptor = builder.Build(typeof(PublicMethodsOnly));

--- a/test/OrchardCore.Tests/Commands/CommandHandlerTests.cs
+++ b/test/OrchardCore.Tests/Commands/CommandHandlerTests.cs
@@ -42,7 +42,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestFooCommand()
+    public async Task FooCommand_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Foo");
         await _handler.ExecuteAsync(commandContext);
@@ -50,7 +50,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestNotExistingCommand()
+    public async Task NotExistingCommand_Default_Succeeds()
     {
         await Assert.ThrowsAsync<InvalidOperationException>(async Task () =>
         {
@@ -60,7 +60,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestCommandWithCustomAlias()
+    public async Task CommandWithCustomAlias_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Bar");
         await _handler.ExecuteAsync(commandContext);
@@ -68,21 +68,21 @@ public class CommandsTests
     }
 
     [Fact]
-    public void TestHelpText()
+    public void HelpText_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Baz");
         Assert.Equal("Baz help", commandContext.CommandDescriptor.HelpText);
     }
 
     [Fact]
-    public void TestEmptyHelpText()
+    public void EmptyHelpText_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Foo");
         Assert.Empty(commandContext.CommandDescriptor.HelpText);
     }
 
     [Fact]
-    public async Task TestCaseInsensitiveForCommand()
+    public async Task CaseInsensitiveForCommand_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("BAZ", new Dictionary<string, string> { { "VERBOSE", "true" } });
         await _handler.ExecuteAsync(commandContext);
@@ -90,7 +90,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestBooleanSwitchForCommand()
+    public async Task BooleanSwitchForCommand_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Baz", new Dictionary<string, string> { { "Verbose", "true" } });
         await _handler.ExecuteAsync(commandContext);
@@ -98,7 +98,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestIntSwitchForCommand()
+    public async Task IntSwitchForCommand_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Baz", new Dictionary<string, string> { { "Level", "2" } });
         await _handler.ExecuteAsync(commandContext);
@@ -106,7 +106,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestStringSwitchForCommand()
+    public async Task StringSwitchForCommand_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Baz", new Dictionary<string, string> { { "User", "OrchardUser" } });
         await _handler.ExecuteAsync(commandContext);
@@ -114,7 +114,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestSwitchForCommandWithoutSupportForIt()
+    public async Task SwitchForCommandWithoutSupportForIt_Default_Succeeds()
     {
         var switches = new Dictionary<string, string> { { "User", "OrchardUser" } };
         var commandContext = CreateCommandContext("Foo", switches);
@@ -122,7 +122,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestCommandThatDoesNotReturnAValue()
+    public async Task CommandThatDoesNotReturnAValue_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Log");
         await _handler.ExecuteAsync(commandContext);
@@ -130,7 +130,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestNotExistingSwitch()
+    public async Task NotExistingSwitch_Default_Succeeds()
     {
         var switches = new Dictionary<string, string> { { "ThisSwitchDoesNotExist", "Insignificant" } };
         var commandContext = CreateCommandContext("Foo", switches);
@@ -138,7 +138,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestCommandArgumentsArePassedCorrectly()
+    public async Task CommandArgumentsArePassedCorrectly_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Concat", new Dictionary<string, string>(), ["left to ", "right"]);
         await _handler.ExecuteAsync(commandContext);
@@ -146,7 +146,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestCommandArgumentsArePassedCorrectlyWithAParamsParameters()
+    public async Task CommandArgumentsArePassedCorrectlyWithAParamsParameters_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("ConcatParams", new Dictionary<string, string>(), ["left to ", "right"]);
         await _handler.ExecuteAsync(commandContext);
@@ -154,7 +154,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestCommandArgumentsArePassedCorrectlyWithAParamsParameterAndNoArguments()
+    public async Task CommandArgumentsArePassedCorrectlyWithAParamsParameterAndNoArguments_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("ConcatParams", new Dictionary<string, string>());
         await _handler.ExecuteAsync(commandContext);
@@ -162,7 +162,7 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestCommandArgumentsArePassedCorrectlyWithNormalParametersAndAParamsParameters()
+    public async Task CommandArgumentsArePassedCorrectlyWithNormalParametersAndAParamsParameters_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("ConcatAllParams",
             new Dictionary<string, string>(),
@@ -172,21 +172,21 @@ public class CommandsTests
     }
 
     [Fact]
-    public async Task TestCommandParamsMismatchWithoutParamsNotEnoughArguments()
+    public async Task CommandParamsMismatchWithoutParamsNotEnoughArguments_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Concat", new Dictionary<string, string>(), ["left to "]);
         await Assert.ThrowsAsync<InvalidOperationException>(async Task () => await _handler.ExecuteAsync(commandContext));
     }
 
     [Fact]
-    public async Task TestCommandParamsMismatchWithoutParamsTooManyArguments()
+    public async Task CommandParamsMismatchWithoutParamsTooManyArguments_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("Foo", new Dictionary<string, string>(), ["left to "]);
         await Assert.ThrowsAsync<InvalidOperationException>(async Task () => await _handler.ExecuteAsync(commandContext));
     }
 
     [Fact]
-    public async Task TestCommandParamsMismatchWithParamsButNotEnoughArguments()
+    public async Task CommandParamsMismatchWithParamsButNotEnoughArguments_Default_Succeeds()
     {
         var commandContext = CreateCommandContext("ConcatAllParams", new Dictionary<string, string>());
         await Assert.ThrowsAsync<InvalidOperationException>(async Task () => await _handler.ExecuteAsync(commandContext));

--- a/test/OrchardCore.Tests/Commands/CommandManagerTests.cs
+++ b/test/OrchardCore.Tests/Commands/CommandManagerTests.cs
@@ -20,7 +20,7 @@ public class CommandManagerTests
     }
 
     [Fact]
-    public async Task ManagerCanRunACommand()
+    public async Task ManagerCanRunACommand_Default_Succeeds()
     {
         var context = new CommandParameters { Arguments = new string[] { "FooBar" }, Output = new StringWriter() };
         await _manager.ExecuteAsync(context);
@@ -28,7 +28,7 @@ public class CommandManagerTests
     }
 
     [Fact]
-    public async Task ManagerCanRunACompositeCommand()
+    public async Task ManagerCanRunACompositeCommand_Default_Succeeds()
     {
         var context = new CommandParameters { Arguments = ("Foo Bar Bleah").Split(' '), Output = new StringWriter() };
         await _manager.ExecuteAsync(context);

--- a/test/OrchardCore.Tests/ContentManagement/ContentElementTests.cs
+++ b/test/OrchardCore.Tests/ContentManagement/ContentElementTests.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.ContentManagement;
 public class ContentElementTests
 {
     [Fact]
-    public void Get_WhenCastingBaseTypeThenConcreteType_ReturnNewInstance()
+    public void Get_CastingBaseTypeThenConcreteTypeReturnNewInstance_Succeeds()
     {
         var contentItem = new ContentItem();
         var titlePart = new TitlePart
@@ -38,7 +38,7 @@ public class ContentElementTests
     }
 
     [Fact]
-    public void Get_WhenCastingConcreteTypeThenBaseType_ReturnNewInstance()
+    public void Get_CastingConcreteTypeThenBaseTypeReturnNewInstance_Succeeds()
     {
         var contentItem = new ContentItem();
         var titlePart = new TitlePart
@@ -69,7 +69,7 @@ public class ContentElementTests
     }
 
     [Fact]
-    public void Apply_WhenCalledWithNullProperty_SetThePropertyToNull()
+    public void Apply_CalledWithNullPropertySetThePropertyToNull_Succeeds()
     {
         var contentItem = new ContentItem();
 

--- a/test/OrchardCore.Tests/ContentManagement/Utilities/StringExtensionsTests.cs
+++ b/test/OrchardCore.Tests/ContentManagement/Utilities/StringExtensionsTests.cs
@@ -11,7 +11,7 @@ public class StringExtensionsTests
     [InlineData("Orchard", "Orchard")]
     [InlineData("OrchardCore", "Orchard Core")]
     [InlineData("orchardCore", "orchard Core")]
-    public void CamelFriendly_ShouldReturnCamelCase(string value, string expected)
+    public void CamelFriendly_Default_ReturnsCamelCase(string value, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.CamelFriendly(value);
@@ -26,7 +26,7 @@ public class StringExtensionsTests
     [InlineData("Orchard Core", 70, "Orchard Core")]
     [InlineData("Orchard Core", 4, $"Orch{DefaultEllipsis}")]
     [InlineData("Orchard Core", 7, $"Orchard{DefaultEllipsis}")]
-    public void Ellipsize_ShouldTrimString(string text, int characterCount, string expected)
+    public void Ellipsize_Default_TrimsString(string text, int characterCount, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.Ellipsize(text, characterCount);
@@ -46,7 +46,7 @@ public class StringExtensionsTests
     [InlineData("Orchard Core", 7, DefaultEllipsis, true, DefaultEllipsis)]
     [InlineData("Orchard Core", 7, CustomEllipsis, true, CustomEllipsis)]
     [InlineData("Orchard Core", 10, CustomEllipsis, true, $"Orchard{CustomEllipsis}")]
-    public void Ellipsize_ShouldTrimString_WithCustomEllipsisString(string text, int characterCount, string ellipsis, bool wordBoundary, string expected)
+    public void Ellipsize_CustomEllipsisString_TrimssString(string text, int characterCount, string ellipsis, bool wordBoundary, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.Ellipsize(text, characterCount, ellipsis, wordBoundary);
@@ -60,7 +60,7 @@ public class StringExtensionsTests
     [InlineData("", "")]
     [InlineData("Welcome to <h1>Orchard Core</h1>", "Welcome to Orchard Core")]
     [InlineData("Welcome to Orchard Core", "Welcome to Orchard Core")]
-    public void ShouldRemoveTagsFromString(string text, string expected)
+    public void Remove_TagsFromString_Succeeds(string text, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.RemoveTags(text);
@@ -80,7 +80,7 @@ public class StringExtensionsTests
     [InlineData("Welcome to <h1>Orchard Core</h1>", true, "Welcome to Orchard Core")]
     [InlineData("Welcome to &lt;h1&gt;Orchard Core&lt;/h1&gt;", true, "Welcome to <h1>Orchard Core</h1>")]
     [InlineData("Welcome to Orchard Core", true, "Welcome to Orchard Core")]
-    public void ShouldRemoveTagsFromString_WithHtmlDecode(string text, bool htmlEncode, string expected)
+    public void RemoveTagsFromString_HtmlDecode_Succeeds(string text, bool htmlEncode, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.RemoveTags(text, htmlEncode);
@@ -95,7 +95,7 @@ public class StringExtensionsTests
     [InlineData("Orchard", null, "Orchard")]
     [InlineData("Orchard", new char[] { }, "Orchard")]
     [InlineData("Orchardion", new[] { 'i', 'o', 'n' }, "Orchard")]
-    public void ShouldStripCharactersFromString(string text, char[] strippedChars, string expected)
+    public void Strip_CharactersFromString_Succeeds(string text, char[] strippedChars, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.Strip(text, strippedChars);
@@ -105,7 +105,7 @@ public class StringExtensionsTests
     }
 
     [Fact]
-    public void ShouldStripCharactersFromStringByPredicate()
+    public void Strip_CharactersFromStringByPredicate_Succeeds()
     {
         // Arrange
         var text = "$Welcome$ to Orchard Core$";
@@ -124,7 +124,7 @@ public class StringExtensionsTests
     [InlineData("Orchard Core", new char[] { }, false)]
     [InlineData("Orchard Core", new[] { 'a', 'e', 'i', 'o', 'u' }, true)]
     [InlineData("Orchard Core", new[] { 'i', 'u' }, false)]
-    public void ShouldMatchAnyCharacterInString(string text, char[] chars, bool expected)
+    public void Match_AnyCharacterInString_Succeeds(string text, char[] chars, bool expected)
     {
         // Arrange & Act
         var result = StringExtensions.Any(text, chars);
@@ -139,7 +139,7 @@ public class StringExtensionsTests
     [InlineData("Orchard Core", new char[] { }, false)]
     [InlineData("Orchard Core", new[] { 'a', 'e', 'i', 'o', 'u' }, false)]
     [InlineData("Orchard Core", new[] { 'a', 'e' }, false)]
-    public void ShouldMatchAllCharactersInString(string text, char[] chars, bool expected)
+    public void Match_AllCharactersInString_Succeeds(string text, char[] chars, bool expected)
     {
         // Arrange & Act
         var result = StringExtensions.All(text, chars);
@@ -154,7 +154,7 @@ public class StringExtensionsTests
     [InlineData("Orchid Core", "Orchid", "Orchard", "Orchard Core")]
     [InlineData("OrCHid .. Orchid Core", "Orchid", "Orchard", "OrCHid .. Orchard Core")]
     [InlineData("Orchid .. OrCHid Core", "Orchid", "Orchard", "Orchard .. OrCHid Core")]
-    public void ShouldReplaceLastOccuranceInString(string text, string searchedText, string replacedText, string expected)
+    public void Replace_LastOccuranceInString_Succeeds(string text, string searchedText, string replacedText, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.ReplaceLastOccurrence(text, searchedText, replacedText);
@@ -167,7 +167,7 @@ public class StringExtensionsTests
     [InlineData("Hisham Bin Ateya", "Hisham Bin Ateya")]
     [InlineData("Sébastien Ros", "Sebastien Ros")]
     [InlineData("Zoltán Lehóczky", "Zoltan Lehoczky")]
-    public void ShouldRemoveDiacriticsFromString(string text, string expected)
+    public void Remove_DiacriticsFromString_Succeeds(string text, string expected)
     {
         // Arrange & Act
         var result = StringExtensions.RemoveDiacritics(text);

--- a/test/OrchardCore.Tests/Data/ContentItemExtensions.cs
+++ b/test/OrchardCore.Tests/Data/ContentItemExtensions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Data;
 public class ContentItemExtensions
 {
     [Fact]
-    public void GetReflectsChangesMadeByApply()
+    public void GetReflectsChangesMadeByApply_Default_Succeeds()
     {
         // arrange
         var value = "changed value";
@@ -24,7 +24,7 @@ public class ContentItemExtensions
     }
 
     [Fact]
-    public void GetReflectsChangesToFieldMadeByApply()
+    public void GetReflectsChangesToFieldMadeByApply_Default_Succeeds()
     {
         // arrange
         var value = "changed value";
@@ -43,7 +43,7 @@ public class ContentItemExtensions
     }
 
     [Fact]
-    public void WeldPreservesFieldsWhenPartWeldedAfterFields()
+    public void WeldPreservesFields_PartWeldedAfterFields_Succeeds()
     {
         // arrange
         var firstValue = "Hello";
@@ -72,7 +72,7 @@ public class ContentItemExtensions
     }
 
     [Fact]
-    public void WeldPreservesFieldsWhenPartWeldedBeforeFields()
+    public void WeldPreservesFields_PartWeldedBeforeFields_Succeeds()
     {
         // arrange
         var firstValue = "Hello";
@@ -102,7 +102,7 @@ public class ContentItemExtensions
     }
 
     [Fact]
-    public void MergeReflectsChangesToWellKnownProperties()
+    public void MergeReflectsChangesToWellKnownProperties_Default_Succeeds()
     {
         // Setup
         var contentItem = new ContentItem
@@ -123,7 +123,7 @@ public class ContentItemExtensions
     }
 
     [Fact]
-    public void MergeRemovesWellKnownPropertiesFromData()
+    public void MergeRemovesWellKnownPropertiesFromData_Default_Succeeds()
     {
         // Setup
         var contentItem = new ContentItem
@@ -144,7 +144,7 @@ public class ContentItemExtensions
     }
 
     [Fact]
-    public void MergeMaintainsDocumentId()
+    public void MergeMaintainsDocumentId_Default_Succeeds()
     {
         // Setup
         var contentItem = new ContentItem
@@ -165,7 +165,7 @@ public class ContentItemExtensions
     }
 
     [Fact]
-    public void MergeReflectsChangesToElements()
+    public void MergeReflectsChangesToElements_Default_Succeeds()
     {
         // Setup
         var value = "merged value";

--- a/test/OrchardCore.Tests/Data/ContentItemTests.cs
+++ b/test/OrchardCore.Tests/Data/ContentItemTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Data;
 public class ContentItemTests
 {
     [Fact]
-    public void NullValueDateTimeFieldSerializationTest()
+    public void NullValueDateTimeFieldSerialization_Default_Succeeds()
     {
         // Arrange
         var jsonStr = """
@@ -33,7 +33,7 @@ public class ContentItemTests
     /// and <seealso cref="TimeSpanJsonConverter"/>
     /// </summary>
     [Fact]
-    public void JsonNode_WhenParseCalled_ConvertShortTimeFormatToTimeField()
+    public void JsonNode_ParseCalledConvertShortTimeFormatToTimeField_Succeeds()
     {
         // Arrange
         var jsonStr = """
@@ -74,7 +74,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void JsonNode_WhenParseCalled_ThrowsJsonExceptionWithInvalidDateTime()
+    public void JsonNode_ParseCalledThrowsJsonExceptionWithInvalidDateTime_Succeeds()
     {
         // Arrange
         var jsonStr = """
@@ -98,7 +98,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ShouldSerializeContent()
+    public void Serialize_Content_Succeeds()
     {
         var contentItem = new ContentItem
         {
@@ -121,7 +121,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ShouldSerializeParts()
+    public void Serialize_Parts_Succeeds()
     {
         var contentItem = new ContentItem();
         var myPart = new MyPart { Text = "test" };
@@ -136,7 +136,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ShouldAlterPart()
+    public void Alter_Part_Succeeds()
     {
         var contentItem = CreateContentItemWithMyPart();
 
@@ -149,7 +149,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ContentShouldOnlyContainParts()
+    public void Content_Default_OnlyContainParts()
     {
         var contentItem = CreateContentItemWithMyPart();
 
@@ -159,7 +159,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ContentShouldStoreFields()
+    public void Content_Default_StoressFields()
     {
         var contentItem = CreateContentItemWithMyPart();
         contentItem.Alter<MyPart>(x =>
@@ -174,7 +174,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ContentShouldBeJsonPathQueryable()
+    public void Content_Default_BeJsonPathQueryable()
     {
         var contentItem = CreateContentItemWithMyPart();
         JsonNode contentItemJson = contentItem.Content;
@@ -196,7 +196,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void RemovingPropertyShouldWork()
+    public void RemovingProperty_Default_Works()
     {
         var contentItem = new ContentItem();
         contentItem.GetOrCreate<MyPart>();
@@ -211,7 +211,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ContentShouldCanCallRemoveMethod()
+    public void Content_Default_CanCallRemoveMethod()
     {
         var contentItem = CreateContentItemWithMyPart();
         contentItem.Alter<MyPart>(x => x.Text = "test");
@@ -220,7 +220,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ShouldDeserializeContentField()
+    public void Deserialize_ContentField_Succeeds()
     {
         var contentItem = CreateContentItemWithMyPart();
         contentItem.Alter<MyPart>(x => x.Text = "test");
@@ -240,7 +240,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ContentShouldStoreDateTimeFields()
+    public void Content_Default_StoressDateTimeFields()
     {
         var contentItem = new ContentItem();
         contentItem.GetOrCreate<MyPart>();
@@ -257,7 +257,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ShouldDeserializeDateTimeFields()
+    public void Deserialize_DateTimeFields_Succeeds()
     {
         var contentItem = new ContentItem();
         contentItem.GetOrCreate<MyPart>();
@@ -278,7 +278,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ContentShouldStoreUtcDateTimeFields()
+    public void Content_Default_StoressUtcDateTimeFields()
     {
         var contentItem = new ContentItem();
         contentItem.GetOrCreate<MyPart>();
@@ -295,7 +295,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ShouldDeserializeUtcDateTimeFields()
+    public void Deserialize_UtcDateTimeFields_Succeeds()
     {
         var contentItem = new ContentItem();
         contentItem.GetOrCreate<MyPart>();
@@ -316,7 +316,7 @@ public class ContentItemTests
     }
 
     [Fact]
-    public void ShouldDeserializeTextFields()
+    public void Deserialize_TextFields_Succeeds()
     {
         var contentItem = new ContentItem();
         contentItem.GetOrCreate<MyPart>();

--- a/test/OrchardCore.Tests/Data/JsonDynamicTests.cs
+++ b/test/OrchardCore.Tests/Data/JsonDynamicTests.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Tests.Data;
 public class JsonDynamicTests
 {
     [Fact]
-    public void JsonDynamicValueMustConvertToBool()
+    public void JsonDynamicValue_Default_ConvertsToBool()
     {
         var expectedValue = true;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -21,7 +21,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableBool()
+    public void JsonDynamicValue_Default_ConvertsToNullableBool()
     {
         bool? expectedValue = true;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -30,7 +30,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToByte()
+    public void JsonDynamicValue_Default_ConvertsToByte()
     {
         byte expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -39,7 +39,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableBye()
+    public void JsonDynamicValue_Default_ConvertsToNullableByte()
     {
         byte? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -48,7 +48,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToChar()
+    public void JsonDynamicValue_Default_ConvertsToChar()
     {
         var expectedValue = 'A';
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -57,7 +57,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableChar()
+    public void JsonDynamicValue_Default_ConvertsToNullableChar()
     {
         char? expectedValue = 'B';
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -66,7 +66,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToDateTime()
+    public void JsonDynamicValue_Default_ConvertsToDateTime()
     {
         var expectedValue = DateTime.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -75,7 +75,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableDateTime()
+    public void JsonDynamicValue_Default_ConvertsToNullableDateTime()
     {
         DateTime? expectedValue = DateTime.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -84,7 +84,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToDateTimeOffset()
+    public void JsonDynamicValue_Default_ConvertsToDateTimeOffset()
     {
         DateTimeOffset expectedValue = DateTimeOffset.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -93,7 +93,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullablDateTimeOffset()
+    public void JsonDynamicValue_Default_ConvertsToNullableDateTimeOffset()
     {
         DateTimeOffset? expectedValue = DateTimeOffset.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -102,7 +102,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToDecimal()
+    public void JsonDynamicValue_Default_ConvertsToDecimal()
     {
         decimal expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -111,7 +111,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableDecimal()
+    public void JsonDynamicValue_Default_ConvertsToNullableDecimal()
     {
         decimal? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -120,7 +120,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToDouble()
+    public void JsonDynamicValue_Default_ConvertsToDouble()
     {
         double expectedValue = 42.42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -129,7 +129,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableDouble()
+    public void JsonDynamicValue_Default_ConvertsToNullableDouble()
     {
         double? expectedValue = 42.42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -138,7 +138,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToGuid()
+    public void JsonDynamicValue_Default_ConvertsToGuid()
     {
         Guid expectedValue = Guid.NewGuid();
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -147,7 +147,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableGuid()
+    public void JsonDynamicValue_Default_ConvertsToNullableGuid()
     {
         Guid? expectedValue = Guid.NewGuid();
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -156,7 +156,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToInt16()
+    public void JsonDynamicValue_Default_ConvertsToInt16()
     {
         short expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -165,7 +165,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableInt16()
+    public void JsonDynamicValue_Default_ConvertsToNullableInt16()
     {
         short? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -174,7 +174,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToInt32()
+    public void JsonDynamicValue_Default_ConvertsToInt32()
     {
         int expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -183,7 +183,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableInt32()
+    public void JsonDynamicValue_Default_ConvertsToNullableInt32()
     {
         int? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -192,7 +192,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToInt64()
+    public void JsonDynamicValue_Default_ConvertsToInt64()
     {
         long expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -201,7 +201,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableInt64()
+    public void JsonDynamicValue_Default_ConvertsToNullableInt64()
     {
         long? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -210,7 +210,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToSByte()
+    public void JsonDynamicValue_Default_ConvertsToSByte()
     {
         sbyte expectedValue = -42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -219,7 +219,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableSByte()
+    public void JsonDynamicValue_Default_ConvertsToNullableSByte()
     {
         sbyte? expectedValue = -42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -228,7 +228,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToSingle()
+    public void JsonDynamicValue_Default_ConvertsToSingle()
     {
         float expectedValue = 42.42F;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -237,7 +237,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableSingle()
+    public void JsonDynamicValue_Default_ConvertsToNullableSingle()
     {
         float? expectedValue = 42.42F;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -246,7 +246,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToString()
+    public void JsonDynamicValue_Default_ConvertsToString()
     {
         var expectedValue = "A test string value";
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -255,7 +255,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToUInt16()
+    public void JsonDynamicValue_Default_ConvertsToUInt16()
     {
         ushort expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -264,7 +264,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableUInt16()
+    public void JsonDynamicValue_Default_ConvertsToNullableUInt16()
     {
         ushort? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -273,7 +273,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToUInt32()
+    public void JsonDynamicValue_Default_ConvertsToUInt32()
     {
         uint expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -282,7 +282,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableUInt32()
+    public void JsonDynamicValue_Default_ConvertsToNullableUInt32()
     {
         uint? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -291,7 +291,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToUInt64()
+    public void JsonDynamicValue_Default_ConvertsToUInt64()
     {
         ulong expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -300,7 +300,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableUInt64()
+    public void JsonDynamicValue_Default_ConvertsToNullableUInt64()
     {
         ulong? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -309,7 +309,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToByteArray()
+    public void JsonDynamicValue_Default_ConvertsToByteArray()
     {
         var expectedValue = Encoding.UTF8.GetBytes("A string in a byte array");
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -318,7 +318,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToTimeSpan()
+    public void JsonDynamicValue_Default_ConvertsToTimeSpan()
     {
         var expectedValue = TimeSpan.FromSeconds(42);
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue.ToString()));
@@ -327,7 +327,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToNullableTimeSpan()
+    public void JsonDynamicValue_Default_ConvertsToNullableTimeSpan()
     {
         var expectedValue = TimeSpan.FromSeconds(42);
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue.ToString()));
@@ -336,7 +336,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueMustConvertToUri()
+    public void JsonDynamicValue_Default_ConvertsToUri()
     {
         var expectedValue = new Uri("https://www.orchardcore.net");
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue.ToString()));
@@ -345,7 +345,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToBool()
+    public void JsonDynamicValueCanImplicitlyConvertToBool_Default_Succeeds()
     {
         var expectedValue = true;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -358,7 +358,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableBool()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableBool_Default_Succeeds()
     {
         bool? expectedValue = true;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -372,7 +372,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToByte()
+    public void JsonDynamicValueCanImplicitlyConvertToByte_Default_Succeeds()
     {
         byte expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -385,7 +385,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableByte()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableByte_Default_Succeeds()
     {
         byte? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -398,7 +398,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToChar()
+    public void JsonDynamicValueCanImplicitlyConvertToChar_Default_Succeeds()
     {
         var expectedValue = 'A';
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -411,7 +411,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableChar()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableChar_Default_Succeeds()
     {
         char? expectedValue = 'B';
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -424,7 +424,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToDateTime()
+    public void JsonDynamicValueCanImplicitlyConvertToDateTime_Default_Succeeds()
     {
         var expectedValue = DateTime.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -437,7 +437,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableDateTime()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableDateTime_Default_Succeeds()
     {
         DateTime? expectedValue = DateTime.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -450,7 +450,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToDateTimeOffset()
+    public void JsonDynamicValueCanImplicitlyConvertToDateTimeOffset_Default_Succeeds()
     {
         DateTimeOffset expectedValue = DateTimeOffset.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -463,7 +463,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullablDateTimeOffset()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableDateTimeOffset_Default_Succeeds()
     {
         DateTimeOffset? expectedValue = DateTimeOffset.UtcNow;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -476,7 +476,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToDecimal()
+    public void JsonDynamicValueCanImplicitlyConvertToDecimal_Default_Succeeds()
     {
         decimal expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -489,7 +489,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableDecimal()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableDecimal_Default_Succeeds()
     {
         decimal? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -502,7 +502,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToDouble()
+    public void JsonDynamicValueCanImplicitlyConvertToDouble_Default_Succeeds()
     {
         double expectedValue = 42.42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -515,7 +515,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableDouble()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableDouble_Default_Succeeds()
     {
         double? expectedValue = 42.42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -528,7 +528,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToGuid()
+    public void JsonDynamicValueCanImplicitlyConvertToGuid_Default_Succeeds()
     {
         Guid expectedValue = Guid.NewGuid();
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -541,7 +541,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableGuid()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableGuid_Default_Succeeds()
     {
         Guid? expectedValue = Guid.NewGuid();
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -554,7 +554,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToInt16()
+    public void JsonDynamicValueCanImplicitlyConvertToInt16_Default_Succeeds()
     {
         short expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -567,7 +567,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableInt16()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableInt16_Default_Succeeds()
     {
         short? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -580,7 +580,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToInt32()
+    public void JsonDynamicValueCanImplicitlyConvertToInt32_Default_Succeeds()
     {
         int expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -593,7 +593,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableInt32()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableInt32_Default_Succeeds()
     {
         int? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -606,7 +606,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToInt64()
+    public void JsonDynamicValueCanImplicitlyConvertToInt64_Default_Succeeds()
     {
         long expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -619,7 +619,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableInt64()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableInt64_Default_Succeeds()
     {
         long? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -632,7 +632,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToSByte()
+    public void JsonDynamicValueCanImplicitlyConvertToSByte_Default_Succeeds()
     {
         sbyte expectedValue = -42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -645,7 +645,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableSByte()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableSByte_Default_Succeeds()
     {
         sbyte? expectedValue = -42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -658,7 +658,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToSingle()
+    public void JsonDynamicValueCanImplicitlyConvertToSingle_Default_Succeeds()
     {
         float expectedValue = 42.42F;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -671,7 +671,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableSingle()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableSingle_Default_Succeeds()
     {
         float? expectedValue = 42.42F;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -684,7 +684,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToString()
+    public void JsonDynamicValueCanImplicitlyConvertToString_Default_Succeeds()
     {
         var expectedValue = "A test string value";
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -697,7 +697,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToUInt16()
+    public void JsonDynamicValueCanImplicitlyConvertToUInt16_Default_Succeeds()
     {
         ushort expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -710,7 +710,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableUInt16()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableUInt16_Default_Succeeds()
     {
         ushort? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -723,7 +723,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToUInt32()
+    public void JsonDynamicValueCanImplicitlyConvertToUInt32_Default_Succeeds()
     {
         uint expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -736,7 +736,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableUInt32()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableUInt32_Default_Succeeds()
     {
         uint? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -749,7 +749,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToUInt64()
+    public void JsonDynamicValueCanImplicitlyConvertToUInt64_Default_Succeeds()
     {
         ulong expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -762,7 +762,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableUInt64()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableUInt64_Default_Succeeds()
     {
         ulong? expectedValue = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -775,7 +775,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToByteArray()
+    public void JsonDynamicValueCanImplicitlyConvertToByteArray_Default_Succeeds()
     {
         var expectedValue = Encoding.UTF8.GetBytes("A string in a byte array");
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue));
@@ -788,7 +788,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToTimeSpan()
+    public void JsonDynamicValueCanImplicitlyConvertToTimeSpan_Default_Succeeds()
     {
         var expectedValue = TimeSpan.FromSeconds(42);
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue.ToString()));
@@ -801,7 +801,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullableTimeSpan()
+    public void JsonDynamicValueCanImplicitlyConvertToNullableTimeSpan_Default_Succeeds()
     {
         TimeSpan? expectedValue = TimeSpan.FromSeconds(42);
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue.ToString()));
@@ -814,7 +814,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToUri()
+    public void JsonDynamicValueCanImplicitlyConvertToUri_Default_Succeeds()
     {
         var expectedValue = new Uri("https://www.orchardcore.net");
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(expectedValue.ToString()));
@@ -827,7 +827,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueCanImplicitlyConvertToNullable()
+    public void JsonDynamicValueCanImplicitlyConvertToNullable_Default_Succeeds()
     {
         int? expectedValue = null;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create((int?)null));
@@ -842,7 +842,7 @@ public class JsonDynamicTests
     // Note: Direct comparison for additional types must be added later. Currently only
     // numbers, booleans and strings are supported.
     [Fact]
-    public void JsonDynamicValueIsComparableToInt32()
+    public void JsonDynamicValueIsComparableToInt32_Default_Succeeds()
     {
         int value = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(value));
@@ -861,7 +861,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueIsComparableToInt64()
+    public void JsonDynamicValueIsComparableToInt64_Default_Succeeds()
     {
         long value = 42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(value));
@@ -880,7 +880,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueIsComparableToDouble()
+    public void JsonDynamicValueIsComparableToDouble_Default_Succeeds()
     {
         double value = 42.42;
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(value));
@@ -899,7 +899,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void JsonDynamicValueIsComparableToString()
+    public void JsonDynamicValueIsComparableToString_Default_Succeeds()
     {
         var value = "A string value";
         dynamic myDynamic = new JsonDynamicValue(JsonValue.Create(value));
@@ -918,7 +918,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public void SerializingJsonDynamicValueMustWriteValueOnly()
+    public void SerializingJsonDynamicValue_Default_WritesValueOnly()
     {
         // Arrange
         var contentItem = GetContentTestData();
@@ -933,7 +933,7 @@ public class JsonDynamicTests
     }
 
     [Fact]
-    public async Task SerializingJsonDynamicValueInScripting()
+    public async Task SerializingJsonDynamicValueInScripting_Default_Succeeds()
     {
         // Arrange
         using var context = new SiteContext();

--- a/test/OrchardCore.Tests/Data/Migration/DataMigrationManagerTests.cs
+++ b/test/OrchardCore.Tests/Data/Migration/DataMigrationManagerTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Data.Migration.Tests;
 public class DataMigrationManagerTests
 {
     [Fact]
-    public async Task UpdateAsync_ShouldExecuteDataMigration_CreateMethod_OnFreshMigration()
+    public async Task UpdateAsync_CreateMethodOnFreshMigration_ExecutessDataMigration()
     {
         // Arrange
         var migration1 = new Migration1();
@@ -24,7 +24,7 @@ public class DataMigrationManagerTests
     }
 
     [Fact]
-    public async Task UpdateAsync_ShouldExecuteDataMigration_UpdateFromMethods()
+    public async Task UpdateAsync_UpdateFromMethods_ExecutessDataMigration()
     {
         // Arrange
         var migration1 = new Migration1();
@@ -40,7 +40,7 @@ public class DataMigrationManagerTests
     }
 
     [Fact]
-    public async Task UpdateAsync_ShouldExecuteStaticDataMigration_CreateAndUpdateMethods()
+    public async Task UpdateAsync_CreateAndUpdateMethods_ExecutessStaticDataMigration()
     {
         // Arrange
         StaticMigration1.Reset();
@@ -58,7 +58,7 @@ public class DataMigrationManagerTests
     }
 
     [Fact]
-    public async Task Uninstall_ShouldExecuteDataMigration_UninstallMethod()
+    public async Task Uninstall_UninstallMethod_ExecutessDataMigration()
     {
         // Arrange
         var migration1 = new Migration1();
@@ -74,7 +74,7 @@ public class DataMigrationManagerTests
     }
 
     [Fact]
-    public async Task Uninstall_ShouldExecuteStaticDataMigration_UninstallMethod()
+    public async Task Uninstall_UninstallMethod_ExecutessStaticDataMigration()
     {
         // Arrange
         StaticUninstallMigration1.Reset();

--- a/test/OrchardCore.Tests/DisplayManagement/AlternatesCollectionTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/AlternatesCollectionTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.DisplayManagement;
 public class AlternatesCollectionTests
 {
     [Fact]
-    public void Add_ShouldAddItem()
+    public void Add_Default_AddsItem()
     {
         var collection = new AlternatesCollection();
 
@@ -16,7 +16,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Add_ShouldIgnoreDuplicate()
+    public void Add_Default_IgnoresDuplicate()
     {
         var collection = new AlternatesCollection();
 
@@ -27,7 +27,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Add_ShouldPreserveInsertionOrder()
+    public void Add_Default_PreservesInsertionOrder()
     {
         var collection = new AlternatesCollection();
 
@@ -41,7 +41,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Add_ThrowsForNull()
+    public void Add_Default_ThrowsForNull()
     {
         var collection = new AlternatesCollection();
 
@@ -49,7 +49,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Remove_ShouldRemoveItem()
+    public void Remove_Default_RemovesItem()
     {
         var collection = new AlternatesCollection();
 
@@ -63,7 +63,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Remove_NonExistent_ShouldNotThrow()
+    public void Remove_NonExistent_DoesNotThrow()
     {
         var collection = new AlternatesCollection();
 
@@ -74,7 +74,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Remove_OnEmpty_ShouldNotThrow()
+    public void Remove_Empty_DoesNotThrow()
     {
         var collection = new AlternatesCollection();
 
@@ -84,7 +84,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Remove_ThrowsForNull()
+    public void Remove_Default_ThrowsForNull()
     {
         var collection = new AlternatesCollection();
 
@@ -92,7 +92,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Remove_PreservesOrderOfRemainingItems()
+    public void Remove_Default_PreservesOrderOfRemainingItems()
     {
         var collection = new AlternatesCollection();
 
@@ -107,7 +107,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Clear_ShouldRemoveAllItems()
+    public void Clear_Default_RemovesAllItems()
     {
         var collection = new AlternatesCollection();
 
@@ -120,7 +120,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Contains_ShouldFindItems()
+    public void Contains_Default_FindItems()
     {
         var collection = new AlternatesCollection();
 
@@ -131,7 +131,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Contains_ThrowsForNull()
+    public void Contains_Default_ThrowsForNull()
     {
         var collection = new AlternatesCollection();
 
@@ -139,7 +139,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Count_ShouldReflectCurrentState()
+    public void Count_Default_ReflectCurrentState()
     {
         var collection = new AlternatesCollection();
 
@@ -159,7 +159,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Last_ShouldReturnEmptyForEmptyCollection()
+    public void Last_Default_ReturnsEmptyForEmptyCollection()
     {
         var collection = new AlternatesCollection();
 
@@ -167,7 +167,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Last_ShouldReturnLastAddedItem()
+    public void Last_Default_ReturnsLastAddedItem()
     {
         var collection = new AlternatesCollection();
 
@@ -191,7 +191,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Indexer_ShouldReturnEmptyForOutOfRange()
+    public void Indexer_Default_ReturnsEmptyForOutOfRange()
     {
         var collection = new AlternatesCollection();
 
@@ -200,7 +200,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Indexer_ShouldReturnCorrectItems()
+    public void Indexer_Default_ReturnsCorrectItems()
     {
         var collection = new AlternatesCollection();
 
@@ -214,7 +214,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeArray_ShouldAddItems()
+    public void AddRangeArray_Default_AddsItems()
     {
         var collection = new AlternatesCollection();
         var array = new[] { "A", "B", "C" };
@@ -228,7 +228,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeArray_EmptyArray_ShouldBeIgnored()
+    public void AddRangeArray_EmptyArray_IsIgnored()
     {
         var collection = new AlternatesCollection();
 
@@ -238,7 +238,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeArray_WithDuplicates_ShouldIgnoreThem()
+    public void AddRangeArray_Duplicates_IgnoresThem()
     {
         var collection = new AlternatesCollection();
 
@@ -252,7 +252,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeEnumerable_ShouldAddItems()
+    public void AddRangeEnumerable_Default_AddsItems()
     {
         var collection = new AlternatesCollection();
         IEnumerable<string> items = new List<string> { "A", "B" };
@@ -265,7 +265,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeEnumerable_ShouldIgnoreDuplicates()
+    public void AddRangeEnumerable_Default_IgnoresDuplicates()
     {
         var collection = new AlternatesCollection();
 
@@ -276,7 +276,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeEnumerable_ThrowsForNull()
+    public void AddRangeEnumerable_Default_ThrowsForNull()
     {
         var collection = new AlternatesCollection();
 
@@ -284,7 +284,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeAlternatesCollection_ShouldCopyAll()
+    public void AddRangeAlternatesCollection_Default_CopyAll()
     {
         var source = new AlternatesCollection();
         source.Add("A");
@@ -301,7 +301,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeAlternatesCollection_ShouldIgnoreDuplicates()
+    public void AddRangeAlternatesCollection_Default_IgnoresDuplicates()
     {
         var source = new AlternatesCollection();
         source.Add("A");
@@ -319,7 +319,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRangeAlternatesCollection_ThrowsForNull()
+    public void AddRangeAlternatesCollection_Default_ThrowsForNull()
     {
         var collection = new AlternatesCollection();
 
@@ -327,7 +327,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Enumerate_ShouldMatchIndexer()
+    public void Enumerate_Default_MatchIndexer()
     {
         var collection = new AlternatesCollection();
 
@@ -346,7 +346,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Enumerate_EmptyCollection_ShouldYieldNothing()
+    public void Enumerate_EmptyCollection_YieldNothing()
     {
         var collection = new AlternatesCollection();
 
@@ -354,7 +354,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Enumerate_PreservesInsertionOrder()
+    public void Enumerate_Default_PreservesInsertionOrder()
     {
         var collection = new AlternatesCollection();
 
@@ -370,7 +370,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Constructor_WithParams_ShouldAddItems()
+    public void Constructor_Params_AddsItems()
     {
         var collection = new AlternatesCollection("A", "B", "C");
 
@@ -381,7 +381,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Constructor_WithDuplicateParams_ShouldDeduplicate()
+    public void Constructor_DuplicateParams_Deduplicate()
     {
         var collection = new AlternatesCollection("A", "B", "A");
 
@@ -391,7 +391,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Constructor_WithNullArray_DoesNotThrow()
+    public void Constructor_NullArray_DoesNotThrow()
     {
         var collection = new AlternatesCollection(null);
 
@@ -399,7 +399,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Empty_ShouldNotAllowMutation()
+    public void Empty_Default_NotAllowMutation()
     {
         Assert.Throws<NotSupportedException>(() => AlternatesCollection.Empty.Add("A"));
         Assert.Throws<NotSupportedException>(() => AlternatesCollection.Empty.AddRange(new[] { "A" }));
@@ -411,7 +411,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Empty_ShouldHaveZeroCount()
+    public void Empty_Default_HasZeroCount()
     {
         Assert.Equal(0, AlternatesCollection.Empty.Count);
         Assert.Equal("", AlternatesCollection.Empty.Last);
@@ -419,7 +419,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Empty_IsReadOnly()
+    public void Empty_Default_IsReadOnly()
     {
         var empty = AlternatesCollection.Empty;
 
@@ -429,7 +429,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Clear_ThenAdd_ShouldWork()
+    public void Clear_ThenAdd_Works()
     {
         var collection = new AlternatesCollection();
 
@@ -446,7 +446,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void MixedOperations_MaintainConsistency()
+    public void MixedOperations_MaintainConsistency_Succeeds()
     {
         var collection = new AlternatesCollection();
 
@@ -473,7 +473,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void Last_AfterClear_ShouldReturnEmpty()
+    public void Last_AfterClear_ReturnsEmpty()
     {
         var collection = new AlternatesCollection();
 
@@ -484,7 +484,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void DuplicatesAcrossMultipleOperations_AreIgnored()
+    public void DuplicatesAcrossMultipleOperations_Default_AreIgnored()
     {
         var collection = new AlternatesCollection();
 
@@ -526,7 +526,7 @@ public class AlternatesCollectionTests
     }
 
     [Fact]
-    public void AddRange_PreservesOrderFromSourceCollection()
+    public void AddRange_Default_PreservesOrderFromSourceCollection()
     {
         var source = new AlternatesCollection();
         source.Add("Z");

--- a/test/OrchardCore.Tests/DisplayManagement/ArgumentsInterceptorTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ArgumentsInterceptorTests.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Tests.DisplayManagement;
 public partial class ArgumentsInterceptorTests
 {
     [Fact]
-    public void From_WithSimpleAnonymousType_CreatesNamedEnumerable()
+    public void From_SimpleAnonymousType_CreatesNamedEnumerable()
     {
         // This call may be intercepted if Interceptors is enabled
         var result = DisplayManagementArguments.From(new { Name = "Test", Value = 42 });
@@ -23,7 +23,7 @@ public partial class ArgumentsInterceptorTests
     }
 
     [Fact]
-    public void From_WithComplexAnonymousType_CreatesNamedEnumerable()
+    public void From_ComplexAnonymousType_CreatesNamedEnumerable()
     {
         // This call may be intercepted if Interceptors is enabled
         var result = DisplayManagementArguments.From(new
@@ -45,7 +45,7 @@ public partial class ArgumentsInterceptorTests
     }
 
     [Fact]
-    public void From_WithMultipleSameSignature_ReusesSameType()
+    public void From_MultipleSameSignature_ReusesSameType()
     {
         // These calls should use the same generated type if intercepted
         var result1 = DisplayManagementArguments.From(new { X = 1, Y = 2 });
@@ -58,7 +58,7 @@ public partial class ArgumentsInterceptorTests
     }
 
     [Fact]
-    public void From_WithDifferentSignatures_CreatesDifferentTypes()
+    public void From_DifferentSignatures_CreatesDifferentTypes()
     {
         // These should generate different types
         var result1 = DisplayManagementArguments.From(new { Name = "Test" });
@@ -69,7 +69,7 @@ public partial class ArgumentsInterceptorTests
     }
 
     [Fact]
-    public void From_WithNullableProperties_HandlesCorrectly()
+    public void From_NullableProperties_HandlesCorrectly()
     {
         var result = DisplayManagementArguments.From(new
         {
@@ -85,7 +85,7 @@ public partial class ArgumentsInterceptorTests
     }
 
     [Fact]
-    public void From_WithNestedAnonymousType_CreatesCorrectStructure()
+    public void From_NestedAnonymousType_CreatesCorrectStructure()
     {
         // Nested anonymous types should be handled correctly, but this will still use reflection.
         var result = DisplayManagementArguments.From(new
@@ -136,7 +136,7 @@ public partial class ArgumentsNamedTypeTests
     }
 
     [Fact]
-    public void From_WithGeneratedArgumentsProvider_UsesGeneratedCode()
+    public void From_GeneratedArgumentsProvider_UsesGeneratedCode()
     {
         var result = DisplayManagementArguments.From(new ProductArguments
         {

--- a/test/OrchardCore.Tests/DisplayManagement/ArgumentsTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ArgumentsTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.DisplayManagement;
 public partial class ArgumentsTests
 {
     [Fact]
-    public void From_WithAnonymousObject_ReturnsNamedEnumerable()
+    public void From_AnonymousObject_ReturnsNamedEnumerable()
     {
         // Arrange
         var obj = new { Name = "Test", Value = 42 };
@@ -21,7 +21,7 @@ public partial class ArgumentsTests
     }
 
     [Fact]
-    public void From_WithNamedEnumerable_UsesOptimizedPath()
+    public void From_NamedEnumerable_UsesOptimizedPath()
     {
         // Arrange
         var obj = new TestNamedEnumerableProvider { Name = "Test", Value = 42 };
@@ -38,7 +38,7 @@ public partial class ArgumentsTests
     }
 
     [Fact]
-    public void From_WithDictionary_ReturnsNamedEnumerable()
+    public void From_Dictionary_ReturnsNamedEnumerable()
     {
         // Arrange
         var dict = new Dictionary<string, object>
@@ -58,7 +58,7 @@ public partial class ArgumentsTests
     }
 
     [Fact]
-    public void From_WithArraysAndNames_ReturnsNamedEnumerable()
+    public void From_ArraysAndNames_ReturnsNamedEnumerable()
     {
         // Arrange
         var values = new object[] { "Test", 42 };
@@ -75,7 +75,7 @@ public partial class ArgumentsTests
     }
 
     [Fact]
-    public void SourceGenerated_SimpleModel_ShouldUseGeneratedProvider()
+    public void SourceGenerated_SimpleModel_UsesGeneratedProvider()
     {
         // Arrange
         var model = new TestSourceGeneratedModel
@@ -100,7 +100,7 @@ public partial class ArgumentsTests
     }
 
     [Fact]
-    public void SourceGenerated_ComplexModel_ShouldIncludeAllProperties()
+    public void SourceGenerated_ComplexModel_IncludeAllProperties()
     {
         // Arrange
         var model = new TestComplexSourceGeneratedModel

--- a/test/OrchardCore.Tests/DisplayManagement/CompositeTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/CompositeTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.DisplayManagement;
 public class CompositeTests
 {
     [Fact]
-    public void CompositesShouldNotOverrideExistingMembers()
+    public void Composites_Default_NotOverrideExistingMembers()
     {
         var composite = new Animal { Color = "Pink" };
 
@@ -13,7 +13,7 @@ public class CompositeTests
     }
 
     [Fact]
-    public void CompositesShouldNotOverrideExistingMembersWhenUsedAsDynamic()
+    public void Composites_UsedAsDynamic_NotOverrideExistingMembers()
     {
         dynamic composite = new Animal();
 
@@ -22,7 +22,7 @@ public class CompositeTests
     }
 
     [Fact]
-    public void CompositesShouldAccessUnknownProperties()
+    public void Composites_Default_AccessUnknownProperties()
     {
         dynamic composite = new Animal();
 
@@ -31,7 +31,7 @@ public class CompositeTests
     }
 
     [Fact]
-    public void CompositesShouldAccessUnknownPropertiesByIndex()
+    public void Composites_Default_AccessUnknownPropertiesByIndex()
     {
         dynamic composite = new Animal();
 
@@ -40,7 +40,7 @@ public class CompositeTests
     }
 
     [Fact]
-    public void CompositesShouldAccessKnownPropertiesByIndex()
+    public void Composites_Default_AccessKnownPropertiesByIndex()
     {
         dynamic composite = new Animal();
 
@@ -49,7 +49,7 @@ public class CompositeTests
     }
 
     [Fact]
-    public void ChainProperties()
+    public void ChainProperties_Default_Succeeds()
     {
         dynamic foo = new Animal();
         foo.Bar("bar");

--- a/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
@@ -89,7 +89,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderSimpleShape()
+    public async Task RenderSimpleShape_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -112,7 +112,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderIShapeBindingResolverProvidedShapes()
+    public async Task RenderIShapeBindingResolverProvidedShapes_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -134,7 +134,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderPreCalculatedShape()
+    public async Task RenderPreCalculatedShape_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -162,7 +162,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task IShapeBindingResolverProvidedShapesDoesNotOverrideShapeDescriptor()
+    public async Task IShapeBindingResolverProvidedShapesDoesNotOverrideShapeDescriptor_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -203,7 +203,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderFallbackShape()
+    public async Task RenderFallbackShape_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -226,7 +226,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task AddAlternatesOnDisplaying()
+    public async Task AddAlternatesOnDisplaying_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -261,7 +261,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task AddAlternatesOnProcessing()
+    public async Task AddAlternatesOnProcessing_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -296,7 +296,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderAlternateShapeExplicitly()
+    public async Task RenderAlternateShapeExplicitly_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -324,7 +324,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderAlternateShapeByMostRecentlyAddedMatchingAlternate()
+    public async Task RenderAlternateShapeByMostRecentlyAddedMatchingAlternate_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -357,7 +357,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderShapeTemplateCommentsWhenEnabled()
+    public async Task RenderShapeTemplateComments_Enabled_Succeeds()
     {
         _shapeRenderingOptions.WriteShapeDebugInformation = true;
 
@@ -392,7 +392,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderAlternateShapeTemplateCommentsUseSelectedBindingWhenEnabled()
+    public async Task RenderAlternateShapeTemplateCommentsUseSelectedBinding_Enabled_Succeeds()
     {
         _shapeRenderingOptions.WriteShapeDebugInformation = true;
 
@@ -433,7 +433,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task RenderLiquidShapeTemplateCommentsWhenEnabled()
+    public async Task RenderLiquidShapeTemplateComments_Enabled_Succeeds()
     {
         _shapeRenderingOptions.WriteShapeDebugInformation = true;
 
@@ -463,7 +463,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeDescriptorDisplayingAndDisplayedAreCalled()
+    public async Task ShapeDescriptorDisplayingAndDisplayedAreCalled_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -490,7 +490,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task DisplayingEventFiresEarlyEnoughToAddAlternateShapeBindingNames()
+    public async Task DisplayingEventFiresEarlyEnoughToAddAlternateShapeBindingNames_Default_Succeeds()
     {
         var htmlDisplay = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -523,7 +523,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeTypeAndBindingNamesAreNotCaseSensitive()
+    public async Task ShapeTypeAndBindingNamesAreNotCaseSensitive_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -543,7 +543,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task IShapeDisplayEventsCalledInCorrectOrder()
+    public async Task IShapeDisplayEventsCalledInCorrectOrder_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var testEvents = _serviceProvider.GetService<IShapeDisplayEvents>() as TestDisplayEvents;
@@ -575,7 +575,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeMorphingChangesTypeAndUsesNewBinding()
+    public async Task ShapeMorphingChangesTypeAndUsesNewBinding_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -619,7 +619,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithAlternatePreservesOriginalMetadata()
+    public async Task ShapeMorphingWithAlternatePreservesOriginalMetadata_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -676,7 +676,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithConditionalLogic()
+    public async Task ShapeMorphingWithConditionalLogic_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -734,7 +734,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithAlternateBinding()
+    public async Task ShapeMorphingWithAlternateBinding_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -784,7 +784,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeMorphingChain()
+    public async Task ShapeMorphingChain_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 
@@ -863,7 +863,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithDisplayEvents()
+    public async Task ShapeMorphingWithDisplayEvents_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var testEvents = _serviceProvider.GetService<IShapeDisplayEvents>() as TestDisplayEvents;
@@ -920,7 +920,7 @@ public class DefaultDisplayManagerTests
     }
 
     [Fact]
-    public async Task ShapeMorphingFailsWhenTargetShapeNotFound()
+    public async Task ShapeMorphingFails_TargetShapeNotFound_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
 

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/BasicShapeTemplateHarvesterTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/BasicShapeTemplateHarvesterTests.cs
@@ -13,44 +13,44 @@ public class BasicShapeTemplateHarvesterTests
     }
 
     [Fact]
-    public void BasicFileNamesComeBackAsShapes()
+    public void BasicFileNamesComeBackAsShapes_Default_Succeeds()
     {
         VerifyShapeType("Views", "Hello", "Hello");
         VerifyShapeType("Views", "World", "World");
     }
 
     [Fact]
-    public void DashBecomesBreakingSeperator()
+    public void DashBecomesBreakingSeperator_Default_Succeeds()
     {
         VerifyShapeType("Views", "Hello-World", "Hello__World");
     }
 
     [Fact]
-    public void DotBecomesNonBreakingSeperator()
+    public void DotBecomesNonBreakingSeperator_Default_Succeeds()
     {
         VerifyShapeType("Views", "Hello.World", "Hello_World");
     }
 
     [Fact]
-    public void DefaultItemsContentTemplate()
+    public void DefaultItemsContentTemplate_Default_Succeeds()
     {
         VerifyShapeType("Views/Items", "Content", "Content");
     }
 
     [Fact]
-    public void ImplicitSpecializationOfItemsContentTemplate()
+    public void ImplicitSpecializationOfItemsContentTemplate_Default_Succeeds()
     {
         VerifyShapeType("Views/Items", "MyType", "MyType");
     }
 
     [Fact]
-    public void ExplicitSpecializationOfItemsContentTemplate()
+    public void ExplicitSpecializationOfItemsContentTemplate_Default_Succeeds()
     {
         VerifyShapeType("Views/Items", "Content-MyType", "Content__MyType");
     }
 
     [Fact]
-    public void ContentItemDisplayTypes()
+    public void ContentItemDisplayTypes_Default_Succeeds()
     {
         VerifyShapeType("Views/Items", "Content", "Content");
         VerifyShapeType("Views/Items", "Content.Summary", "Content_Summary");
@@ -58,7 +58,7 @@ public class BasicShapeTemplateHarvesterTests
     }
 
     [Fact]
-    public void ExplicitSpecializationMixedWithDisplayTypes()
+    public void ExplicitSpecializationMixedWithDisplayTypes_Default_Succeeds()
     {
         VerifyShapeType("Views/Items", "Content-MyType", "Content__MyType");
         VerifyShapeType("Views/Items", "Content-MyType.Summary", "Content_Summary__MyType");
@@ -66,25 +66,25 @@ public class BasicShapeTemplateHarvesterTests
     }
 
     [Fact]
-    public void DefaultItemsContentTemplate2()
+    public void DefaultItemsContentTemplate2_Default_Succeeds()
     {
         VerifyShapeType("Views", "Content", "Content");
     }
 
     [Fact]
-    public void ImplicitSpecializationOfItemsContentTemplate2()
+    public void ImplicitSpecializationOfItemsContentTemplate2_Default_Succeeds()
     {
         VerifyShapeType("Views", "MyType", "MyType");
     }
 
     [Fact]
-    public void ExplicitSpecializationOfItemsContentTemplate2()
+    public void ExplicitSpecializationOfItemsContentTemplate2_Default_Succeeds()
     {
         VerifyShapeType("Views", "Content-MyType", "Content__MyType");
     }
 
     [Fact]
-    public void ContentItemDisplayTypes2()
+    public void ContentItemDisplayTypes2_Default_Succeeds()
     {
         VerifyShapeType("Views", "Content", "Content");
         VerifyShapeType("Views", "Content.Summary", "Content_Summary");
@@ -92,7 +92,7 @@ public class BasicShapeTemplateHarvesterTests
     }
 
     [Fact]
-    public void ExplicitSpecializationMixedWithDisplayTypes2()
+    public void ExplicitSpecializationMixedWithDisplayTypes2_Default_Succeeds()
     {
         VerifyShapeType("Views", "Content-MyType", "Content__MyType");
         VerifyShapeType("Views", "Content-MyType.Summary", "Content_Summary__MyType");
@@ -100,7 +100,7 @@ public class BasicShapeTemplateHarvesterTests
     }
 
     [Fact]
-    public void MultipleDotsAreNormalizedToUnderscore()
+    public void MultipleDotsAreNormalizedToUnderscore_Default_Succeeds()
     {
         VerifyShapeType("Views/Parts", "Common.Body", "Parts_Common_Body");
         VerifyShapeType("Views/Parts", "Common.Body.Summary", "Parts_Common_Body_Summary");
@@ -108,7 +108,7 @@ public class BasicShapeTemplateHarvesterTests
     }
 
     [Fact]
-    public void MultipleDotsAreNormalizedToUnderscore2()
+    public void MultipleDotsAreNormalizedToUnderscore2_Default_Succeeds()
     {
         VerifyShapeType("Views", "Parts.Common.Body", "Parts_Common_Body");
         VerifyShapeType("Views", "Parts.Common.Body.Summary", "Parts_Common_Body_Summary");
@@ -116,14 +116,14 @@ public class BasicShapeTemplateHarvesterTests
     }
 
     [Fact]
-    public void FieldNamesMayBeInSubfolderOrPrefixed()
+    public void FieldNamesMayBeInSubfolderOrPrefixed_Default_Succeeds()
     {
         VerifyShapeType("Views/Fields", "Common.Text", "Fields_Common_Text");
         VerifyShapeType("Views", "Fields.Common.Text", "Fields_Common_Text");
     }
 
     [Fact]
-    public void FieldNamesMayHaveLongOrShortAlternates()
+    public void FieldNamesMayHaveLongOrShortAlternates_Default_Succeeds()
     {
         VerifyShapeType("Views/Fields", "Common.Text-FirstName", "Fields_Common_Text__FirstName");
         VerifyShapeType("Views/Fields", "Common.Text-FirstName.SpecialCase", "Fields_Common_Text_SpecialCase__FirstName");

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerBindingsTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerBindingsTests.cs
@@ -133,7 +133,7 @@ public class DefaultShapeTableManagerBindingsTests : IDisposable
     }
 
     [Fact]
-    public async Task OnlyFirstBindingPerBindingSourceIsUsed()
+    public async Task OnlyFirstBindingPerBindingSourceIsUsed_Default_Succeeds()
     {
         var manager = _sp.GetRequiredService<IShapeTableManager>();
         var table = await manager.GetShapeTableAsync(themeId: null);

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerTests.cs
@@ -315,14 +315,14 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public void ManagerCanBeResolved()
+    public void ManagerCanBeResolved_Default_Succeeds()
     {
         var manager = _serviceProvider.GetService<IShapeTableManager>();
         Assert.NotNull(manager);
     }
 
     [Fact]
-    public async Task DefaultShapeTableIsReturnedForNullOrEmpty()
+    public async Task DefaultShapeTableIsReturnedForNullOrEmpty_Default_Succeeds()
     {
         var manager = _serviceProvider.GetService<IShapeTableManager>();
         var shapeTable1 = await manager.GetShapeTableAsync(null);
@@ -332,7 +332,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task CallbackAlterationsContributeToDescriptor()
+    public async Task CallbackAlterationsContributeToDescriptor_Default_Succeeds()
     {
         Func<ShapeCreatingContext, Task> cb1 = x => { return Task.CompletedTask; };
         Func<ShapeCreatedContext, Task> cb2 = x => { return Task.CompletedTask; };
@@ -357,7 +357,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task DefaultPlacementIsReturnedByDefault()
+    public async Task DefaultPlacementIsReturnedByDefault_Default_Succeeds()
     {
         var manager = _serviceProvider.GetService<IShapeTableManager>();
 
@@ -368,7 +368,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task DescribedPlacementIsReturnedIfNotNull()
+    public async Task DescribedPlacementIsReturnedIfNotNull_Default_Succeeds()
     {
         var shapeDetail = new ShapePlacementContext("Foo", "Detail", string.Empty, null);
         var shapeSummary = new ShapePlacementContext("Foo", "Summary", string.Empty, null);
@@ -398,7 +398,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task TwoArgumentVariationDoesSameThing()
+    public async Task TwoArgumentVariationDoesSameThing_Default_Succeeds()
     {
         var shapeDetail = new ShapePlacementContext("Foo", "Detail", string.Empty, null);
         var shapeSummary = new ShapePlacementContext("Foo", "Summary", string.Empty, null);
@@ -429,7 +429,7 @@ public class DefaultShapeTableManagerTests : IDisposable
 
     // "Path not supported yet"
     [Fact]
-    internal async Task PathConstraintShouldMatch()
+    internal async Task PathConstraint_Default_Match()
     {
         // all path have a trailing / as per the current implementation
         // todo: (sebros) find a way to 'use' the current implementation in DefaultContentDisplay.BindPlacement instead of emulating it
@@ -472,7 +472,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task OnlyShapesFromTheGivenThemeAreProvided()
+    public async Task OnlyShapesFromTheGivenThemeAreProvided_Default_Succeeds()
     {
         _serviceProvider.GetService<TestShapeProvider>();
         var manager = _serviceProvider.GetService<IShapeTableManager>();
@@ -483,7 +483,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task ShapesFromTheBaseThemeAreProvided()
+    public async Task ShapesFromTheBaseThemeAreProvided_Default_Succeeds()
     {
         _serviceProvider.GetService<TestShapeProvider>();
         var manager = _serviceProvider.GetService<IShapeTableManager>();
@@ -494,7 +494,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task DerivedThemesCanOverrideBaseThemeShapeBindings()
+    public async Task DerivedThemesCanOverrideBaseThemeShapeBindings_Default_Succeeds()
     {
         _serviceProvider.GetService<TestShapeProvider>();
         var manager = _serviceProvider.GetService<IShapeTableManager>();
@@ -510,7 +510,7 @@ public class DefaultShapeTableManagerTests : IDisposable
     /// Related to PR: https://github.com/OrchardCMS/OrchardCore/pull/18502
     /// </summary>
     [Fact]
-    public async Task ShapeTableProviderRegisteredInMultipleFeaturesIsProcessedForEachFeature()
+    public async Task ShapeTableProviderRegisteredInMultipleFeaturesIsProcessedForEachFeature_Default_Succeeds()
     {
         // Arrange
         IServiceCollection serviceCollection = new ServiceCollection();

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/DefaultShapeTableManagerTests.cs
@@ -359,9 +359,14 @@ public class DefaultShapeTableManagerTests : IDisposable
     [Fact]
     public async Task DefaultPlacementIsReturnedByDefault_Default_Succeeds()
     {
+        var shapeType = nameof(DefaultPlacementIsReturnedByDefault_Default_Succeeds);
+
+        _serviceProvider.GetService<TestShapeProvider>().Discover =
+            builder => builder.Describe(shapeType).From(TestFeature());
+
         var manager = _serviceProvider.GetService<IShapeTableManager>();
 
-        var hello = (await manager.GetShapeTableAsync(null)).Descriptors["Hello"];
+        var hello = (await manager.GetShapeTableAsync(null)).Descriptors[shapeType];
         hello.DefaultPlacement = "Header:5";
         var result = hello.Placement(null);
         Assert.Equal("Header:5", result.Location);
@@ -451,13 +456,14 @@ public class DefaultShapeTableManagerTests : IDisposable
             var path = rule.Item1;
             var context = rule.Item2;
             var match = rule.Item3;
+            var shapeType = nameof(PathConstraint_Default_Match);
 
             _serviceProvider.GetService<TestShapeProvider>().Discover =
-                builder => builder.Describe("Hello").From(TestFeature())
+                builder => builder.Describe(shapeType).From(TestFeature())
                                .Placement(ctx => true, new PlacementInfo("Match"));
 
             var manager = _serviceProvider.GetService<IShapeTableManager>();
-            var hello = (await manager.GetShapeTableAsync(null)).Descriptors["Hello"];
+            var hello = (await manager.GetShapeTableAsync(null)).Descriptors[shapeType];
             //var result = hello.Placement(new ShapePlacementContext { Path = context });
 
             //if (match)

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/GroupingMetadataTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/GroupingMetadataTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.DisplayManagement.Descriptors;
 public class GroupingMetadataTests
 {
     [Fact]
-    public void Empty_ShouldReturnDefaultInstance()
+    public void Empty_Default_ReturnsDefaultInstance()
     {
         var empty = GroupingMetadata.Empty;
 
@@ -18,7 +18,7 @@ public class GroupingMetadataTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void ParseTabOrCard_WithNullOrEmpty_ReturnsEmpty(string value)
+    public void ParseTabOrCard_NullOrEmpty_ReturnsEmpty(string value)
     {
         var result = GroupingMetadata.ParseTabOrCard(value);
 
@@ -30,7 +30,7 @@ public class GroupingMetadataTests
     [InlineData("Settings", "Settings", null)]
     [InlineData("Content", "Content", null)]
     [InlineData("Tab1", "Tab1", null)]
-    public void ParseTabOrCard_WithNameOnly_ReturnsCorrectName(string input, string expectedName, string expectedPosition)
+    public void ParseTabOrCard_NameOnly_ReturnsCorrectName(string input, string expectedName, string expectedPosition)
     {
         var result = GroupingMetadata.ParseTabOrCard(input);
 
@@ -46,7 +46,7 @@ public class GroupingMetadataTests
     [InlineData("Tab1;2.5", "Tab1", "2.5")]
     [InlineData("Details;before", "Details", "before")]
     [InlineData("Other;after", "Other", "after")]
-    public void ParseTabOrCard_WithPosition_ReturnsCorrectValues(string input, string expectedName, string expectedPosition)
+    public void ParseTabOrCard_Position_ReturnsCorrectValues(string input, string expectedName, string expectedPosition)
     {
         var result = GroupingMetadata.ParseTabOrCard(input);
 
@@ -59,7 +59,7 @@ public class GroupingMetadataTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void ParseColumn_WithNullOrEmpty_ReturnsEmpty(string value)
+    public void ParseColumn_NullOrEmpty_ReturnsEmpty(string value)
     {
         var result = GroupingMetadata.ParseColumn(value);
 
@@ -71,7 +71,7 @@ public class GroupingMetadataTests
     [InlineData("Left", "Left", null, null)]
     [InlineData("Right", "Right", null, null)]
     [InlineData("Content", "Content", null, null)]
-    public void ParseColumn_WithNameOnly_ReturnsCorrectName(string input, string expectedName, string expectedPosition, string expectedWidth)
+    public void ParseColumn_NameOnly_ReturnsCorrectName(string input, string expectedName, string expectedPosition, string expectedWidth)
     {
         var result = GroupingMetadata.ParseColumn(input);
 
@@ -85,7 +85,7 @@ public class GroupingMetadataTests
     [InlineData("Left;1", "Left", "1", null)]
     [InlineData("Content;5.1", "Content", "5.1", null)]
     [InlineData("Right;before", "Right", "before", null)]
-    public void ParseColumn_WithPositionOnly_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
+    public void ParseColumn_PositionOnly_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
     {
         var result = GroupingMetadata.ParseColumn(input);
 
@@ -99,7 +99,7 @@ public class GroupingMetadataTests
     [InlineData("Left_9", "Left", null, "9")]
     [InlineData("Content_3", "Content", null, "3")]
     [InlineData("Right_lg-6", "Right", null, "lg-6")]
-    public void ParseColumn_WithWidthOnly_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
+    public void ParseColumn_WidthOnly_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
     {
         var result = GroupingMetadata.ParseColumn(input);
 
@@ -113,7 +113,7 @@ public class GroupingMetadataTests
     [InlineData("Left_9;1", "Left", "1", "9")]
     [InlineData("Content_3;5", "Content", "5", "3")]
     [InlineData("Right_lg-6;2.5", "Right", "2.5", "lg-6")]
-    public void ParseColumn_WithWidthThenPosition_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
+    public void ParseColumn_WidthThenPosition_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
     {
         var result = GroupingMetadata.ParseColumn(input);
 
@@ -127,7 +127,7 @@ public class GroupingMetadataTests
     [InlineData("Left;1_9", "Left", "1", "9")]
     [InlineData("Content;5_3", "Content", "5", "3")]
     [InlineData("Right;2.5_lg-6", "Right", "2.5", "lg-6")]
-    public void ParseColumn_WithPositionThenWidth_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
+    public void ParseColumn_PositionThenWidth_ReturnsCorrectValues(string input, string expectedName, string expectedPosition, string expectedWidth)
     {
         var result = GroupingMetadata.ParseColumn(input);
 
@@ -230,7 +230,7 @@ public class GroupingMetadataTests
     [Theory]
     [InlineData("Settings", "Settings")]
     [InlineData("Settings;1", "Settings;1")]
-    public void ToLocationString_ReturnsCorrectFormat(string input, string expected)
+    public void ToLocationString_Default_ReturnsCorrectFormat(string input, string expected)
     {
         var result = GroupingMetadata.ParseTabOrCard(input);
         Assert.Equal(expected, result.ToString());

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/LocationParserTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/LocationParserTests.cs
@@ -20,7 +20,7 @@ public class LocationParserTests
     [InlineData("/Content:5@Group1#Tab1")]
     [InlineData("/Content:5@Group1#Tab1%Card1")]
     [InlineData("/Content:5@Group1#Tab1%Card1|Col1")]
-    public void ZoneShouldBeParsed(string location)
+    public void Zone_Default_BeParsed(string location)
     {
         Assert.Equal("Content", new PlacementInfo(location).Zones.FirstOrDefault());
     }
@@ -55,7 +55,7 @@ public class LocationParserTests
     [InlineData("/Content:5@Group1#Tab1%Card1", "5")]
     [InlineData("/Content:5@Group1#Tab1|Col1", "5")]
     [InlineData("/Content:5@Group1#Tab1%Card1|Col1", "5")]
-    public void PositionShouldBeParsed(string location, string expectedPosition)
+    public void Position_Default_BeParsed(string location, string expectedPosition)
     {
         Assert.Equal(expectedPosition, new PlacementInfo(location).Position);
     }
@@ -91,7 +91,7 @@ public class LocationParserTests
     [InlineData("/Content:5@Group1#Tab1%Card1", true)]
     [InlineData("/Content:5@Group1#Tab1|Col1", true)]
     [InlineData("/Content:5@Group1#Tab1|Card1%Col1", true)]
-    public void LayoutZoneShouldBeParsed(string location, bool expectedIsLayoutZone)
+    public void LayoutZone_Default_BeParsed(string location, bool expectedIsLayoutZone)
     {
         Assert.Equal(expectedIsLayoutZone, new PlacementInfo(location).IsLayoutZone());
     }
@@ -136,7 +136,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1@Group1%Card1", "Tab1")]
     [InlineData("/Content:5#Tab1@Group1|Col1", "Tab1")]
     [InlineData("/Content:5#Tab1@Group1%Card1|Col1", "Tab1")]
-    public void TabShouldBeParsed(string location, string expectedTab)
+    public void Tab_Default_BeParsed(string location, string expectedTab)
     {
         var info = new PlacementInfo(location);
         var actualTab = info.Tab.HasValue ? info.Tab.Name : "";
@@ -152,7 +152,7 @@ public class LocationParserTests
     [InlineData("Content:after", "after")]
     [InlineData("Content:before#Tab1", "before")]
     [InlineData("Content:after#Tab1", "after")]
-    public void PositionShouldSupportSpecialAndDotFormats(string location, string expectedPosition)
+    public void Position_Default_SupportSpecialAndDotFormats(string location, string expectedPosition)
     {
         Assert.Equal(expectedPosition, new PlacementInfo(location).Position);
     }
@@ -163,7 +163,7 @@ public class LocationParserTests
     [InlineData("Content", "5", "5")]
     [InlineData("Content", "0", "0")]
     [InlineData("Content:3", "5", "3")]
-    public void Position_ShouldUseDefaultPosition_WhenNoExplicitPosition(string location, string defaultPosition, string expectedPosition)
+    public void Position_NoExplicitPosition_UsesDefaultPosition(string location, string defaultPosition, string expectedPosition)
     {
         // When Location has no ':' delimiter, Position returns DefaultPosition ?? "".
         // When Location has a ':' delimiter, the explicit position takes precedence.
@@ -215,7 +215,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1@Group1%Card1", "Group1")]
     [InlineData("/Content:5#Tab1@Group1|Col1", "Group1")]
     [InlineData("/Content:5#Tab1@Group1%Card1|Col1", "Group1")]
-    public void GroupShouldBeParsed(string location, string expectedGroup)
+    public void Group_Default_BeParsed(string location, string expectedGroup)
     {
         Assert.Equal(expectedGroup, new PlacementInfo(location).Group);
     }
@@ -263,7 +263,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1%Card1|Col1", "Col1")]
     [InlineData("/Content:5#Tab1@Group1|Col1", "Col1")]
     [InlineData("/Content:5#Tab1%Card1@Group1|Col1", "Col1")]
-    public void ColumnShouldBeParsed(string location, string expectedColumn)
+    public void Column_Default_BeParsed(string location, string expectedColumn)
     {
         var info = new PlacementInfo(location);
         var actualColumn = info.Column.HasValue ? info.Column.Name : null;
@@ -307,7 +307,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1%Card1|Col1", "Card1")]
     [InlineData("/Content:5@Group1%Card1|Col1", "Card1")]
     [InlineData("/Content:5#Tab1@Group1%Card1|Col1", "Card1")]
-    public void CardNameShouldBeParsed(string location, string expectedCardName)
+    public void CardName_Default_BeParsed(string location, string expectedCardName)
     {
         var info = new PlacementInfo(location);
         var actualCardName = info.Card.HasValue ? info.Card.Name : null;
@@ -335,7 +335,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1@Group1%Card1;1", "1")]
     [InlineData("/Content:5%Card1;3|Col1", "3")]
     [InlineData("/Content:5#Tab1%Card1;2|Col1", "2")]
-    public void CardPositionShouldBeParsed(string location, string expectedCardPosition)
+    public void CardPosition_Default_BeParsed(string location, string expectedCardPosition)
     {
         var info = new PlacementInfo(location);
         var actualCardPosition = info.Card.HasValue ? info.Card.Position : null;
@@ -363,7 +363,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1;4|Col1", "4")]
     [InlineData("/Content:5#Tab1;5@Group1%Card1", "5")]
     [InlineData("/Content:5#Tab1;6@Group1%Card1|Col1", "6")]
-    public void TabPositionShouldBeParsed(string location, string expectedTabPosition)
+    public void TabPosition_Default_BeParsed(string location, string expectedTabPosition)
     {
         var info = new PlacementInfo(location);
         var actualTabPosition = info.Tab.HasValue ? info.Tab.Position : null;
@@ -397,7 +397,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1%Card1|Col1_6", "6")]
     [InlineData("/Content:5@Group1%Card1|Col1_3", "3")]
     [InlineData("/Content:5#Tab1@Group1%Card1|Col1_9", "9")]
-    public void ColumnWidthShouldBeParsed(string location, string expectedColumnWidth)
+    public void ColumnWidth_Default_BeParsed(string location, string expectedColumnWidth)
     {
         var info = new PlacementInfo(location);
         var actualColumnWidth = info.Column.HasValue ? info.Column.Width : null;
@@ -433,7 +433,7 @@ public class LocationParserTests
     [InlineData("/Content:5#Tab1%Card1|Col1;7", "7")]
     [InlineData("/Content:5@Group1%Card1|Col1;8", "8")]
     [InlineData("/Content:5#Tab1@Group1%Card1|Col1;9", "9")]
-    public void ColumnPositionShouldBeParsed(string location, string expectedColumnPosition)
+    public void ColumnPosition_Default_BeParsed(string location, string expectedColumnPosition)
     {
         var info = new PlacementInfo(location);
         var actualColumnPosition = info.Column.HasValue ? info.Column.Position : null;
@@ -451,7 +451,7 @@ public class LocationParserTests
     [InlineData("/Content:5|Right;3_md-4", "Right", "md-4", "3")]
     [InlineData("Content:5#Tab1@Group1%Card1|Col1_9;2", "Col1", "9", "2")]
     [InlineData("/Content:5#Tab1@Group1%Card1|Col1_9;2", "Col1", "9", "2")]
-    public void ColumnWidthAndPositionShouldBeParsed(string location, string expectedName, string expectedWidth, string expectedPosition)
+    public void ColumnWidthAndPosition_Default_BeParsed(string location, string expectedName, string expectedWidth, string expectedPosition)
     {
         var info = new PlacementInfo(location);
         Assert.True(info.Column.HasValue);
@@ -478,7 +478,7 @@ public class LocationParserTests
     [InlineData("/Content.Metadata:5", new[] { "Content", "Metadata" })]
     [InlineData("/Content.Metadata.Details:5", new[] { "Content", "Metadata", "Details" })]
     [InlineData("/Content.Metadata:5#Tab1@Group1%Card1|Col1", new[] { "Content", "Metadata" })]
-    public void MultipleZonesShouldBeParsed(string location, string[] expectedZones)
+    public void MultipleZones_Default_BeParsed(string location, string[] expectedZones)
     {
         var info = new PlacementInfo(location);
         Assert.Equal(expectedZones, info.Zones);
@@ -488,7 +488,7 @@ public class LocationParserTests
     [InlineData("Content:5#Tab1;2@Group1%Card1;3|Col1_9;4", "Content", "5", "Tab1", "2", "Group1", "Card1", "3", "Col1", "9", "4")]
     [InlineData("/Content:5#Tab1;2@Group1%Card1;3|Col1_9;4", "Content", "5", "Tab1", "2", "Group1", "Card1", "3", "Col1", "9", "4")]
     [InlineData("Content.Metadata:10#Settings;1@Advanced%Options;5|Left_lg-6;2", "Content", "10", "Settings", "1", "Advanced", "Options", "5", "Left", "lg-6", "2")]
-    public void CompleteLocationStringShouldBeParsed(
+    public void CompleteLocationString_Default_BeParsed(
         string location,
         string expectedZone,
         string expectedPosition,
@@ -517,7 +517,7 @@ public class LocationParserTests
 
     [Theory]
     [InlineData("-")]
-    public void HiddenLocationShouldBeDetected(string location)
+    public void HiddenLocation_Default_BeDetected(string location)
     {
         var info = new PlacementInfo(location);
         Assert.True(info.IsHidden());
@@ -526,7 +526,7 @@ public class LocationParserTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void EmptyOrNullLocationShouldBeHidden(string location)
+    public void EmptyOrNullLocation_Default_BeHidden(string location)
     {
         var info = new PlacementInfo(location);
         Assert.True(info.IsHidden());
@@ -534,7 +534,7 @@ public class LocationParserTests
     }
 
     [Fact]
-    public void FromLocation_ShouldReturnHiddenInstance_ForHiddenLocation()
+    public void FromLocation_HiddenLocation_ReturnsHiddenInstance()
     {
         var result = PlacementInfo.FromLocation("-");
 
@@ -542,14 +542,14 @@ public class LocationParserTests
     }
 
     [Fact]
-    public void FromLocation_ShouldReturnNull_ForNullOrEmptyLocation()
+    public void FromLocation_NullOrEmptyLocation_ReturnsNull()
     {
         Assert.Null(PlacementInfo.FromLocation(null));
         Assert.Null(PlacementInfo.FromLocation(""));
     }
 
     [Fact]
-    public void FromLocation_ShouldReturnCachedInstance_ForSameLocation()
+    public void FromLocation_SameLocation_ReturnsCachedInstance()
     {
         var first = PlacementInfo.FromLocation("Content:5#Tab1");
         var second = PlacementInfo.FromLocation("Content:5#Tab1");
@@ -558,7 +558,7 @@ public class LocationParserTests
     }
 
     [Fact]
-    public void WithSource_ShouldReturnSameInstance_WhenSourceUnchanged()
+    public void WithSource_SourceUnchanged_ReturnsSameInstance()
     {
         var placement = new PlacementInfo("Content:5", source: "TestSource");
 
@@ -568,7 +568,7 @@ public class LocationParserTests
     }
 
     [Fact]
-    public void WithSource_ShouldReturnNewInstance_WhenSourceChanged()
+    public void WithSource_SourceChanged_ReturnsNewInstance()
     {
         var placement = new PlacementInfo("Content:5", source: "OldSource");
 
@@ -581,7 +581,7 @@ public class LocationParserTests
     }
 
     [Fact]
-    public void ToString_ShouldReturnLocation()
+    public void ToString_Default_ReturnsLocation()
     {
         var placement = new PlacementInfo("Content:5#Tab1");
 
@@ -589,7 +589,7 @@ public class LocationParserTests
     }
 
     [Fact]
-    public void ToString_ShouldReturnEmpty_ForEmptyPlacement()
+    public void ToString_EmptyPlacement_ReturnsEmpty()
     {
         var placement = new PlacementInfo();
 

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/PlacementInfoExtensionsCombineTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/PlacementInfoExtensionsCombineTests.cs
@@ -7,7 +7,7 @@ public class PlacementInfoExtensionsCombineTests
     #region Combine - Null Handling
 
     [Fact]
-    public void Combine_BothNull_ShouldReturnNull()
+    public void Combine_BothNull_ReturnsNull()
     {
         // Act
         PlacementInfo first = null;
@@ -18,7 +18,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_FirstNull_ShouldReturnSecond()
+    public void Combine_FirstNull_ReturnsSecond()
     {
         // Arrange
         var second = new PlacementInfo("Content:1");
@@ -31,7 +31,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_SecondNull_ShouldReturnFirst()
+    public void Combine_SecondNull_ReturnsFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content:1");
@@ -48,7 +48,7 @@ public class PlacementInfoExtensionsCombineTests
     #region Combine - Location Overriding (Last Non-Empty Wins)
 
     [Fact]
-    public void Combine_SecondHasLocation_ShouldOverrideFirst()
+    public void Combine_SecondHasLocation_OverrideFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content:1");
@@ -62,7 +62,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_SecondHasEmptyLocation_ShouldKeepFirst()
+    public void Combine_SecondHasEmptyLocation_KeepsFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content:1");
@@ -76,7 +76,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_SecondHasNullLocation_ShouldKeepFirst()
+    public void Combine_SecondHasNullLocation_KeepsFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content:1");
@@ -115,7 +115,7 @@ public class PlacementInfoExtensionsCombineTests
     /// This proves that only providers with explicit locations can override.
     /// </summary>
     [Fact]
-    public void Combine_LaterProviderEmptyLocation_ShouldNotOverride()
+    public void Combine_LaterProviderEmptyLocation_NotOverride()
     {
         // Arrange
         var providerA = new PlacementInfo("Content:1");
@@ -136,7 +136,7 @@ public class PlacementInfoExtensionsCombineTests
     #region Combine - ShapeType Overriding
 
     [Fact]
-    public void Combine_SecondHasShapeType_ShouldOverrideFirst()
+    public void Combine_SecondHasShapeType_OverrideFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content", shapeType: "TypeA");
@@ -150,7 +150,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_SecondHasEmptyShapeType_ShouldKeepFirst()
+    public void Combine_SecondHasEmptyShapeType_KeepsFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content", shapeType: "TypeA");
@@ -168,7 +168,7 @@ public class PlacementInfoExtensionsCombineTests
     #region Combine - DefaultPosition Overriding
 
     [Fact]
-    public void Combine_SecondHasDefaultPosition_ShouldOverrideFirst()
+    public void Combine_SecondHasDefaultPosition_OverrideFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content", defaultPosition: "1");
@@ -182,7 +182,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_SecondHasEmptyDefaultPosition_ShouldKeepFirst()
+    public void Combine_SecondHasEmptyDefaultPosition_KeepsFirst()
     {
         // Arrange
         var first = new PlacementInfo("Content", defaultPosition: "1");
@@ -200,7 +200,7 @@ public class PlacementInfoExtensionsCombineTests
     #region Combine - Source Tracking
 
     [Fact]
-    public void Combine_ShouldConcatenateSources()
+    public void Combine_Default_ConcatenateSources()
     {
         // Arrange
         var first = new PlacementInfo("Content", source: "ModuleA");
@@ -214,7 +214,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_MultipleProviders_ShouldTrackAllSources()
+    public void Combine_MultipleProviders_TrackAllSources()
     {
         // Arrange
         var providerA = new PlacementInfo("Content:1", source: "ProjectA");
@@ -235,7 +235,7 @@ public class PlacementInfoExtensionsCombineTests
     #region Combine - Alternates and Wrappers Merging
 
     [Fact]
-    public void Combine_ShouldMergeAlternates()
+    public void Combine_Default_MergeAlternates()
     {
         // Arrange
         var first = new PlacementInfo("Content", alternates: ["Alt1"]);
@@ -250,7 +250,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_ShouldMergeWrappers()
+    public void Combine_Default_MergeWrappers()
     {
         // Arrange
         var first = new PlacementInfo("Content", wrappers: ["Wrapper1"]);
@@ -265,7 +265,7 @@ public class PlacementInfoExtensionsCombineTests
     }
 
     [Fact]
-    public void Combine_NullAlternates_ShouldHandleGracefully()
+    public void Combine_NullAlternates_HandlesGracefully()
     {
         // Arrange
         var first = new PlacementInfo("Content", alternates: null);
@@ -283,7 +283,7 @@ public class PlacementInfoExtensionsCombineTests
     #region Combine - Creates New Instance
 
     [Fact]
-    public void Combine_ShouldReturnNewInstance_WhenBothNonNull()
+    public void Combine_BothNonNull_ReturnsNewInstance()
     {
         // Arrange
         var first = new PlacementInfo("Content:1");

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/PlacementLocationBuilderTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/PlacementLocationBuilderTests.cs
@@ -7,7 +7,7 @@ public class PlacementLocationBuilderTests
     #region Zone Tests
 
     [Fact]
-    public void Build_ZoneOnly_ShouldReturnZoneName()
+    public void Build_ZoneOnly_ReturnsZoneName()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -17,7 +17,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZoneWithDotNotation_ShouldReturnDottedZone()
+    public void Build_ZoneWithDotNotation_ReturnsDottedZone()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content.Metadata")
@@ -27,20 +27,20 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_NoZone_ShouldThrowInvalidOperationException()
+    public void Build_NoZone_ThrowsInvalidOperationException()
     {
         var builder = new PlacementLocationBuilder();
         Assert.Throws<InvalidOperationException>(() => builder.ToString());
     }
 
     [Fact]
-    public void Build_NullZone_ShouldThrowArgumentException()
+    public void Build_NullZone_ThrowsArgumentException()
     {
         Assert.ThrowsAny<ArgumentException>(() => new PlacementLocationBuilder().Zone(null));
     }
 
     [Fact]
-    public void Build_EmptyZone_ShouldThrowArgumentException()
+    public void Build_EmptyZone_ThrowsArgumentException()
     {
         Assert.ThrowsAny<ArgumentException>(() => new PlacementLocationBuilder().Zone(""));
     }
@@ -55,7 +55,7 @@ public class PlacementLocationBuilderTests
     [InlineData("5.1", "Content:5.1")]
     [InlineData("before", "Content:before")]
     [InlineData("after", "Content:after")]
-    public void Build_ZoneWithPosition_ShouldReturnCorrectString(string position, string expected)
+    public void Build_ZoneWithPosition_ReturnsCorrectString(string position, string expected)
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", position)
@@ -65,7 +65,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZoneWithNullPosition_ShouldReturnZoneOnly()
+    public void Build_ZoneWithNullPosition_ReturnsZoneOnly()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", null)
@@ -79,7 +79,7 @@ public class PlacementLocationBuilderTests
     #region Tab Tests
 
     [Fact]
-    public void Build_ZoneWithTab_ShouldReturnCorrectString()
+    public void Build_ZoneWithTab_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -90,7 +90,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZoneWithTabAndTabPosition_ShouldReturnCorrectString()
+    public void Build_ZoneWithTabAndTabPosition_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -101,7 +101,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZonePositionAndTab_ShouldReturnCorrectString()
+    public void Build_ZonePositionAndTab_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Parameters", "1")
@@ -112,7 +112,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_NullTab_ShouldThrowArgumentException()
+    public void Build_NullTab_ThrowsArgumentException()
     {
         Assert.ThrowsAny<ArgumentException>(() =>
             new PlacementLocationBuilder().Zone("Content").Tab(null));
@@ -123,7 +123,7 @@ public class PlacementLocationBuilderTests
     #region Group Tests
 
     [Fact]
-    public void Build_ZoneWithGroup_ShouldReturnCorrectString()
+    public void Build_ZoneWithGroup_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -134,7 +134,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_NullGroup_ShouldThrowArgumentException()
+    public void Build_NullGroup_ThrowsArgumentException()
     {
         Assert.ThrowsAny<ArgumentException>(() =>
             new PlacementLocationBuilder().Zone("Content").Group(null));
@@ -145,7 +145,7 @@ public class PlacementLocationBuilderTests
     #region Card Tests
 
     [Fact]
-    public void Build_ZoneWithCard_ShouldReturnCorrectString()
+    public void Build_ZoneWithCard_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -156,7 +156,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZoneWithCardAndCardPosition_ShouldReturnCorrectString()
+    public void Build_ZoneWithCardAndCardPosition_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -167,7 +167,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_NullCard_ShouldThrowArgumentException()
+    public void Build_NullCard_ThrowsArgumentException()
     {
         Assert.ThrowsAny<ArgumentException>(() =>
             new PlacementLocationBuilder().Zone("Content").Card(null));
@@ -178,7 +178,7 @@ public class PlacementLocationBuilderTests
     #region Column Tests
 
     [Fact]
-    public void Build_ZoneWithColumn_ShouldReturnCorrectString()
+    public void Build_ZoneWithColumn_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -189,7 +189,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZoneWithColumnAndWidth_ShouldReturnCorrectString()
+    public void Build_ZoneWithColumnAndWidth_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -200,7 +200,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZoneWithColumnPositionAndWidth_ShouldReturnCorrectString()
+    public void Build_ZoneWithColumnPositionAndWidth_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -211,7 +211,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ZoneWithColumnAndPosition_ShouldReturnCorrectString()
+    public void Build_ZoneWithColumnAndPosition_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -222,7 +222,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ColumnWithBreakpointWidth_ShouldReturnCorrectString()
+    public void Build_ColumnWithBreakpointWidth_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -233,7 +233,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_NullColumn_ShouldThrowArgumentException()
+    public void Build_NullColumn_ThrowsArgumentException()
     {
         Assert.ThrowsAny<ArgumentException>(() =>
             new PlacementLocationBuilder().Zone("Content").Column(null));
@@ -244,7 +244,7 @@ public class PlacementLocationBuilderTests
     #region Layout Zone Tests
 
     [Fact]
-    public void Build_AsLayoutZone_ShouldPrefixWithSlash()
+    public void Build_AsLayoutZone_PrefixWithSlash()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content")
@@ -255,7 +255,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_LayoutZoneWithPosition_ShouldReturnCorrectString()
+    public void Build_LayoutZoneWithPosition_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -270,7 +270,7 @@ public class PlacementLocationBuilderTests
     #region Nesting Hierarchy Tests (Tab → Card → Column)
 
     [Fact]
-    public void Build_TabThenCard_ShouldReturnCorrectString()
+    public void Build_TabThenCard_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -282,7 +282,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_TabThenColumn_ShouldReturnCorrectString()
+    public void Build_TabThenColumn_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -294,7 +294,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_CardThenColumn_ShouldReturnCorrectString()
+    public void Build_CardThenColumn_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -319,7 +319,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_CardWithoutTab_ShouldWork()
+    public void Build_CardWithoutTab_Works()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -330,7 +330,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ColumnWithoutCardOrTab_ShouldWork()
+    public void Build_ColumnWithoutCardOrTab_Works()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -345,7 +345,7 @@ public class PlacementLocationBuilderTests
     #region Group at Different Nesting Levels
 
     [Fact]
-    public void Build_GroupOnZone_ShouldReturnCorrectString()
+    public void Build_GroupOnZone_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -356,7 +356,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_GroupOnTab_ShouldReturnCorrectString()
+    public void Build_GroupOnTab_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -368,7 +368,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_GroupOnCard_ShouldReturnCorrectString()
+    public void Build_GroupOnCard_ReturnsCorrectString()
     {
         // Group always appears between tab and card in the serialized string.
         var result = new PlacementLocationBuilder()
@@ -382,7 +382,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_GroupOnColumn_ShouldReturnCorrectString()
+    public void Build_GroupOnColumn_ReturnsCorrectString()
     {
         // Group always appears between tab and card in the serialized string.
         var result = new PlacementLocationBuilder()
@@ -401,7 +401,7 @@ public class PlacementLocationBuilderTests
     #region All Components Combined
 
     [Fact]
-    public void Build_AllComponentsWithPositions_ShouldReturnCorrectString()
+    public void Build_AllComponentsWithPositions_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -414,7 +414,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_LayoutZoneAllComponents_ShouldReturnCorrectString()
+    public void Build_LayoutZoneAllComponents_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -428,7 +428,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_AllComponentsWithGroup_ShouldReturnCorrectString()
+    public void Build_AllComponentsWithGroup_ReturnsCorrectString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -446,7 +446,7 @@ public class PlacementLocationBuilderTests
     #region Real-World Scenario Tests
 
     [Fact]
-    public void Build_SettingsTabPlacement_ShouldMatchManualString()
+    public void Build_SettingsTabPlacement_MatchManualString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Parameters", "1")
@@ -457,7 +457,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_CapabilitiesTabPlacement_ShouldMatchManualString()
+    public void Build_CapabilitiesTabPlacement_MatchManualString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Parameters", "5")
@@ -468,7 +468,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ColumnPlacementFromDocs_ShouldMatchManualString()
+    public void Build_ColumnPlacementFromDocs_MatchManualString()
     {
         var result = new PlacementLocationBuilder()
             .Zone("Parts", "0")
@@ -479,7 +479,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_HiddenLocation_ShouldUseStringDirectly()
+    public void Build_HiddenLocation_UsesStringDirectly()
     {
         Assert.Equal(PlacementInfo.HiddenLocation, "-");
     }
@@ -489,7 +489,7 @@ public class PlacementLocationBuilderTests
     #region PlacementInfo Parsing Roundtrip Tests
 
     [Fact]
-    public void Build_ShouldProduceStringParsableByPlacementInfo_Zone()
+    public void Build_Zone_ProducesStringParsableByPlacementInfo()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content")
@@ -500,7 +500,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ShouldProduceStringParsableByPlacementInfo_Position()
+    public void Build_Position_ProducesStringParsableByPlacementInfo()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5.1")
@@ -514,7 +514,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_ShouldProduceStringParsableByPlacementInfo_AllComponents()
+    public void Build_AllComponents_ProducesStringParsableByPlacementInfo()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -538,7 +538,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Build_LayoutZone_ShouldBeDetectedByPlacementInfo()
+    public void Build_LayoutZone_IsDetectedByPlacementInfo()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -552,7 +552,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_ZoneOnly_ShouldParseCorrectly()
+    public void Roundtrip_ZoneOnly_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Parameters")
@@ -569,7 +569,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_ZoneWithPosition_ShouldParseCorrectly()
+    public void Roundtrip_ZoneWithPosition_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "3.5")
@@ -581,7 +581,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_ZoneWithBeforePosition_ShouldParseCorrectly()
+    public void Roundtrip_ZoneWithBeforePosition_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "before")
@@ -593,7 +593,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_TabOnly_ShouldParseCorrectly()
+    public void Roundtrip_TabOnly_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "1")
@@ -609,7 +609,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_TabWithPosition_ShouldParseCorrectly()
+    public void Roundtrip_TabWithPosition_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "1")
@@ -622,7 +622,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_CardOnly_ShouldParseCorrectly()
+    public void Roundtrip_CardOnly_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -639,7 +639,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_ColumnOnly_ShouldParseCorrectly()
+    public void Roundtrip_ColumnOnly_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -657,7 +657,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_ColumnWithBreakpointWidth_ShouldParseCorrectly()
+    public void Roundtrip_ColumnWithBreakpointWidth_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content")
@@ -671,7 +671,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_GroupOnly_ShouldParseCorrectly()
+    public void Roundtrip_GroupOnly_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -685,7 +685,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_TabThenCard_ShouldParseCorrectly()
+    public void Roundtrip_TabThenCard_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -704,7 +704,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_TabThenCardThenColumn_ShouldParseCorrectly()
+    public void Roundtrip_TabThenCardThenColumn_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -726,7 +726,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_CardThenColumn_ShouldParseCorrectly()
+    public void Roundtrip_CardThenColumn_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Parts", "0")
@@ -745,7 +745,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_TabWithGroup_ShouldParseCorrectly()
+    public void Roundtrip_TabWithGroup_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -759,7 +759,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_LayoutZoneFullNesting_ShouldParseCorrectly()
+    public void Roundtrip_LayoutZoneFullNesting_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content", "5")
@@ -783,7 +783,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void Roundtrip_DottedZone_ShouldParseCorrectly()
+    public void Roundtrip_DottedZone_ParsesCorrectly()
     {
         var location = new PlacementLocationBuilder()
             .Zone("Content.Metadata", "1")
@@ -801,7 +801,7 @@ public class PlacementLocationBuilderTests
     #region Implicit Conversion and ToString Tests
 
     [Fact]
-    public void ImplicitConversion_FromBuilder_AfterZone_ShouldReturnBuildResult()
+    public void ImplicitConversion_FromBuilderAfterZone_ReturnsBuildResult()
     {
         string result = new PlacementLocationBuilder()
             .Zone("Content", "1");
@@ -810,7 +810,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void ImplicitConversion_FromBuilder_AfterTab_ShouldReturnBuildResult()
+    public void ImplicitConversion_FromBuilderAfterTab_ReturnsBuildResult()
     {
         string result = new PlacementLocationBuilder()
             .Zone("Content", "1")
@@ -820,7 +820,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void ImplicitConversion_FromBuilder_AfterCard_ShouldReturnBuildResult()
+    public void ImplicitConversion_FromBuilderAfterCard_ReturnsBuildResult()
     {
         string result = new PlacementLocationBuilder()
             .Zone("Content", "1")
@@ -831,7 +831,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void ImplicitConversion_FromBuilder_AfterColumn_ShouldReturnBuildResult()
+    public void ImplicitConversion_FromBuilderAfterColumn_ReturnsBuildResult()
     {
         string result = new PlacementLocationBuilder()
             .Zone("Content", "1")
@@ -841,7 +841,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void ToString_AfterZone_ShouldReturnBuildResult()
+    public void ToString_AfterZone_ReturnsBuildResult()
     {
         var builder = new PlacementLocationBuilder()
             .Zone("Content", "1");
@@ -850,7 +850,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void ToString_AfterTab_ShouldReturnBuildResult()
+    public void ToString_AfterTab_ReturnsBuildResult()
     {
         var builder = new PlacementLocationBuilder()
             .Zone("Content", "1")
@@ -864,7 +864,7 @@ public class PlacementLocationBuilderTests
     #region Type Safety Tests - All Methods Return Same Builder
 
     [Fact]
-    public void TypeSafety_ZoneReturnsSameBuilder()
+    public void TypeSafety_ZoneReturnsSameBuilder_Succeeds()
     {
         var builder = new PlacementLocationBuilder();
         var result = builder.Zone("Content");
@@ -872,7 +872,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void TypeSafety_TabReturnsSameBuilder()
+    public void TypeSafety_TabReturnsSameBuilder_Succeeds()
     {
         var builder = new PlacementLocationBuilder();
         var result = builder.Zone("Content").Tab("Settings");
@@ -880,7 +880,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void TypeSafety_CardReturnsSameBuilder()
+    public void TypeSafety_CardReturnsSameBuilder_Succeeds()
     {
         var builder = new PlacementLocationBuilder();
         var result = builder.Zone("Content").Card("Details");
@@ -888,7 +888,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void TypeSafety_ColumnReturnsSameBuilder()
+    public void TypeSafety_ColumnReturnsSameBuilder_Succeeds()
     {
         var builder = new PlacementLocationBuilder();
         var result = builder.Zone("Content").Column("Left");
@@ -896,7 +896,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void TypeSafety_GroupReturnsSameBuilder()
+    public void TypeSafety_GroupReturnsSameBuilder_Succeeds()
     {
         var builder = new PlacementLocationBuilder();
         var result = builder.Zone("Content").Group("search");
@@ -904,7 +904,7 @@ public class PlacementLocationBuilderTests
     }
 
     [Fact]
-    public void TypeSafety_AsLayoutZoneReturnsSameBuilder()
+    public void TypeSafety_AsLayoutZoneReturnsSameBuilder_Succeeds()
     {
         var builder = new PlacementLocationBuilder();
         var result = builder.Zone("Content").AsLayoutZone();

--- a/test/OrchardCore.Tests/DisplayManagement/Descriptors/ShapeAttributeBindingStrategyTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Descriptors/ShapeAttributeBindingStrategyTests.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Tests.DisplayManagement.Descriptors;
 public class ShapeAttributeBindingStrategyTests
 {
     [Fact]
-    public async Task StaticShapeMethodsDoNotResolveTheirProviderInstance()
+    public async Task StaticShapeMethodsDoNotResolveTheirProviderInstance_Default_Succeeds()
     {
         var methodInfo = typeof(StaticShapeProvider).GetMethod(nameof(StaticShapeProvider.StaticShape));
         var occurrence = new ShapeAttributeOccurrence(new ShapeAttribute(), methodInfo, typeof(StaticShapeProvider));

--- a/test/OrchardCore.Tests/DisplayManagement/DynamicCacheTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/DynamicCacheTests.cs
@@ -96,7 +96,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ShapeResultsShouldBeInitialized()
+    public async Task ShapeResults_Default_BeInitialized()
     {
         var shapeType = "shapetype1";
 
@@ -136,7 +136,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ShapeResultsAreRenderedOnceWhenCached()
+    public async Task ShapeResultsAreRenderedOnce_Cached_Succeeds()
     {
         var shapeType = "shapetype1";
         var cacheTag = "mytag";
@@ -228,7 +228,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task DriverResultsAssignProcessing()
+    public async Task DriverResultsAssignProcessing_Default_Succeeds()
     {
         // ShapeMetadata.Processing is the method which is not invoked when the shape is cached.
         // We need to ensure that the delegate used in the driver InitializeAsync call is used as Processing and not during
@@ -256,7 +256,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithCachingCachesFinalMorphedShape()
+    public async Task ShapeMorphingWithCachingCachesFinalMorphedShape_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var factory = _serviceProvider.GetService<IShapeFactory>();
@@ -351,7 +351,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ShapeMorphingChainWithCachingCachesFinalResult()
+    public async Task ShapeMorphingChainWithCachingCachesFinalResult_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var factory = _serviceProvider.GetService<IShapeFactory>();
@@ -479,7 +479,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ConditionalShapeMorphingWithCachingRespectsCacheKeys()
+    public async Task ConditionalShapeMorphingWithCachingRespectsCacheKeys_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var factory = _serviceProvider.GetService<IShapeFactory>();
@@ -612,7 +612,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithAlternatesAndCachingPreservesAlternates()
+    public async Task ShapeMorphingWithAlternatesAndCachingPreservesAlternates_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var factory = _serviceProvider.GetService<IShapeFactory>();
@@ -708,7 +708,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithCacheInvalidationRecreatesCorrectly()
+    public async Task ShapeMorphingWithCacheInvalidationRecreatesCorrectly_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var factory = _serviceProvider.GetService<IShapeFactory>();
@@ -799,7 +799,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task DoubleMorphingWithConcatenationCachesFinalCombinedResult()
+    public async Task DoubleMorphingWithConcatenationCachesFinalCombinedResult_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var factory = _serviceProvider.GetService<IShapeFactory>();
@@ -955,7 +955,7 @@ public class DynamicCacheTests
     }
 
     [Fact]
-    public async Task ShapeMorphingWithCachingCachesInnerMorphedShape()
+    public async Task ShapeMorphingWithCachingCachesInnerMorphedShape_Default_Succeeds()
     {
         var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
         var factory = _serviceProvider.GetService<IShapeFactory>();

--- a/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Tests.DisplayManagement;
 public class LiquidTests
 {
     [Fact]
-    public async Task ComparingTextField_ReturnsCorrectValue()
+    public async Task ComparingTextField_Default_ReturnsCorrectValue()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -45,7 +45,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task ComparingDateTimeField_ReturnsCorrectValue()
+    public async Task ComparingDateTimeField_Default_ReturnsCorrectValue()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -80,7 +80,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task ComparingNumericField_ReturnsCorrectValue()
+    public async Task ComparingNumericField_Default_ReturnsCorrectValue()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -113,7 +113,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task SortingContentItems_ShouldSortTheArrayOnIntegerField()
+    public async Task SortingContentItems_Default_SortTheArrayOnIntegerField()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -139,7 +139,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task FilteringContentItems_ShouldFilterTheArrayOnBooleanField()
+    public async Task FilteringContentItems_Default_FilterTheArrayOnBooleanField()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -165,7 +165,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task FilteringAndSortingContentItems_ShouldFilterAndSortTheArrayOnContentFields()
+    public async Task FilteringAndSortingContentItems_Default_FilterAndSortTheArrayOnContentFields()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -191,7 +191,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldCompareSingleValueWithString()
+    public async Task StringValuesValue_Default_CompareSingleValueWithString()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -215,7 +215,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldCompareMultipleValuesWithString()
+    public async Task StringValuesValue_Default_CompareMultipleValuesWithString()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -240,7 +240,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldSupportContainsCheck()
+    public async Task StringValuesValue_Default_SupportContainsCheck()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -264,7 +264,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldSupportArrayIteration()
+    public async Task StringValuesValue_Default_SupportArrayIteration()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -288,7 +288,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldSupportArrayIndexing()
+    public async Task StringValuesValue_Default_SupportArrayIndexing()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -312,7 +312,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldSupportSizeProperty()
+    public async Task StringValuesValue_Default_SupportSizeProperty()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -336,7 +336,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldSupportFirstAndLastProperties()
+    public async Task StringValuesValue_Default_SupportFirstAndLastProperties()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -360,7 +360,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldHandleEmptyValues()
+    public async Task StringValuesValue_Default_HandlesEmptyValues()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -385,7 +385,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldCompareSingleValueAsString()
+    public async Task StringValuesValue_Default_CompareSingleValueAsString()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -410,7 +410,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldConcatenateMultipleValuesForStringComparison()
+    public async Task StringValuesValue_Default_ConcatenateMultipleValuesForStringComparison()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -435,7 +435,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldSupportBooleanConversion()
+    public async Task StringValuesValue_Default_SupportBooleanConversion()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -459,7 +459,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_EmptyShouldBeTruthy()
+    public async Task StringValuesValue_Default_EmptyBeTruthy()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -485,7 +485,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task StringValuesValue_ShouldHtmlEncodeOutput()
+    public async Task StringValuesValue_Default_HtmlEncodeOutput()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -500,7 +500,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task RequestQueryStringValues_ShouldHtmlEncodeOutput()
+    public async Task RequestQueryStringValues_Default_HtmlEncodeOutput()
     {
         var result = await RenderRequestValueAsync("{{ Request.Query.q }}", request =>
         {
@@ -511,7 +511,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task RequestHeaderStringValues_ShouldHtmlEncodeOutput()
+    public async Task RequestHeaderStringValues_Default_HtmlEncodeOutput()
     {
         var result = await RenderRequestValueAsync("{{ Request.Headers.test }}", request =>
         {
@@ -522,7 +522,7 @@ public class LiquidTests
     }
 
     [Fact]
-    public async Task RequestFormStringValues_ShouldHtmlEncodeOutput()
+    public async Task RequestFormStringValues_Default_HtmlEncodeOutput()
     {
         var result = await RenderRequestValueAsync("{{ Request.Form.q }}", request =>
         {

--- a/test/OrchardCore.Tests/DisplayManagement/NilTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/NilTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.DisplayManagement;
 public class NilTests
 {
     [Fact]
-    public void NilShouldEqualToNull()
+    public void Nil_Default_EqualToNull()
     {
         var nil = Nil.Instance;
 
@@ -17,7 +17,7 @@ public class NilTests
     }
 
     [Fact]
-    public void NilShouldBeRecursive()
+    public void Nil_Default_BeRecursive()
     {
         dynamic nil = Nil.Instance;
 
@@ -27,21 +27,21 @@ public class NilTests
     }
 
     [Fact]
-    public void CallingToStringOnNilShouldReturnEmpty()
+    public void CallingToStringOnNil_Default_ReturnsEmpty()
     {
         var nil = Nil.Instance;
         Assert.Equal("", nil.ToString());
     }
 
     [Fact]
-    public void CallingToStringOnDynamicNilShouldReturnEmpty()
+    public void CallingToStringOnDynamicNil_Default_ReturnsEmpty()
     {
         dynamic nil = Nil.Instance;
         Assert.Equal("", nil.Foo.Bar.ToString());
     }
 
     [Fact]
-    public void ConvertingToStringShouldReturnNullString()
+    public void ConvertingToString_Default_ReturnsNullString()
     {
         dynamic nil = Nil.Instance;
         Assert.True((string)nil == null);

--- a/test/OrchardCore.Tests/DisplayManagement/Notify/NotifierTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Notify/NotifierTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.DisplayManagement.Notify;
 public class NotifierTests
 {
     [Fact]
-    public async Task SuccessAsync_WithoutMilliseconds_SetsDefaultMilliseconds()
+    public async Task SuccessAsync_OutMilliseconds_SetsDefaultMilliseconds()
     {
         var notifier = new Notifier(NullLogger<Notifier>.Instance);
 
@@ -18,7 +18,7 @@ public class NotifierTests
     }
 
     [Fact]
-    public async Task ErrorAsync_WithoutMilliseconds_DoesNotSetMilliseconds()
+    public async Task ErrorAsync_OutMilliseconds_DoesNotSetMilliseconds()
     {
         var notifier = new Notifier(NullLogger<Notifier>.Instance);
 
@@ -30,7 +30,7 @@ public class NotifierTests
     }
 
     [Fact]
-    public async Task SuccessAsync_WithMilliseconds_SetsMillisecondsOnNotifyEntry()
+    public async Task SuccessAsync_Milliseconds_SetsMillisecondsOnNotifyEntry()
     {
         var notifier = new Notifier(NullLogger<Notifier>.Instance);
 
@@ -42,7 +42,7 @@ public class NotifierTests
     }
 
     [Fact]
-    public void NotifyEntryConverter_RoundTripsMilliseconds()
+    public void NotifyEntryConverter_Default_RoundTripsMilliseconds()
     {
         var options = new JsonSerializerOptions();
         options.Converters.Add(new NotifyEntryConverter(HtmlEncoder.Default));

--- a/test/OrchardCore.Tests/DisplayManagement/ShapeFactoryTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ShapeFactoryTests.cs
@@ -37,7 +37,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task ShapeHasAttributesType()
+    public async Task ShapeHasAttributesType_Default_Succeeds()
     {
         var factory = _serviceProvider.GetService<IShapeFactory>();
         dynamic foo = await factory.CreateAsync("Foo", ArgsUtility.Empty());
@@ -46,7 +46,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CreateShapeWithNamedArguments()
+    public async Task CreateShapeWithNamedArguments_Default_Succeeds()
     {
         var factory = _serviceProvider.GetService<IShapeFactory>();
         dynamic foo = await factory.CreateAsync("Foo", ArgsUtility.Named(new { one = 1, two = "dos" }));
@@ -55,7 +55,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CallSyntax()
+    public async Task CallSyntax_Default_Succeeds()
     {
         dynamic factory = _serviceProvider.GetService<IShapeFactory>();
         var foo = await factory.Foo();
@@ -64,7 +64,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CallSyntaxAsync()
+    public async Task CallSyntaxAsync_Default_Succeeds()
     {
         dynamic factory = _serviceProvider.GetService<IShapeFactory>();
         var foo = await factory.FooAsync();
@@ -73,7 +73,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CallInitializer()
+    public async Task CallInitializer_Default_Succeeds()
     {
         dynamic factory = _serviceProvider.GetService<IShapeFactory>();
         var bar = new { One = 1, Two = "two" };
@@ -84,7 +84,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task ShapeFactoryUsesCustomShapeType()
+    public async Task ShapeFactoryUsesCustomShapeType_Default_Succeeds()
     {
         var descriptor = new ShapeDescriptor
         {
@@ -106,7 +106,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task ShapeFactoryWithCustomShapeTypeAppliesArguments()
+    public async Task ShapeFactoryWithCustomShapeTypeAppliesArguments_Default_Succeeds()
     {
         var descriptor = new ShapeDescriptor
         {
@@ -129,7 +129,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CreateStronglyTypedShapeUsesGeneratedShapeType()
+    public async Task CreateStronglyTypedShapeUsesGeneratedShapeType_Default_Succeeds()
     {
         var factory = _serviceProvider.GetRequiredService<IShapeFactory>();
 
@@ -153,7 +153,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CreateStronglyTypedShapeDelegatesShapeMembers()
+    public async Task CreateStronglyTypedShapeDelegatesShapeMembers_Default_Succeeds()
     {
         var factory = _serviceProvider.GetRequiredService<IShapeFactory>();
 
@@ -181,7 +181,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CreateStronglyTypedShapeFallsBackToCastleProxy()
+    public async Task CreateStronglyTypedShapeFallsBackToCastleProxy_Default_Succeeds()
     {
         var factory = _serviceProvider.GetRequiredService<IShapeFactory>();
         var shapeFactoryExtensionsType = typeof(IShapeFactory).Assembly.GetType("OrchardCore.DisplayManagement.ShapeFactoryExtensions", throwOnError: true);
@@ -198,7 +198,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task CreateStronglyTypedShapeUsesAttributedModelWithoutInterception()
+    public async Task CreateStronglyTypedShapeUsesAttributedModelWithoutInterception_Default_Succeeds()
     {
         var factory = _serviceProvider.GetRequiredService<IShapeFactory>();
         var shape = await factory.CreateAsync<AttributedShapeViewModel>(model => model.Title = "Attributed");
@@ -212,7 +212,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task DisplayDriverInitializeUsesGeneratedShapeType()
+    public async Task DisplayDriverInitializeUsesGeneratedShapeType_Default_Succeeds()
     {
         var factory = _serviceProvider.GetRequiredService<IShapeFactory>();
         var shapeResult = new TestDisplayDriver().Build();
@@ -231,7 +231,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task DisplayDriverInitializeWithoutInitializerUsesGeneratedShapeType()
+    public async Task DisplayDriverInitializeWithoutInitializerUsesGeneratedShapeType_Default_Succeeds()
     {
         var factory = _serviceProvider.GetRequiredService<IShapeFactory>();
         var shapeResult = new TestDisplayDriverWithoutInitializer().Build();
@@ -248,7 +248,7 @@ public class ShapeFactoryTests
     }
 
     [Fact]
-    public async Task DisplayDriverInitializeWithoutShapeTypeOrInitializerUsesGeneratedShapeType()
+    public async Task DisplayDriverInitializeWithoutShapeTypeOrInitializerUsesGeneratedShapeType_Default_Succeeds()
     {
         var factory = _serviceProvider.GetRequiredService<IShapeFactory>();
         var shapeResult = new TestDisplayDriverWithoutShapeTypeOrInitializer().Build();

--- a/test/OrchardCore.Tests/DisplayManagement/ShapeHelperTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ShapeHelperTests.cs
@@ -34,7 +34,7 @@ public class ShapeHelperTests
     }
 
     [Fact]
-    public async Task CreatingNewShapeTypeByName()
+    public async Task CreatingNewShapeTypeByName_Default_Succeeds()
     {
         dynamic shape = _serviceProvider.GetService<IShapeFactory>();
 
@@ -44,7 +44,7 @@ public class ShapeHelperTests
     }
 
     [Fact]
-    public async Task CreatingShapeWithAdditionalNamedParameters()
+    public async Task CreatingShapeWithAdditionalNamedParameters_Default_Succeeds()
     {
         dynamic shape = _serviceProvider.GetService<IShapeFactory>();
 
@@ -56,7 +56,7 @@ public class ShapeHelperTests
     }
 
     [Fact]
-    public async Task WithPropertyBearingObjectInsteadOfNamedParameters()
+    public async Task WithPropertyBearingObjectInsteadOfNamedParameters_Default_Succeeds()
     {
         dynamic shape = _serviceProvider.GetService<IShapeFactory>();
 

--- a/test/OrchardCore.Tests/DisplayManagement/ShapeResultTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ShapeResultTests.cs
@@ -21,7 +21,7 @@ public class ShapeResultTests
     [InlineData("", null)]
     [InlineData(null, "")]
     [InlineData(null, null)]
-    public async Task Shape_WhenCalled_ReturnShapeWhenGroupIsMatched(string groupId, string renderingGroupId)
+    public async Task Shape_CalledReturnShapeWhenGroupIsMatched_Succeeds(string groupId, string renderingGroupId)
     {
         var serviceProvider = GetServiceProvider(new GroupDisplayDriverStub(groupId));
 
@@ -46,7 +46,7 @@ public class ShapeResultTests
     [InlineData(null, "groupTwo")]
     [InlineData("groupOne", "")]
     [InlineData("groupOne", null)]
-    public async Task Shape_WhenCalled_ReturnNullWhenIncorrectGroupIsSpecified(string groupId, string renderingGroupId)
+    public async Task Shape_CalledReturnNullWhenIncorrectGroupIsSpecified_Succeeds(string groupId, string renderingGroupId)
     {
         var serviceProvider = GetServiceProvider(new GroupDisplayDriverStub(groupId));
 

--- a/test/OrchardCore.Tests/DisplayManagement/ShapeSerializerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ShapeSerializerTests.cs
@@ -35,7 +35,7 @@ public class ShapeSerializerTests
     }
 
     [Fact]
-    public async Task ShouldSerialize()
+    public async Task Serialize_Default_Succeeds()
     {
         var shape = _serviceProvider.GetService<IShapeFactory>();
 
@@ -46,7 +46,7 @@ public class ShapeSerializerTests
     }
 
     [Fact]
-    public async Task ShouldSkipRecursiveShapes()
+    public async Task Skip_RecursiveShapes_Succeeds()
     {
         var shape = _serviceProvider.GetService<IShapeFactory>();
 

--- a/test/OrchardCore.Tests/DisplayManagement/Title/PageTitleBuilderTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Title/PageTitleBuilderTests.cs
@@ -20,7 +20,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void GenerateTitleEmpty()
+    public void GenerateTitleEmpty_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -30,7 +30,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void FixedTitleSet()
+    public void FixedTitleSet_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -41,7 +41,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void FixedTitleClearAndCheck()
+    public void FixedTitleClearAndCheck_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -53,7 +53,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void FixedTitleAddSegment()
+    public void FixedTitleAddSegment_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -65,7 +65,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void TitleAddSegment()
+    public void TitleAddSegment_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -77,7 +77,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void TitleMultiAddSegment()
+    public void TitleMultiAddSegment_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -91,7 +91,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void TitleAddAndClear()
+    public void TitleAddAndClear_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -105,7 +105,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void TitleMultiGenerateTitle()
+    public void TitleMultiGenerateTitle_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = _serviceProvider.GetService<IPageTitleBuilder>();
@@ -120,7 +120,7 @@ public class PageTitleBuilderTests
     }
 
     [Fact]
-    public void TitleAddSegments()
+    public void TitleAddSegments_Default_Succeeds()
     {
         // Arrange
         var pageTitleBuilder = (PageTitleBuilder)_serviceProvider.GetService<IPageTitleBuilder>();

--- a/test/OrchardCore.Tests/DisplayManagement/ViewBufferTextWriterContentTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ViewBufferTextWriterContentTests.cs
@@ -13,7 +13,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteString()
+    public void Write_String_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -25,7 +25,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteChar()
+    public void Write_Char_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -37,7 +37,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteBufferFragment()
+    public void Write_BufferFragment_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -49,7 +49,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteBuffer()
+    public void Write_Buffer_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -61,7 +61,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteObject()
+    public void Write_Object_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -73,7 +73,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteMultipleFragments()
+    public void Write_MultipleFragments_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -86,7 +86,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteMultipleStringPages()
+    public void Write_MultipleStringPages_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -101,7 +101,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteMultipleCharPages()
+    public void Write_MultipleCharPages_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 
@@ -116,7 +116,7 @@ public class ViewBufferTextWriterContentTests
     }
 
     [Fact]
-    public void ShouldWriteMultipleBufferFragmentPages()
+    public void Write_MultipleBufferFragmentPages_Succeeds()
     {
         var buffer = new ViewBufferTextWriterContent();
 

--- a/test/OrchardCore.Tests/DisplayManagement/ZoneonDemandTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ZoneonDemandTests.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.DisplayManagement;
 public class ZoneOnDemandTests
 {
     [Fact]
-    public void ZoneOnDemandIsEqualToNull()
+    public void ZoneOnDemandIsEqualToNull_Default_Succeeds()
     {
         var zoneOnDemand = CreateZoneOnDemand("SomeZone");
 
@@ -18,7 +18,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void DynamicZoneOnDemandIsEqualToNull()
+    public void DynamicZoneOnDemandIsEqualToNull_Default_Succeeds()
     {
         dynamic zoneOnDemand = CreateZoneOnDemand("SomeZone");
 
@@ -29,7 +29,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void ZoneOnDemandAsBaseTypeIsNotEqualToNull()
+    public void ZoneOnDemandAsBaseTypeIsNotEqualToNull_Default_Succeeds()
     {
         var zoneOnDemand = CreateZoneOnDemand("SomeZone");
 
@@ -43,7 +43,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void ZoneOnDemandIsNotEqualToItself()
+    public void ZoneOnDemandIsNotEqualToItself_Default_Succeeds()
     {
         var zoneOnDemand1 = CreateZoneOnDemand("SomeZone");
         var zoneOnDemand2 = zoneOnDemand1;
@@ -53,7 +53,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void DynamicZoneOnDemandIsNotEqualToItself()
+    public void DynamicZoneOnDemandIsNotEqualToItself_Default_Succeeds()
     {
         dynamic zoneOnDemand1 = CreateZoneOnDemand("SomeZone");
         dynamic zoneOnDemand2 = zoneOnDemand1;
@@ -63,7 +63,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void ZoneOnDemandAsBaseTypeIsEqualToItself()
+    public void ZoneOnDemandAsBaseTypeIsEqualToItself_Default_Succeeds()
     {
         var zoneOnDemand = CreateZoneOnDemand("SomeZone");
 
@@ -78,13 +78,13 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void ZoneHoldingPropertiesMissingIndexThrows()
+    public void ZoneHoldingPropertiesMissingIndexThrows_Default_Succeeds()
     {
         Assert.Throws<KeyNotFoundException>(() => { _ = CreateZoneHolding().Properties["SomeZone"]; });
     }
 
     [Fact]
-    public void DynamicZoneHoldingMissingIndexIsNull()
+    public void DynamicZoneHoldingMissingIndexIsNull_Default_Succeeds()
     {
         dynamic zoneHolding = CreateZoneHolding();
         var zone = zoneHolding["SomeZone"];
@@ -94,7 +94,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void DynamicZoneHoldingMissingPropertyAddsAnEmptyZoneOnDemand()
+    public void DynamicZoneHoldingMissingPropertyAddsAnEmptyZoneOnDemand_Default_Succeeds()
     {
         dynamic zoneHolding = CreateZoneHolding();
         var someZone = zoneHolding.SomeZone;
@@ -116,7 +116,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void DynamicZonesMissingPropertyReturnsATemporaryZoneOnDemand()
+    public void DynamicZonesMissingPropertyReturnsATemporaryZoneOnDemand_Default_Succeeds()
     {
         dynamic zoneHolding = CreateZoneHolding();
         var zoneOnDemand = zoneHolding.Zones.SomeZone;
@@ -134,7 +134,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public async Task AddingAnItemToAZoneOnDemandAddsAZoneShapeToItsParent()
+    public async Task AddingAnItemToAZoneOnDemandAddsAZoneShapeToItsParent_Default_Succeeds()
     {
         dynamic zoneHolding = CreateZoneHolding();
         var zoneOnDemand = zoneHolding.Zones.SomeZone;
@@ -155,7 +155,7 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void DynamicZoneOnDemandShouldBeRecursive()
+    public void DynamicZoneOnDemand_Default_BeRecursive()
     {
         dynamic zoneOnDemand = CreateZoneOnDemand("SomeZone");
 
@@ -165,21 +165,21 @@ public class ZoneOnDemandTests
     }
 
     [Fact]
-    public void CallingToStringOnZoneOnDemandShouldReturnEmpty()
+    public void CallingToStringOnZoneOnDemand_Default_ReturnsEmpty()
     {
         var zoneOnDemand = CreateZoneOnDemand("SomeZone");
         Assert.Equal("", zoneOnDemand.ToString());
     }
 
     [Fact]
-    public void CallingToStringOnDynamicZoneOnDemandShouldReturnEmpty()
+    public void CallingToStringOnDynamicZoneOnDemand_Default_ReturnsEmpty()
     {
         dynamic zoneOnDemand = CreateZoneOnDemand("SomeZone");
         Assert.Equal("", zoneOnDemand.Foo.Bar.ToString());
     }
 
     [Fact]
-    public void ConvertingZoneOnDemandToStringShouldReturnNullString()
+    public void ConvertingZoneOnDemandToString_Default_ReturnsNullString()
     {
         dynamic zoneOnDemand = CreateZoneOnDemand("SomeZone");
         Assert.True((string)zoneOnDemand == null);

--- a/test/OrchardCore.Tests/DisplayManagement/Zones/FlatPositionComparerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Zones/FlatPositionComparerTests.cs
@@ -19,7 +19,7 @@ public class FlatPositionComparerTests
     #region Instance Tests
 
     [Fact]
-    public void Instance_ShouldReturnSameInstance()
+    public void Instance_Default_ReturnsSameInstance()
     {
         // Arrange & Act
         var instance1 = FlatPositionComparer.Instance;
@@ -39,7 +39,7 @@ public class FlatPositionComparerTests
     [InlineData("1", "1", 0)]
     [InlineData("10", "2", 1)]
     [InlineData("2", "10", -1)]
-    public void Compare_SimpleNumbers_ShouldCompareNumerically(string x, string y, int expected)
+    public void Compare_SimpleNumbers_CompareNumerically(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -54,7 +54,7 @@ public class FlatPositionComparerTests
     [InlineData("1.1", "1.1", 0)]
     [InlineData("1.10", "1.2", 1)]
     [InlineData("1.2", "1.10", -1)]
-    public void Compare_DecimalPositions_ShouldCompareNumerically(string x, string y, int expected)
+    public void Compare_DecimalPositions_CompareNumerically(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -69,7 +69,7 @@ public class FlatPositionComparerTests
     [InlineData("1.2.1", "1.1.2", 1)]
     [InlineData("1.1.2", "1.2.1", -1)]
     [InlineData("1.1.1", "1.1.1", 0)]
-    public void Compare_MultiLevelPositions_ShouldCompareCorrectly(string x, string y, int expected)
+    public void Compare_MultiLevelPositions_CompareCorrectly(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -83,7 +83,7 @@ public class FlatPositionComparerTests
     [InlineData("1.1", "1", 1)]
     [InlineData("1.2", "1.2.1", -1)]
     [InlineData("1.2.1", "1.2", 1)]
-    public void Compare_DifferentLevels_ShouldCompareCorrectly(string x, string y, int expected)
+    public void Compare_DifferentLevels_CompareCorrectly(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -98,7 +98,7 @@ public class FlatPositionComparerTests
     [InlineData("1", null, 1)]
     [InlineData(null, "before", 1)]
     [InlineData("before", null, -1)]
-    public void Compare_NullValues_ShouldHandleCorrectly(string x, string y, int expected)
+    public void Compare_NullValues_HandlesCorrectly(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -115,7 +115,7 @@ public class FlatPositionComparerTests
     [InlineData("0", "", 0)]
     [InlineData("   ", "0", 0)]
     [InlineData("0", "   ", 0)]
-    public void Compare_EmptyValues_ShouldTreatAsZero(string x, string y, int expected)
+    public void Compare_EmptyValues_TreatAsZero(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -133,7 +133,7 @@ public class FlatPositionComparerTests
     [InlineData("1", "before", 1)]
     [InlineData("after", "1", 1)]
     [InlineData("1", "after", -1)]
-    public void Compare_KnownPartitions_ShouldNormalizeCorrectly(string x, string y, int expected)
+    public void Compare_KnownPartitions_NormalizeCorrectly(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -146,7 +146,7 @@ public class FlatPositionComparerTests
     [InlineData("BEFORE", "after", -1)]
     [InlineData("After", "BEFORE", 1)]
     [InlineData("BeFoRe", "AfTeR", -1)]
-    public void Compare_KnownPartitions_ShouldBeCaseInsensitive(string x, string y, int expected)
+    public void Compare_KnownPartitions_IsCaseInsensitive(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -161,7 +161,7 @@ public class FlatPositionComparerTests
     [InlineData("alpha", "alpha", 0)]
     [InlineData("Alpha", "alpha", 0)]
     [InlineData("ALPHA", "alpha", 0)]
-    public void Compare_NonNumericStrings_ShouldCompareAlphabetically(string x, string y, int expected)
+    public void Compare_NonNumericStrings_CompareAlphabetically(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -174,7 +174,7 @@ public class FlatPositionComparerTests
     [InlineData("1:test", "2:test", -1)]
     [InlineData("2:test", "1:test", 1)]
     [InlineData("test:", "test", 0)]
-    public void Compare_ColonSeparators_ShouldHandleCorrectly(string x, string y, int expected)
+    public void Compare_ColonSeparators_HandlesCorrectly(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -187,7 +187,7 @@ public class FlatPositionComparerTests
     [InlineData("1.2:3", "1.2:4", -1)]
     [InlineData("1:2.3", "1:2.4", -1)]
     [InlineData("1:2:3", "1:2:4", -1)]
-    public void Compare_MixedSeparators_ShouldHandleCorrectly(string x, string y, int expected)
+    public void Compare_MixedSeparators_HandlesCorrectly(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -201,7 +201,7 @@ public class FlatPositionComparerTests
     [InlineData("1..", "1", 0)]
     [InlineData("test.", "test", 0)]
     [InlineData("test..", "test", 0)]
-    public void Compare_TrailingDots_ShouldBeTrimmed(string x, string y, int expected)
+    public void Compare_TrailingDots_IsTrimmed(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -211,7 +211,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void Compare_SameReference_ShouldReturnZero()
+    public void Compare_SameReference_ReturnsZero()
     {
         // Arrange
         var position = "1.2.3";
@@ -228,7 +228,7 @@ public class FlatPositionComparerTests
     #region IPositioned Comparison Tests
 
     [Fact]
-    public void Compare_IPositioned_ShouldCompareByPosition()
+    public void Compare_IPositioned_CompareByPosition()
     {
         // Arrange
         var item1 = new TestPositioned { Position = "1" };
@@ -242,7 +242,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void Compare_IPositioned_WithNullPositions_ShouldHandleCorrectly()
+    public void Compare_IPositionedWithNullPositions_HandlesCorrectly()
     {
         // Arrange
         var item1 = new TestPositioned { Position = null };
@@ -256,7 +256,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void Compare_IPositioned_SamePositions_ShouldReturnZero()
+    public void Compare_IPositionedSamePositions_ReturnsZero()
     {
         // Arrange
         var item1 = new TestPositioned { Position = "1.2" };
@@ -274,7 +274,7 @@ public class FlatPositionComparerTests
     #region Complex Scenario Tests
 
     [Fact]
-    public void Compare_BasicOrderingRules_ShouldWork()
+    public void Compare_BasicOrderingRules_Works()
     {
         // Test that basic ordering works for key transitions
         Assert.True(_comparer.Compare("before", "1") < 0, "before should come before 1");
@@ -290,7 +290,7 @@ public class FlatPositionComparerTests
     [InlineData("1.after", "1.1", 1)]
     [InlineData("before.1", "1.before", -1)]
     [InlineData("after.1", "1.after", 1)]
-    public void Compare_BeforeAfterInComplexPositions_ShouldWork(string x, string y, int expected)
+    public void Compare_BeforeAfterInComplexPositions_Works(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -304,7 +304,7 @@ public class FlatPositionComparerTests
     [InlineData("text2", "text1", 1)]
     [InlineData("text1.1", "text1.2", -1)]
     [InlineData("text1.alpha", "text1.beta", -1)]
-    public void Compare_TextBasedPositions_ShouldCompareAlphabetically(string x, string y, int expected)
+    public void Compare_TextBasedPositions_CompareAlphabetically(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -314,7 +314,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void Compare_MixedNumericAndText_ShouldHandleCorrectly()
+    public void Compare_MixedNumericAndText_HandlesCorrectly()
     {
         // Test ordering between numbers and strings
         Assert.True(_comparer.Compare("1", "alpha") < 0, "Numbers should come before text");
@@ -330,7 +330,7 @@ public class FlatPositionComparerTests
     [InlineData("0", "00", 0)]
     [InlineData("1", "01", 0)]
     [InlineData("10", "010", 0)]
-    public void Compare_LeadingZeros_ShouldBeNumericallyEqual(string x, string y, int expected)
+    public void Compare_LeadingZeros_IsNumericallyEqual(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -344,7 +344,7 @@ public class FlatPositionComparerTests
     [InlineData("1", "1.0", -1)]
     [InlineData("1.0.0", "1.0", 1)]
     [InlineData("1.0", "1.0.0", -1)]
-    public void Compare_TrailingZeros_ShouldConsiderMoreSpecific(string x, string y, int expected)
+    public void Compare_TrailingZeros_ConsiderMoreSpecific(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -356,7 +356,7 @@ public class FlatPositionComparerTests
     [Theory]
     [InlineData("short", "verylongpositionname")]
     [InlineData("verylongpositionname", "short")]
-    public void Compare_VeryLongStrings_ShouldCompareCorrectly(string x, string y)
+    public void Compare_VeryLongStrings_CompareCorrectly(string x, string y)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -380,7 +380,7 @@ public class FlatPositionComparerTests
     [Theory]
     [InlineData("specialchars!@#", "specialchars$%^")]
     [InlineData("unicode-ñ", "unicode-ö")]
-    public void Compare_SpecialCharacters_ShouldCompareAlphabetically(string x, string y)
+    public void Compare_SpecialCharacters_CompareAlphabetically(string x, string y)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -406,7 +406,7 @@ public class FlatPositionComparerTests
     #region Normalization Tests
 
     [Fact]
-    public void Compare_BeforePartition_ShouldBeNormalized()
+    public void Compare_BeforePartition_IsNormalized()
     {
         // Test that "before" gets normalized to a low value
         Assert.True(_comparer.Compare("before", "0") < 0);
@@ -417,7 +417,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void Compare_AfterPartition_ShouldBeNormalized()
+    public void Compare_AfterPartition_IsNormalized()
     {
         // Test that "after" gets normalized to a high value
         Assert.True(_comparer.Compare("after", "0") > 0);
@@ -429,7 +429,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void Compare_NonNormalizedPartitions_ShouldNotBeSpecial()
+    public void Compare_NonNormalizedPartitions_IsNotSpecial()
     {
         // Test that similar but different strings don't get normalized
         var result1 = _comparer.Compare("beforex", "0");
@@ -442,7 +442,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void Compare_EmptyStringBehavior_ShouldBeTreatedAsZero()
+    public void Compare_EmptyStringBehavior_IsTreatedAsZero()
     {
         // Empty string should be treated as "0"
         Assert.Equal(0, _comparer.Compare("", "0"));
@@ -466,7 +466,7 @@ public class FlatPositionComparerTests
     [InlineData("11", "12.4", -1)]
     [InlineData("12.5", "12", 1)]
     [InlineData("12", "12.5", -1)]
-    public void Compare_DotNotation_ShouldOrderCorrectly(string x, string y, int expected)
+    public void Compare_DotNotation_OrderCorrectly(string x, string y, int expected)
     {
         // Act
         var result = _comparer.Compare(x, y);
@@ -476,7 +476,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void OrderBy_DotNotation_ShouldProduceCorrectSequence()
+    public void OrderBy_DotNotation_ProducesCorrectSequence()
     {
         // Arrange - Positions that simulate shapes from different modules.
         var positions = new[] { "12.5", "11", "12.4", "12", "1", "1.1" };
@@ -506,7 +506,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void OrderBy_EmptyAndNull_ShouldSortCorrectly()
+    public void OrderBy_EmptyAndNull_SortCorrectly()
     {
         // Arrange - null normalizes to "before.", empty/whitespace normalizes to "0".
         var items = new TestPositioned[]
@@ -528,7 +528,7 @@ public class FlatPositionComparerTests
     }
 
     [Fact]
-    public void OrderBy_ComplexScenario_ShouldOrderCorrectly()
+    public void OrderBy_ComplexScenario_OrderCorrectly()
     {
         // Arrange - A realistic scenario with various position formats.
         var positions = new[]
@@ -556,7 +556,7 @@ public class FlatPositionComparerTests
     [InlineData("before", "", -1)]
     [InlineData("", "after", -1)]
     [InlineData("after", "", 1)]
-    public void Compare_EmptyPosition_ShouldBehaveAsZero(string x, string y, int expected)
+    public void Compare_EmptyPosition_IshaveAsZero(string x, string y, int expected)
     {
         // Empty position normalizes to "0", meaning:
         // "before" < "" (0) < any positive number < "after"

--- a/test/OrchardCore.Tests/DisplayManagement/Zones/ShapePositionOrderingTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Zones/ShapePositionOrderingTests.cs
@@ -10,7 +10,7 @@ public class ShapePositionOrderingTests
     /// registering shapes in arbitrary order).
     /// </summary>
     [Fact]
-    public async Task Items_ShouldOrderByPosition_RegardlessOfInsertionOrder()
+    public async Task Items_RegardlessOfInsertionOrder_OrderByPosition()
     {
         // Arrange - Add shapes in reverse order to prove insertion order doesn't matter.
         var zone = new Shape();
@@ -37,7 +37,7 @@ public class ShapePositionOrderingTests
     /// determines the final order, not the project/registration order.
     /// </summary>
     [Fact]
-    public async Task Items_ShouldOrderByPosition_NotByProjectRegistrationOrder()
+    public async Task Items_NotByProjectRegistrationOrder_OrderByPosition()
     {
         // Arrange
         var zone = new Shape();
@@ -68,7 +68,7 @@ public class ShapePositionOrderingTests
     /// are sorted purely by their position value.
     /// </summary>
     [Fact]
-    public async Task Items_ShouldOrderMultipleModuleShapes_ByPositionOnly()
+    public async Task Items_ByPositionOnly_OrderMultipleModuleShapes()
     {
         // Arrange - Simulate 5 different modules adding shapes in arbitrary order.
         var zone = new Shape();
@@ -102,7 +102,7 @@ public class ShapePositionOrderingTests
     /// and "after" comes after all numbered positions.
     /// </summary>
     [Fact]
-    public async Task Items_BeforeShouldBeFirst_AfterShouldBeLast()
+    public async Task Items_AfterBeLast_BeforeBeFirst()
     {
         // Arrange
         var zone = new Shape();
@@ -127,7 +127,7 @@ public class ShapePositionOrderingTests
     /// Proves the full ordering: before &lt; 0 &lt; 1 &lt; 2 &lt; ... &lt; after.
     /// </summary>
     [Fact]
-    public async Task Items_ShouldOrderCorrectly_BeforeNumbersAfter()
+    public async Task Items_BeforeNumbersAfter_OrderCorrectly()
     {
         // Arrange
         var zone = new Shape();
@@ -165,7 +165,7 @@ public class ShapePositionOrderingTests
     /// Proves that a shape with no position (empty string) is treated as position "0".
     /// </summary>
     [Fact]
-    public async Task Items_EmptyPosition_ShouldBeTreatedAsZero()
+    public async Task Items_EmptyPosition_IsTreatedAsZero()
     {
         // Arrange
         var zone = new Shape();
@@ -191,7 +191,7 @@ public class ShapePositionOrderingTests
     /// 12.5 should come after 12.4, and both after 11.
     /// </summary>
     [Fact]
-    public async Task Items_DotNotation_ShouldOrderCorrectly()
+    public async Task Items_DotNotation_OrderCorrectly()
     {
         // Arrange
         var zone = new Shape();
@@ -219,7 +219,7 @@ public class ShapePositionOrderingTests
     /// Proves that sub-positions work: 1 &lt; 1.1 &lt; 1.2 &lt; 1.10 &lt; 2.
     /// </summary>
     [Fact]
-    public async Task Items_SubPositions_ShouldOrderNumerically()
+    public async Task Items_SubPositions_OrderNumerically()
     {
         // Arrange
         var zone = new Shape();
@@ -254,7 +254,7 @@ public class ShapePositionOrderingTests
     /// Proves the complete ordering model works end-to-end.
     /// </summary>
     [Fact]
-    public async Task Items_CompleteOrdering_ShouldWorkEndToEnd()
+    public async Task Items_CompleteOrdering_WorksEndToEnd()
     {
         // Arrange
         var zone = new Shape();
@@ -300,7 +300,7 @@ public class ShapePositionOrderingTests
     /// but the position itself is the primary sort key.
     /// </summary>
     [Fact]
-    public async Task Items_SamePosition_ShouldMaintainStableOrder()
+    public async Task Items_SamePosition_MaintainStableOrder()
     {
         // Arrange
         var zone = new Shape();
@@ -330,7 +330,7 @@ public class ShapePositionOrderingTests
     /// Proves that deeply nested dot notation (e.g., 1.2.3) is supported.
     /// </summary>
     [Fact]
-    public async Task Items_DeepDotNotation_ShouldOrderCorrectly()
+    public async Task Items_DeepDotNotation_OrderCorrectly()
     {
         // Arrange
         var zone = new Shape();

--- a/test/OrchardCore.Tests/DisplayManagement/Zones/ZoneShapesTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Zones/ZoneShapesTests.cs
@@ -207,7 +207,7 @@ public class ZoneShapesTests
     #region Zone Shape Tests
 
     [Fact]
-    public async Task Zone_ShouldRenderAllShapes()
+    public async Task Zone_Default_RenderAllShapes()
     {
         // Arrange
         var shapes = new List<object>
@@ -229,7 +229,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task Zone_WithEmptyCollection_ShouldReturnEmpty()
+    public async Task Zone_EmptyCollection_ReturnsEmpty()
     {
         // Arrange
         var shapes = new List<object>();
@@ -248,7 +248,7 @@ public class ZoneShapesTests
     #region ContentZone Tests - No Grouping
 
     [Fact]
-    public async Task ContentZone_WithoutGrouping_ShouldRenderDirectly()
+    public async Task ContentZone_OutGrouping_RenderDirectly()
     {
         // Arrange
         var shape = await _shapeFactory.CreateAsync<Shape>("TestShape");
@@ -269,7 +269,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ContentZone_WithEmptyShapes_ShouldReturnEmpty()
+    public async Task ContentZone_EmptyShapes_ReturnsEmpty()
     {
         // Arrange
         var zone = new Shape();
@@ -285,7 +285,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ContentZone_WithoutGrouping_ShouldPreserveExistingPositionOrder()
+    public async Task ContentZone_OutGrouping_PreservesExistingPositionOrder()
     {
         // Arrange
         var first = CreateTestShape("First");
@@ -312,7 +312,7 @@ public class ZoneShapesTests
     #region ContentZone Tests - Tab Grouping
 
     [Fact]
-    public async Task ContentZone_WithMultipleTabs_ShouldCreateTabContainer()
+    public async Task ContentZone_MultipleTabs_CreatesTabContainer()
     {
         // Arrange
         var shape1 = CreateShapeWithTabGrouping("Tab1", "1");
@@ -339,7 +339,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ContentZone_WithSingleTab_ShouldRenderDirectlyWithoutTabContainer()
+    public async Task ContentZone_SingleTab_RenderDirectlyWithoutTabContainer()
     {
         // Arrange
         var shape1 = CreateShapeWithTabGrouping("Tab1", "1");
@@ -369,7 +369,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ContentZone_TabsWithPosition_ShouldOrderCorrectly()
+    public async Task ContentZone_TabsWithPosition_OrderCorrectly()
     {
         // Arrange
         var shape1 = CreateShapeWithTabGrouping("Tab3", "5");
@@ -403,7 +403,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ContentZone_TabsWithContentKey_ShouldHandleDefault()
+    public async Task ContentZone_TabsWithContentKey_HandlesDefault()
     {
         // Arrange
         var shape1 = CreateShapeWithTabGrouping("Tab1", "1");
@@ -441,7 +441,7 @@ public class ZoneShapesTests
     #region CardGrouping Tests
 
     [Fact]
-    public async Task CardGrouping_WithMultipleCards_ShouldCreateCardContainer()
+    public async Task CardGrouping_MultipleCards_CreatesCardContainer()
     {
         // Arrange
         var shape1 = CreateShapeWithCardGrouping("Card1", "1");
@@ -467,7 +467,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task CardGrouping_WithSingleCard_ShouldProceedToColumnGrouping()
+    public async Task CardGrouping_SingleCard_ProceedToColumnGrouping()
     {
         // Arrange
         var shape1 = CreateShapeWithCardGrouping("Card1", "1");
@@ -492,7 +492,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task CardGrouping_CardsWithPosition_ShouldOrderCorrectly()
+    public async Task CardGrouping_CardsWithPosition_OrderCorrectly()
     {
         // Arrange
         var shape1 = CreateShapeWithCardGrouping("Card3", "3");
@@ -534,7 +534,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task CardGrouping_WithContentKey_ShouldHandleDefault()
+    public async Task CardGrouping_ContentKey_HandlesDefault()
     {
         // Arrange
         var shape1 = CreateShapeWithCardGrouping("Card1", "1");
@@ -566,7 +566,7 @@ public class ZoneShapesTests
     #region ColumnGrouping Tests
 
     [Fact]
-    public async Task ColumnGrouping_WithMultipleColumns_ShouldCreateColumnContainer()
+    public async Task ColumnGrouping_MultipleColumns_CreatesColumnContainer()
     {
         // Arrange
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", null);
@@ -590,7 +590,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_WithSameColumnName_ShouldCreateSeparateColumns()
+    public async Task ColumnGrouping_SameColumnName_CreatesSeparateColumns()
     {
         // Arrange - items with same column name each get their own column wrapper
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", null);
@@ -622,7 +622,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_ColumnsWithPosition_ShouldOrderCorrectly()
+    public async Task ColumnGrouping_ColumnsWithPosition_OrderCorrectly()
     {
         // Arrange
         var shape1 = CreateShapeWithColumnGrouping("Col3", "3", null);
@@ -663,7 +663,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_WithWidthModifier_ShouldApplyColumnClasses()
+    public async Task ColumnGrouping_WidthModifier_ApplyColumnClasses()
     {
         // Arrange
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", "6");
@@ -686,7 +686,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_WithBreakpointModifier_ShouldApplyCorrectClasses()
+    public async Task ColumnGrouping_BreakpointModifier_ApplyCorrectClasses()
     {
         // Arrange
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", "lg-4");
@@ -710,7 +710,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_WithoutWidthModifier_ShouldApplyDefaultClasses()
+    public async Task ColumnGrouping_OutWidthModifier_ApplyDefaultClasses()
     {
         // Arrange
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", null);
@@ -733,7 +733,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_WithContentKey_ShouldRenderNonColumnItemsOutsideRow()
+    public async Task ColumnGrouping_ContentKey_RenderNonColumnItemsOutsideRow()
     {
         // Arrange
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", null);
@@ -764,7 +764,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_NonColumnItemsAfterColumns_ShouldRenderAfterRow()
+    public async Task ColumnGrouping_NonColumnItemsAfterColumns_RenderAfterRow()
     {
         // Arrange - column items first, then non-column item
         var shape1 = CreateShapeWithColumnGrouping("Left", "1", "4");
@@ -799,7 +799,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_NonColumnItemsBeforeColumns_ShouldRenderBeforeRow()
+    public async Task ColumnGrouping_NonColumnItemsBeforeColumns_RenderBeforeRow()
     {
         // Arrange - non-column item first, then column items
         var shape1 = CreateShapeWithoutGrouping(); // Goes to "Content" key, before columns
@@ -830,7 +830,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_ShouldPreserveExistingPositionOrderForNonColumnItems()
+    public async Task ColumnGrouping_Default_PreservesExistingPositionOrderForNonColumnItems()
     {
         // Arrange
         var beforeSecond = CreateTestShape("BeforeSecond");
@@ -868,7 +868,7 @@ public class ZoneShapesTests
     #region Complex Grouping Scenarios
 
     [Fact]
-    public async Task ContentZone_WithTabCardAndColumn_ShouldProcessHierarchically()
+    public async Task ContentZone_TabCardAndColumn_ProcessHierarchically()
     {
         // Arrange - Shapes with Tab -> Card -> Column hierarchy
         var shape1 = CreateShapeWithFullGrouping("Tab1", "1", "Card1", "1", "Col1", "1", "6");
@@ -903,7 +903,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ContentZone_MixedGroupingLevels_ShouldHandleCorrectly()
+    public async Task ContentZone_MixedGroupingLevels_HandlesCorrectly()
     {
         // Arrange - Some shapes with tabs, some without
         var shape1 = CreateShapeWithTabGrouping("Tab1", "1");

--- a/test/OrchardCore.Tests/Email/EmailAddressValidatorTests.cs
+++ b/test/OrchardCore.Tests/Email/EmailAddressValidatorTests.cs
@@ -10,7 +10,7 @@ public class EmailAddressValidatorTests
     [InlineData("mailbox@domain", true)]
     [InlineData(null, false)]
     [InlineData("", false)]
-    public void ValidateEmailAddress(string address, bool isValid)
+    public void ValidateEmailAddress_Default_Succeeds(string address, bool isValid)
     {
         // Arrange
         var emailAddressValidator = new EmailAddressValidator();
@@ -22,7 +22,7 @@ public class EmailAddressValidatorTests
     [Theory]
     [InlineData("hishamco_2007@hotmail.com", false)]
     [InlineData("hishamco@orchardcore.net", true)]
-    public void UseCustomEmailAddressValidator(string address, bool isValid)
+    public void UseCustomEmailAddressValidator_Default_Succeeds(string address, bool isValid)
     {
         // Arrange
         var emailAddressValidator = new OrchardCoreEmailValidator();

--- a/test/OrchardCore.Tests/Email/EmailTests.cs
+++ b/test/OrchardCore.Tests/Email/EmailTests.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Email;
 public class EmailTests
 {
     [Fact]
-    public async Task SendEmail_UsesDefaultSender()
+    public async Task SendEmail_Default_UsesDefaultSender()
     {
         // Arrange
         var message = new MailMessage
@@ -25,7 +25,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_WithCcHeader()
+    public async Task SendEmail_CcHeader_Succeeds()
     {
         // Arrange
         var message = new MailMessage
@@ -43,7 +43,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_WithBccHeader()
+    public async Task SendEmail_BccHeader_Succeeds()
     {
         // Arrange
         var message = new MailMessage
@@ -61,7 +61,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_WithDisplayName()
+    public async Task SendEmail_DisplayName_Succeeds()
     {
         var message = new MailMessage
         {
@@ -74,7 +74,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_UsesCustomSender()
+    public async Task SendEmail_Default_UsesCustomSender()
     {
         var message = new MailMessage
         {
@@ -90,7 +90,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_UsesCustomAuthorAndSender()
+    public async Task SendEmail_Default_UsesCustomAuthorAndSender()
     {
         var message = new MailMessage
         {
@@ -106,7 +106,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_UsesMultipleAuthors()
+    public async Task SendEmail_Default_UsesMultipleAuthors()
     {
         var message = new MailMessage
         {
@@ -122,7 +122,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_UsesReplyTo()
+    public async Task SendEmail_Default_UsesReplyTo()
     {
         var message = new MailMessage
         {
@@ -139,7 +139,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task ReplyTo_ShouldHaveAuthors_IfNotSet()
+    public async Task ReplyTo_NotSet_HasAuthors()
     {
         var message = new MailMessage
         {
@@ -162,7 +162,7 @@ public class EmailTests
     [InlineData("mailbox@domain.com", "", "mailbox@domain.com")]
     [InlineData("(comment)mailbox(comment)@(comment)domain.com(me) ", "me", "mailbox@domain.com")]
     [InlineData("Sébastien <sébastien@domain.com>", "Sébastien", "sébastien@domain.com")]
-    public void MailBoxAddress_ShouldParseEmail(string text, string name, string address)
+    public void MailBoxAddress_Default_ParsesEmail(string text, string name, string address)
     {
         Assert.True(MailboxAddress.TryParse(text, out var mailboxAddress));
         Assert.Equal(name, mailboxAddress.Name);
@@ -170,7 +170,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_WithoutToAndCcAndBccHeaders_ShouldThrowsException()
+    public async Task SendEmail_OutToAndCcAndBccHeaders_ThrowsException()
     {
         // Arrange
         var message = new MailMessage
@@ -194,7 +194,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_WithTextAndHtmlFormats()
+    public async Task SendEmail_TextAndHtmlFormats_Succeeds()
     {
         // Arrange
         var message = new MailMessage
@@ -216,7 +216,7 @@ public class EmailTests
     }
 
     [Fact]
-    public async Task SendEmail_CreatesMissingPickupDirectory()
+    public async Task SendEmail_Default_CreatesMissingPickupDirectory()
     {
         // Arrange
         var pickupDirectoryPath = Path.Combine(Directory.GetCurrentDirectory(), "Email", "Sites", "Blog1", "Emails");

--- a/test/OrchardCore.Tests/Email/SmtpOptionsConfigurationTests.cs
+++ b/test/OrchardCore.Tests/Email/SmtpOptionsConfigurationTests.cs
@@ -20,7 +20,7 @@ public class SmtpOptionsConfigurationTests
     [InlineData("/Outbound", "Outbound")]
     [InlineData("Outbound", "Outbound")]
     [InlineData("Email/Outbound", "Email\\Outbound")]
-    public void Configure_ResolvesPickupDirectoryLocationUnderDefaultTenantBase(string pickupDirectoryLocation, string expectedRelativePath)
+    public void Configure_Default_ResolvesPickupDirectoryLocationUnderDefaultTenantBase(string pickupDirectoryLocation, string expectedRelativePath)
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -46,7 +46,7 @@ public class SmtpOptionsConfigurationTests
     }
 
     [Fact]
-    public void Configure_UsesConfiguredPickupDirectoryLocationBaseWithFluidTokens()
+    public void Configure_Default_UsesConfiguredPickupDirectoryLocationBaseWithFluidTokens()
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -78,7 +78,7 @@ public class SmtpOptionsConfigurationTests
     [InlineData("Email\\..\\Shared")]
     [InlineData("C:\\Emails")]
     [InlineData("\\\\server\\share\\Emails")]
-    public void Configure_DisablesPickupDirectoryOutsideConfiguredBase(string pickupDirectoryLocation)
+    public void Configure_DisablesPickupDirectoryOutsideConfiguredBase_Succeeds(string pickupDirectoryLocation)
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -100,7 +100,7 @@ public class SmtpOptionsConfigurationTests
     }
 
     [Fact]
-    public void PostConfigure_ResolvesDefaultPickupDirectoryLocationBase()
+    public void PostConfigure_Default_ResolvesDefaultPickupDirectoryLocationBase()
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -130,7 +130,7 @@ public class SmtpOptionsConfigurationTests
     }
 
     [Fact]
-    public void PostConfigure_DisablesDefaultPickupDirectoryLocationOutsideConfiguredBase()
+    public void PostConfigure_DisablesDefaultPickupDirectoryLocationOutsideConfiguredBase_Succeeds()
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -160,7 +160,7 @@ public class SmtpOptionsConfigurationTests
     }
 
     [Fact]
-    public void PostConfigure_UsesSlashRootForConfiguredPickupDirectoryLocation()
+    public void PostConfigure_Default_UsesSlashRootForConfiguredPickupDirectoryLocation()
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings

--- a/test/OrchardCore.Tests/Email/SmtpPickupDirectoryResolverTests.cs
+++ b/test/OrchardCore.Tests/Email/SmtpPickupDirectoryResolverTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Tests.Email;
 public class SmtpPickupDirectoryResolverTests
 {
     [Fact]
-    public void GetPickupDirectoryLocationBase_UsesDefaultTemplate()
+    public void GetPickupDirectoryLocationBase_Default_UsesDefaultTemplate()
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -29,7 +29,7 @@ public class SmtpPickupDirectoryResolverTests
     }
 
     [Fact]
-    public void GetPickupDirectoryLocationBase_ExpandsFluidTokens()
+    public void GetPickupDirectoryLocationBase_ExpandsFluidTokens_Succeeds()
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -56,7 +56,7 @@ public class SmtpPickupDirectoryResolverTests
     [InlineData("/Outbound")]
     [InlineData("Outbound")]
     [InlineData("Email/Outbound")]
-    public void IsValidPickupDirectoryLocation_AllowsSupportedValues(string pickupDirectoryLocation)
+    public void IsValidPickupDirectoryLocation_Default_AllowssSupportedValues(string pickupDirectoryLocation)
     {
         Assert.True(SmtpPickupDirectoryResolver.IsValidPickupDirectoryLocation(pickupDirectoryLocation));
     }
@@ -77,13 +77,13 @@ public class SmtpPickupDirectoryResolverTests
     [InlineData("C:\\Emails")]
     [InlineData("\\\\server\\share\\Emails")]
     [InlineData("{{ ShellSettings.Name }}\\Emails")]
-    public void IsValidPickupDirectoryLocation_RejectsUnsafeValues(string pickupDirectoryLocation)
+    public void IsValidPickupDirectoryLocation_Default_RejectssUnsafeValues(string pickupDirectoryLocation)
     {
         Assert.False(SmtpPickupDirectoryResolver.IsValidPickupDirectoryLocation(pickupDirectoryLocation));
     }
 
     [Fact]
-    public void ConfigurePickupDirectory_AppliesBaseAndResolvedPath()
+    public void ConfigurePickupDirectory_AppliesBaseAndResolvedPath_Succeeds()
     {
         var appDataPath = GetRootedPath("App", "App_Data");
         var shellSettings = new ShellSettings
@@ -114,7 +114,7 @@ public class SmtpPickupDirectoryResolverTests
     [InlineData("/", null)]
     [InlineData("/Outbound", "Outbound")]
     [InlineData("Email/Outbound", "Email/Outbound")]
-    public void ResolvePickupDirectoryLocation_ResolvesInsideBasePath(string pickupDirectoryLocation, string expectedRelativePath)
+    public void ResolvePickupDirectoryLocation_Default_ResolvesInsideBasePath(string pickupDirectoryLocation, string expectedRelativePath)
     {
         var basePath = GetRootedPath("App", "App_Data", "Sites", "Default", "Emails");
 
@@ -132,7 +132,7 @@ public class SmtpPickupDirectoryResolverTests
     [InlineData("../Shared")]
     [InlineData("./Drafts")]
     [InlineData("Emails/../Shared")]
-    public void ResolvePickupDirectoryLocation_ThrowsForUnsafeValues(string pickupDirectoryLocation)
+    public void ResolvePickupDirectoryLocation_Default_ThrowsForUnsafeValues(string pickupDirectoryLocation)
     {
         var basePath = GetRootedPath("App", "App_Data", "Sites", "Default", "Emails");
 

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -76,7 +76,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void ShouldReturnExtension()
+    public void Return_Extension_Succeeds()
     {
         var extensions = _moduleThemeScopedExtensionManager.GetExtensions()
             .Where(e => e.Manifest.ModuleInfo.Category == "Test");
@@ -85,7 +85,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void ShouldReturnAllDependenciesIncludingFeatureForAGivenFeatureOrdered()
+    public void Return_AllDependenciesIncludingFeatureForAGivenFeatureOrdered_Succeeds()
     {
         var features = _moduleScopedExtensionManager.GetFeatureDependencies("Sample3");
 
@@ -96,7 +96,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void ShouldNotReturnFeaturesNotDependentOn()
+    public void Not_ReturnFeaturesNotDependentOn_Succeeds()
     {
         var features = _moduleScopedExtensionManager.GetFeatureDependencies("Sample2");
 
@@ -106,7 +106,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void GetDependentFeaturesShouldReturnAllFeaturesThatHaveADependencyOnAFeature()
+    public void GetDependentFeatures_Default_ReturnsAllFeaturesThatHaveADependencyOnAFeature()
     {
         var features = _moduleScopedExtensionManager.GetDependentFeatures("Sample1");
 
@@ -118,7 +118,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void GetFeaturesShouldReturnAllFeaturesOrderedByDependency()
+    public void GetFeatures_Default_ReturnsAllFeaturesOrderedByDependency()
     {
         var features = _moduleScopedExtensionManager.GetFeatures()
             .Where(f => f.Category == "Test" && !f.IsTheme());
@@ -131,7 +131,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void GetFeaturesWithAIdShouldReturnThatFeatureWithDependenciesOrdered()
+    public void GetFeaturesWithAId_Default_ReturnsThatFeatureWithDependenciesOrdered()
     {
         var features = _moduleScopedExtensionManager.GetFeatures((IEnumerable<string>)["Sample2"]);
 
@@ -141,7 +141,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void GetFeaturesWithAIdShouldReturnThatFeatureWithDependenciesOrderedWithNoDuplicates()
+    public void GetFeaturesWithAId_Default_ReturnsThatFeatureWithDependenciesOrderedWithNoDuplicates()
     {
         var features = _moduleScopedExtensionManager.GetFeatures((IEnumerable<string>)["Sample2", "Sample3"]);
 
@@ -152,7 +152,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void GetFeaturesWithAIdShouldNotReturnFeaturesTheHaveADependencyOutsideOfGraph()
+    public void GetFeaturesWithAId_Default_DoesNotReturnFeaturesTheHaveADependencyOutsideOfGraph()
     {
         var features = _moduleScopedExtensionManager.GetFeatures((IEnumerable<string>)["Sample4"]);
 
@@ -165,7 +165,7 @@ public class ExtensionManagerTests
     /* Theme Base Theme Dependencies */
 
     [Fact]
-    public void GetFeaturesShouldReturnCorrectThemeHierarchy()
+    public void GetFeatures_Default_ReturnsCorrectThemeHierarchy()
     {
         var features = _themeScopedExtensionManager.GetFeatures((IEnumerable<string>)["DerivedThemeSample"]);
 
@@ -177,7 +177,7 @@ public class ExtensionManagerTests
     /* Theme and Module Dependencies */
 
     [Fact]
-    public void GetFeaturesShouldReturnBothThemesAndModules()
+    public void GetFeatures_Default_ReturnsBothThemesAndModules()
     {
         var features = _moduleThemeScopedExtensionManager.GetFeatures()
             .Where(f => f.Category == "Test");
@@ -186,7 +186,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void GetFeaturesShouldReturnThemesAfterModules()
+    public void GetFeatures_Default_ReturnsThemesAfterModules()
     {
         var features = _moduleThemeScopedExtensionManager.GetFeatures()
             .Where(f => f.Category == "Test");
@@ -202,7 +202,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void GetFeaturesShouldReturnThemesAfterModulesWhenRequestingBoth()
+    public void GetFeatures_RequestingBoth_ReturnsThemesAfterModules()
     {
         var features = _moduleThemeScopedExtensionManager.GetFeatures((IEnumerable<string>)["DerivedThemeSample", "Sample3"]);
 
@@ -214,7 +214,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void ShouldReturnNotFoundExtensionInfoWhenNotFound()
+    public void Return_NotFound_Succeeds()
     {
         var extension = _moduleThemeScopedExtensionManager.GetExtension("NotFound");
 
@@ -224,7 +224,7 @@ public class ExtensionManagerTests
     /* The extension manager must populate the ITypeFeatureProvider correctly */
 
     [Fact]
-    public void TypeFeatureProviderIsPopulatedWithComponentTypes()
+    public void TypeFeatureProviderIsPopulatedWithComponentTypes_Default_Succeeds()
     {
         var feature = _moduleScopedExtensionManager.GetFeatures((IEnumerable<string>)["Sample1"]).First();
         var types = _moduleScopedTypeFeatureProvider.GetTypesForFeature(feature);
@@ -235,7 +235,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void TypeFeatureProviderTypeMustBeMappedToAllFeatures()
+    public void TypeFeatureProviderType_Default_BeMappedToAllFeatures()
     {
         // Types in modules that have no feature that matches the extension ID must be mapped to all features.
         var features = _moduleScopedExtensionManager.GetFeatures((IEnumerable<string>)["Sample1", "Sample2", "Sample3", "Sample4"]);
@@ -249,7 +249,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void TypeFeatureProviderTypeMustBeMappedToExtensionFeature()
+    public void TypeFeatureProviderType_Default_BeMappedToExtensionFeature()
     {
         // Types in modules that have a feature that matches the extension ID must be mapped to that feature.
         var feature = _moduleScopedExtensionManager.GetFeatures((IEnumerable<string>)["BaseThemeSample"]).First();
@@ -261,7 +261,7 @@ public class ExtensionManagerTests
     }
 
     [Fact]
-    public void TypeFeatureProviderTypeMustBeSkipped()
+    public void TypeFeatureProviderType_Default_BeSkipped()
     {
         var feature = _moduleScopedExtensionManager.GetFeatures((IEnumerable<string>)["Sample2"]).First();
         var types = _moduleScopedTypeFeatureProvider.GetTypesForFeature(feature);

--- a/test/OrchardCore.Tests/Hosting/Console/CommandParserTests.cs
+++ b/test/OrchardCore.Tests/Hosting/Console/CommandParserTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Hosting.Console;
 public class CommandParserTests
 {
     [Fact]
-    public void ParserUnderstandsSimpleArguments()
+    public void ParserUnderstandsSimpleArguments_Default_Succeeds()
     {
         // a b cdef
         // => a
@@ -20,7 +20,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserIgnoresExtraSpaces()
+    public void ParserIgnoresExtraSpaces_Default_Succeeds()
     {
         //  a    b    cdef
         // => a
@@ -35,7 +35,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserGroupsQuotedArguments()
+    public void ParserGroupsQuotedArguments_Default_Succeeds()
     {
         // feature enable "a b cdef"
         // => feature
@@ -50,7 +50,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserUnderstandsQuotesInsideArgument()
+    public void ParserUnderstandsQuotesInsideArgument_Default_Succeeds()
     {
         // feature enable /foo:"a b cdef"
         // => feature
@@ -65,7 +65,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserBackslashEscapesQuote()
+    public void ParserBackslashEscapesQuote_Default_Succeeds()
     {
         // feature enable \"a b cdef\"
         // => feature
@@ -84,7 +84,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserBackslashDoesnotEscapeBackslash()
+    public void ParserBackslashDoesnotEscapeBackslash_Default_Succeeds()
     {
         // feature enable \\a
         // => feature
@@ -99,7 +99,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserBackslashDoesnotEscapeOtherCharacters()
+    public void ParserBackslashDoesnotEscapeOtherCharacters_Default_Succeeds()
     {
         // feature enable \a
         // => feature
@@ -114,7 +114,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserUnderstandsTrailingBackslash()
+    public void ParserUnderstandsTrailingBackslash_Default_Succeeds()
     {
         // feature enable \
         // => feature
@@ -129,7 +129,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserUnderstandsTrailingBackslash2()
+    public void ParserUnderstandsTrailingBackslash2_Default_Succeeds()
     {
         // feature enable b\
         // => feature
@@ -144,7 +144,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserUnderstandsEmptyArgument()
+    public void ParserUnderstandsEmptyArgument_Default_Succeeds()
     {
         // feature enable ""
         // => feature
@@ -159,7 +159,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserUnderstandsTrailingQuote()
+    public void ParserUnderstandsTrailingQuote_Default_Succeeds()
     {
         // feature enable "
         // => feature
@@ -174,7 +174,7 @@ public class CommandParserTests
     }
 
     [Fact]
-    public void ParserUnderstandsEmptyArgument2()
+    public void ParserUnderstandsEmptyArgument2_Default_Succeeds()
     {
         // "
         // => <empty arg>
@@ -184,7 +184,7 @@ public class CommandParserTests
         Assert.Equal("", result[0]);
     }
     [Fact]
-    public void ParserUnderstandsEmptyArgument3()
+    public void ParserUnderstandsEmptyArgument3_Default_Succeeds()
     {
         // ""
         // => <empty arg>

--- a/test/OrchardCore.Tests/Html/HtmlSanitizerTests.cs
+++ b/test/OrchardCore.Tests/Html/HtmlSanitizerTests.cs
@@ -11,7 +11,7 @@ public class HtmlSanitizerTests
     [InlineData("<IMG SRC=javascript:alert(\"XSS\")>", @"<img>")]
     [InlineData("<a href=\"javascript: alert('xss')\">Click me</a>", @"<a>Click me</a>")]
     [InlineData("<a href=\"[locale 'en']javascript: alert('xss')[/locale]\">Click me</a>", @"<a>Click me</a>")]
-    public void ShouldSanitizeHTML(string html, string sanitized)
+    public void Sanitize_HTML_Succeeds(string html, string sanitized)
     {
         // Setup
         var output = _sanitizer.Sanitize(html);
@@ -21,7 +21,7 @@ public class HtmlSanitizerTests
     }
 
     [Fact]
-    public void ShouldConfigureSanitizer()
+    public void Configure_Sanitizer_Succeeds()
     {
         var services = new ServiceCollection();
         services.AddOptions<HtmlSanitizerOptions>();
@@ -40,7 +40,7 @@ public class HtmlSanitizerTests
     }
 
     [Fact]
-    public void ShouldReconfigureSanitizer()
+    public void Reconfigure_Sanitizer_Succeeds()
     {
         // Setup. With defaults.
         var services = new ServiceCollection();

--- a/test/OrchardCore.Tests/Infrastructure/ResultTests.cs
+++ b/test/OrchardCore.Tests/Infrastructure/ResultTests.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Infrastructure.Tests;
 public class ResultTests
 {
     [Fact]
-    public void Success_ShouldBeSingleton_WithSucceededTrue_AndNoErrors()
+    public void Success_SucceededTrueAndNoErrors_IsSingleton()
     {
         // Arrange & Act
         var firstResult = Result.Success();
@@ -16,7 +16,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void SuccessOfT_ReturnsResultOfT_WithProvidedValue_AndSucceededTrue()
+    public void SuccessOfT_SucceededTrue_ReturnsResultOfTWithProvidedValue()
     {
         // Arrange
         var value = "Done!!";
@@ -32,7 +32,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void Failed_NullArray_ReturnsFailed_WithNoErrors()
+    public void Failed_NullArray_ReturnsFailedWithNoErrors()
     {
         // Arrange & Act
         var result = Result.Failed((ResultError[])null);
@@ -43,7 +43,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void Failed_NoArguments_ReturnsFailed_WithNoErrors()
+    public void Failed_NoArguments_ReturnsFailedWithNoErrors()
     {
         // Arrange & Act
         var result = Result.Failed();
@@ -54,7 +54,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void Failed_WithMultipleErrors_AddsAllErrors()
+    public void Failed_MultipleErrors_AddsAllErrors()
     {
         // Arrange
         var error1 = new ResultError { Message = new LocalizedString("FirstName", "First Name is required.") };
@@ -73,7 +73,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void Failed_WithLocalizedString_CreatesSingleResultError_WithMatchingMessage()
+    public void Failed_LocalizedString_CreatesSingleResultErrorWithMatchingMessage()
     {
         // Arrange
         var localized = new LocalizedString("key", "message text");
@@ -90,7 +90,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void FailedT_ReturnsResultT_WithDefaultValue_AndProvidedErrors()
+    public void FailedT_ProvidedErrors_ReturnsResultTWithDefaultValue()
     {
         // Arrange
         var error = new ResultError { Message = new LocalizedString("key", "message text") };

--- a/test/OrchardCore.Tests/Localization/CultureDictionaryTests.cs
+++ b/test/OrchardCore.Tests/Localization/CultureDictionaryTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Localization;
 public class CultureDictionaryTests
 {
     [Fact]
-    public void MergeAddsRecordToEmptyDictionary()
+    public void MergeAddsRecordToEmptyDictionary_Default_Succeeds()
     {
         var dictionary = new CultureDictionary("cs", PluralizationRule.Czech);
         var record = new CultureDictionaryRecord("ball", "míč", "míče", "míčů");
@@ -16,7 +16,7 @@ public class CultureDictionaryTests
     }
 
     [Fact]
-    public void MergeOverwritesTranslationsForSameKeys()
+    public void MergeOverwritesTranslationsForSameKeys_Default_Succeeds()
     {
         var dictionary = new CultureDictionary("cs", PluralizationRule.Czech);
         var record = new CultureDictionaryRecord("ball", "míč", "míče", "míčů");
@@ -29,7 +29,7 @@ public class CultureDictionaryTests
     }
 
     [Fact]
-    public void IndexerReturnNullIfKeyDoesntExist()
+    public void IndexerReturnNullIfKeyDoesntExist_Default_Succeeds()
     {
         var dictionary = new CultureDictionary("cs", PluralizationRule.Czech);
         var key = new CultureDictionaryRecordKey { MessageId = "ball" };
@@ -39,7 +39,7 @@ public class CultureDictionaryTests
     }
 
     [Fact]
-    public void IndexerThrowsPluralFormNotFoundExceptionIfSpecifiedPluralFormDoesntExist()
+    public void IndexerThrowsPluralFormNotFoundExceptionIfSpecifiedPluralFormDoesntExist_Default_Succeeds()
     {
         // Arrange
         var dictionary = new CultureDictionary("cs", PluralizationRule.Czech);
@@ -55,7 +55,7 @@ public class CultureDictionaryTests
     }
 
     [Fact]
-    public void EnumerateCultureDictionary()
+    public void EnumerateCultureDictionary_Default_Succeeds()
     {
         // Arrange
         var dictionary = new CultureDictionary("ar", PluralizationRule.Arabic);

--- a/test/OrchardCore.Tests/Localization/CultureScopeTests.cs
+++ b/test/OrchardCore.Tests/Localization/CultureScopeTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Localization;
 public class CultureScopeTests
 {
     [Fact]
-    public void CultureScopeSetsUICultureIfNotProvided()
+    public void CultureScopeSetsUICultureIfNotProvided_Default_Succeeds()
     {
         // Arrange
         var culture = "ar-YE";
@@ -19,7 +19,7 @@ public class CultureScopeTests
     }
 
     [Fact]
-    public void CultureScopeSetsBothCultureAndUICulture()
+    public void CultureScopeSetsBothCultureAndUICulture_Default_Succeeds()
     {
         // Arrange
         var culture = "ar";
@@ -34,7 +34,7 @@ public class CultureScopeTests
     }
 
     [Fact]
-    public void CultureScopeSetsOrginalCulturesAfterEndOfScope()
+    public void CultureScopeSetsOrginalCulturesAfterEndOfScope_Default_Succeeds()
     {
         // Arrange
         var culture = CultureInfo.CurrentCulture;
@@ -52,7 +52,7 @@ public class CultureScopeTests
     }
 
     [Fact]
-    public async Task CultureScopeSetsOrginalCulturesOnException()
+    public async Task CultureScopeSetsOrginalCulturesOnException_Default_Succeeds()
     {
         // Arrange
         var culture = CultureInfo.CurrentCulture;

--- a/test/OrchardCore.Tests/Localization/Data/DataLocalizedStringTests.cs
+++ b/test/OrchardCore.Tests/Localization/Data/DataLocalizedStringTests.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Localization.Data.Tests;
 public class DataLocalizedStringTests
 {
     [Fact]
-    public void DataLocalizedString_ReturnsValue_WithStringDataType()
+    public void DataLocalizedString_StringDataType_ReturnsValue()
     {
         // Arrange
         var dataLocalizedString = new DataLocalizedString("Content Types", "Blog", "Translated Blog");
@@ -16,7 +16,7 @@ public class DataLocalizedStringTests
     }
 
     [Fact]
-    public void DataLocalizedString_ReturnsValue_WithVarDataType()
+    public void DataLocalizedString_VarDataType_ReturnsValue()
     {
         // Arrange
         var dataLocalizedString = new DataLocalizedString("Content Types", "Blog", "Translated Blog");
@@ -29,7 +29,7 @@ public class DataLocalizedStringTests
     }
 
     [Fact]
-    public void DataLocalizedString_ReturnsValue_WithToString()
+    public void DataLocalizedString_ToString_ReturnsValue()
     {
         // Arrange
         var dataLocalizedString = new DataLocalizedString("Content Types", "Blog", "Translated Blog");
@@ -42,7 +42,7 @@ public class DataLocalizedStringTests
     }
 
     [Fact]
-    public void DataLocalizedString_ReturnsValue_WithLocalizer()
+    public void DataLocalizedString_Localizer_ReturnsValue()
     {
         // Arrange
         var context = "context";

--- a/test/OrchardCore.Tests/Localization/Data/DataLocalizerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Localization/Data/DataLocalizerFactoryTests.cs
@@ -10,7 +10,7 @@ public class DataLocalizerFactoryTests
     }
 
     [Fact]
-    public void CreateDataLocalizer()
+    public void CreateDataLocalizer_Default_Succeeds()
     {
         // Arrange
         var context = "context";

--- a/test/OrchardCore.Tests/Localization/Data/DataLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/Data/DataLocalizerTests.cs
@@ -19,7 +19,7 @@ public class DataLocalizerTests : IDisposable
     }
 
     [Fact]
-    public void LocalizerReturnsTranslationsFromProvidedDictionary()
+    public void LocalizerReturnsTranslationsFromProvidedDictionary_Default_Succeeds()
     {
         // Arrange
         SetupDictionary("fr", new CultureDictionaryRecord("Hello", _context, new[] { "Bonjour" }));
@@ -36,7 +36,7 @@ public class DataLocalizerTests : IDisposable
     }
 
     [Fact]
-    public void LocalizerReturnsOriginalTextIfTranslationsDoesntExistInProvidedDictionary()
+    public void LocalizerReturnsOriginalTextIfTranslationsDoesntExistInProvidedDictionary_Default_Succeeds()
     {
         // Arrange
         SetupDictionary("fr", new CultureDictionaryRecord("Hello", _context, new[] { "Bonjour" }));
@@ -53,7 +53,7 @@ public class DataLocalizerTests : IDisposable
     }
 
     [Fact]
-    public void LocalizerReturnsOriginalTextIfDictionaryIsEmpty()
+    public void LocalizerReturnsOriginalTextIfDictionaryIsEmpty_Default_Succeeds()
     {
         // Arrange
         SetupDictionary("fr", Array.Empty<CultureDictionaryRecord>());
@@ -70,7 +70,7 @@ public class DataLocalizerTests : IDisposable
     }
 
     [Fact]
-    public void LocalizerFallbacksToParentCultureIfTranslationDoesntExistInSpecificCulture()
+    public void LocalizerFallbacksToParentCultureIfTranslationDoesntExistInSpecificCulture_Default_Succeeds()
     {
         // Arrange
         SetupDictionary("fr", new CultureDictionaryRecord("Hello", _context, new[] { "Bonjour" }));
@@ -89,7 +89,7 @@ public class DataLocalizerTests : IDisposable
     }
 
     [Fact]
-    public void LocalizerReturnsTranslationFromSpecificCultureIfItExists()
+    public void LocalizerReturnsTranslationFromSpecificCultureIfItExists_Default_Succeeds()
     {
         // Arrange
         SetupDictionary("fr", new CultureDictionaryRecord("Hello", _context, new[] { "Bonjour" }));
@@ -108,7 +108,7 @@ public class DataLocalizerTests : IDisposable
     }
 
     [Fact]
-    public void LocalizerReturnsFormattedTranslation()
+    public void LocalizerReturnsFormattedTranslation_Default_Succeeds()
     {
         // Arrange
         SetupDictionary("cs", new CultureDictionaryRecord("The page (ID:{0}) was deleted.", _context, new[] { "Stránka (ID:{0}) byla smazána." }));
@@ -127,7 +127,7 @@ public class DataLocalizerTests : IDisposable
     [Theory]
     [InlineData(false, "hello", "hello")]
     [InlineData(true, "hello", "مرحبا")]
-    public void LocalizerFallBackToParentCultureIfFallBackToParentUICulturesIsTrue(bool fallBackToParentCulture, string resourceKey, string expected)
+    public void LocalizerFallBackToParentCultureIfFallBackToParentUICulturesIsTrue_Default_Succeeds(bool fallBackToParentCulture, string resourceKey, string expected)
     {
         // Arrange
         SetupDictionary("ar", new CultureDictionaryRecord("hello", _context, new[] { "مرحبا" }));
@@ -147,7 +147,7 @@ public class DataLocalizerTests : IDisposable
     [Theory]
     [InlineData(false, new[] { "مدونة", "منتج" })]
     [InlineData(true, new[] { "مدونة", "منتج", "قائمة", "صفحة", "مقالة" })]
-    public void LocalizerReturnsGetAllStrings(bool includeParentCultures, string[] expected)
+    public void LocalizerReturnsGetAllStrings_Default_Succeeds(bool includeParentCultures, string[] expected)
     {
         // Arrange
         SetupDictionary("ar", new CultureDictionaryRecord[]

--- a/test/OrchardCore.Tests/Localization/DefaultPluralRuleProviderTests.cs
+++ b/test/OrchardCore.Tests/Localization/DefaultPluralRuleProviderTests.cs
@@ -12,7 +12,7 @@ public class DefaultPluralRuleProviderTests
     [InlineData("zh-Hans-CN", "zh")]
     [InlineData("zh-Hans", "zh")]
     [InlineData("zh-Hant", "zh")]
-    public void TryGetRuleShouldReturnRuleForTopCulture(string culture, string expected)
+    public void TryGetRule_Default_ReturnsRuleForTopCulture(string culture, string expected)
     {
         var expectedCulture = CultureInfo.GetCultureInfo(expected);
         var testCulture = CultureInfo.GetCultureInfo(culture);

--- a/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
+++ b/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
@@ -22,7 +22,7 @@ public class LocalizationManagerTests : IDisposable
     }
 
     [Fact]
-    public void GetDictionaryReturnsDictionaryWithPluralRuleAndCultureIfNoTranslationsExists()
+    public void GetDictionaryReturnsDictionaryWithPluralRuleAndCultureIfNoTranslationsExists_Default_Succeeds()
     {
         _translationProvider.Setup(o => o.LoadTranslations(
             It.Is<string>(culture => culture == "cs"),
@@ -38,7 +38,7 @@ public class LocalizationManagerTests : IDisposable
     }
 
     [Fact]
-    public void GetDictionaryReturnsDictionaryWithTranslationsFromProvider()
+    public void GetDictionaryReturnsDictionaryWithTranslationsFromProvider_Default_Succeeds()
     {
         var dictionaryRecord = new CultureDictionaryRecord("ball", "míč", "míče", "míčů");
         _translationProvider
@@ -56,7 +56,7 @@ public class LocalizationManagerTests : IDisposable
     }
 
     [Fact]
-    public void GetDictionarySelectsPluralRuleFromProviderWithHigherPriority()
+    public void GetDictionarySelectsPluralRuleFromProviderWithHigherPriority_Default_Succeeds()
     {
         PluralizationRuleDelegate csPluralRuleOverride = n => ((n == 1) ? 0 : (n >= 2 && n <= 4) ? 1 : 0);
 
@@ -79,7 +79,7 @@ public class LocalizationManagerTests : IDisposable
     [Theory]
     [InlineData("en", "Hello en !")]
     [InlineData("zh-CN", "你好！")]
-    public async Task TestLocalizationRule(string culture, string expected)
+    public async Task LocalizationRule_Default_Succeeds(string culture, string expected)
     {
         var context = new SiteContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Localization/LocalizationOrchardHelperExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Localization/LocalizationOrchardHelperExtensionsTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Localization;
 public class LocalizationOrchardHelperExtensionsTests
 {
     [Fact]
-    public void GetJSLocalizations_ThrowsArgumentNullException_WhenGroupsIsNull()
+    public void GetJSLocalizations_GroupsIsNull_ThrowsArgumentNullException()
     {
         var orchardHelper = CreateOrchardHelper([]);
 
@@ -13,7 +13,7 @@ public class LocalizationOrchardHelperExtensionsTests
     }
 
     [Fact]
-    public void GetJSLocalizations_CallsLocalizersPerRequestedGroupAndMergesResults()
+    public void GetJSLocalizations_CallsLocalizersPerRequestedGroupAndMergesResults_Succeeds()
     {
         var firstLocalizer = new TrackingJSLocalizer(new Dictionary<string, IDictionary<string, string>>
         {
@@ -45,7 +45,7 @@ public class LocalizationOrchardHelperExtensionsTests
     }
 
     [Fact]
-    public void GetJSLocalizations_IgnoresNullResults()
+    public void GetJSLocalizations_Default_IgnoressNullResults()
     {
         var orchardHelper = CreateOrchardHelper([new NullReturningJSLocalizer()]);
 

--- a/test/OrchardCore.Tests/Localization/LocalizationServiceCollectionExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Localization/LocalizationServiceCollectionExtensionsTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Localization.Tests;
 public class LocalizationServiceCollectionExtensionsTests
 {
     [Fact]
-    public void AddDataLocaliztion_RegisterRequiredServices()
+    public void AddDataLocaliztion_RegisterRequiredServices_Succeeds()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -31,7 +31,7 @@ public class LocalizationServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddOrchardCore_RegistersNullDataLocalizer()
+    public void AddOrchardCore_RegistersNullDataLocalizer_Succeeds()
     {
         // Arrange
         var services = new ServiceCollection();
@@ -56,7 +56,7 @@ public class LocalizationServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddDataLocalization_ReplacesNullDataLocalizer()
+    public void AddDataLocalization_ReplacesNullDataLocalizer_Succeeds()
     {
         // Arrange
         var services = new ServiceCollection();

--- a/test/OrchardCore.Tests/Localization/LocalizationServiceTests.cs
+++ b/test/OrchardCore.Tests/Localization/LocalizationServiceTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Localization;
 public class LocalizationServiceTest
 {
     [Fact]
-    public void GetAllCulturesAndAliases_ShouldContainsChineseCultures()
+    public void GetAllCulturesAndAliases_Default_ContainsChineseCultures()
     {
         // Arrange
         var localizationService = new LocalizationService(Mock.Of<ISiteService>());

--- a/test/OrchardCore.Tests/Localization/NullHtmlLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/NullHtmlLocalizerTests.cs
@@ -15,7 +15,7 @@ public class HtmlStringLocalizerTests
     [InlineData("there are more (2) &lt;br/&gt;", 2, "there is one ({0}) {1}", "there are more ({0}) {1}", "<br/>")]
     [InlineData("1 minute ago", 1, "{0} minute ago", "{0} minutes ago")]
     [InlineData("20 minutes ago", 20, "{0} minute ago", "{0} minutes ago")]
-    public void HtmlNullLocalizerSupportsPlural(string expected, int count, string singular, string plural, params object[] arguments)
+    public void HtmlNullLocalizerSupportsPlural_Default_Succeeds(string expected, int count, string singular, string plural, params object[] arguments)
     {
         var localizer = NullHtmlLocalizer.Instance;
 

--- a/test/OrchardCore.Tests/Localization/NullStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/NullStringLocalizerTests.cs
@@ -15,7 +15,7 @@ public class NullStringLocalizerTests
     [InlineData("there are more (2) &lt;br/&gt;", 2, "there is one ({0}) {1}", "there are more ({0}) {1}", "<br/>")]
     [InlineData("1 minute ago", 1, "{0} minute ago", "{0} minutes ago")]
     [InlineData("20 minutes ago", 20, "{0} minute ago", "{0} minutes ago")]
-    public void HtmlNullLocalizerSupportsPlural(string expected, int count, string singular, string plural, params object[] arguments)
+    public void HtmlNullLocalizerSupportsPlural_Default_Succeeds(string expected, int count, string singular, string plural, params object[] arguments)
     {
         var localizer = new NullHtmlLocalizerFactory().Create(typeof(object));
 
@@ -35,7 +35,7 @@ public class NullStringLocalizerTests
     [InlineData("there are more (2) <br/>", 2, "there is one ({0}) {1}", "there are more ({0}) {1}", "<br/>")]
     [InlineData("1 minute ago", 1, "{0} minute ago", "{0} minutes ago")]
     [InlineData("20 minutes ago", 20, "{0} minute ago", "{0} minutes ago")]
-    public void StringNullLocalizerSupportsPlural(string expected, int count, string singular, string plural, params object[] arguments)
+    public void StringNullLocalizerSupportsPlural_Default_Succeeds(string expected, int count, string singular, string plural, params object[] arguments)
     {
         var localizer = NullStringLocalizer.Instance;
 

--- a/test/OrchardCore.Tests/Localization/PoParserTests.cs
+++ b/test/OrchardCore.Tests/Localization/PoParserTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Localization;
 public class PoParserTests
 {
     [Fact]
-    public async Task ParseAsync_ReturnsSimpleEntry()
+    public async Task ParseAsync_Default_ReturnsSimpleEntry()
     {
         // msgid "Unknown system error"
         // msgstr "Error desconegut del sistema"
@@ -17,7 +17,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_IgnoresEntryWithoutTranslation()
+    public async Task ParseAsync_Default_IgnoressEntryWithoutTranslation()
     {
         // "msgid "Unknown system error"
         // "msgstr ""
@@ -27,7 +27,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_IgnoresPoeditHeader()
+    public async Task ParseAsync_Default_IgnoressPoeditHeader()
     {
         // # Translation of kstars.po into Spanish.
         // # This file is distributed under the same license as the kdeedu package.
@@ -55,7 +55,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_SetsContext()
+    public async Task ParseAsync_Default_SetsContext()
     {
         // msgctxt "OrchardCore.Localization"
         // msgid "Unknown system error"
@@ -66,7 +66,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_IgnoresComments()
+    public async Task ParseAsync_Default_IgnoressComments()
     {
         // # translator-comments
         // #. extracted-comments
@@ -86,7 +86,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_OnlyTrimsLeadingAndTrailingQuotes()
+    public async Task ParseAsync_LyTrimsLeadingAndTrailingQuotes_Succeeds()
     {
         // msgid "\"{0}\""
         // msgstr "\"{0}\""
@@ -98,7 +98,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_HandleUnclosedQuote()
+    public async Task ParseAsync_HandleUnclosedQuote_Succeeds()
     {
         // msgctxt "
         // msgid "Foo \"{0}\""
@@ -110,7 +110,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_HandlesMultilineEntry()
+    public async Task ParseAsync_Default_HandlesMultilineEntry()
     {
         // msgid ""
         // "Here is an example of how one might continue a very long string\n"
@@ -126,7 +126,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_PreservesEscapedCharacters()
+    public async Task ParseAsync_Default_PreservesEscapedCharacters()
     {
         // msgid "Line:\t\"{0}\"\n"
         // msgstr "Line:\t\"{0}\"\n"
@@ -138,7 +138,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_ReadsPluralTranslations()
+    public async Task ParseAsync_Default_ReadsPluralTranslations()
     {
         // msgid "book"
         // msgid_plural "books"
@@ -155,7 +155,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_ReadsPluralAndMultilineText()
+    public async Task ParseAsync_Default_ReadsPluralAndMultilineText()
     {
         // msgid ""
         // "Here is an example of how one might continue a very long string\n"
@@ -178,7 +178,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public async Task ParseAsync_ReadsMultipleEntries()
+    public async Task ParseAsync_Default_ReadsMultipleEntries()
     {
         // #. "File {0} does not exist"
         // msgctxt "OrchardCore.FileSystems.Media.FileSystemStorageProvider"
@@ -202,7 +202,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_ReturnsSimpleEntry()
+    public void Parse_Default_ReturnsSimpleEntry()
     {
         // msgid "Unknown system error"
         // msgstr "Error desconegut del sistema"
@@ -213,7 +213,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_IgnoresEntryWithoutTranslation()
+    public void Parse_Default_IgnoressEntryWithoutTranslation()
     {
         // "msgid "Unknown system error"
         // "msgstr ""
@@ -223,7 +223,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_IgnoresPoeditHeader()
+    public void Parse_Default_IgnoressPoeditHeader()
     {
         // # Translation of kstars.po into Spanish.
         // # This file is distributed under the same license as the kdeedu package.
@@ -251,7 +251,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_SetsContext()
+    public void Parse_Default_SetsContext()
     {
         // msgctxt "OrchardCore.Localization"
         // msgid "Unknown system error"
@@ -262,7 +262,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_IgnoresComments()
+    public void Parse_Default_IgnoressComments()
     {
         // # translator-comments
         // #. extracted-comments
@@ -282,7 +282,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_OnlyTrimsLeadingAndTrailingQuotes()
+    public void Parse_LyTrimsLeadingAndTrailingQuotes_Succeeds()
     {
         // msgid "\"{0}\""
         // msgstr "\"{0}\""
@@ -294,7 +294,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_HandleUnclosedQuote()
+    public void Parse_HandleUnclosedQuote_Succeeds()
     {
         // msgctxt "
         // msgid "Foo \"{0}\""
@@ -306,7 +306,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_HandlesMultilineEntry()
+    public void Parse_Default_HandlesMultilineEntry()
     {
         // msgid ""
         // "Here is an example of how one might continue a very long string\n"
@@ -322,7 +322,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_PreservesEscapedCharacters()
+    public void Parse_Default_PreservesEscapedCharacters()
     {
         // msgid "Line:\t\"{0}\"\n"
         // msgstr "Line:\t\"{0}\"\n"
@@ -334,7 +334,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_ReadsPluralTranslations()
+    public void Parse_Default_ReadsPluralTranslations()
     {
         // msgid "book"
         // msgid_plural "books"
@@ -351,7 +351,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_ReadsPluralAndMultilineText()
+    public void Parse_Default_ReadsPluralAndMultilineText()
     {
         // msgid ""
         // "Here is an example of how one might continue a very long string\n"
@@ -374,7 +374,7 @@ public class PoParserTests
     }
 
     [Fact]
-    public void Parse_ReadsMultipleEntries()
+    public void Parse_Default_ReadsMultipleEntries()
     {
         // #. "File {0} does not exist"
         // msgctxt "OrchardCore.FileSystems.Media.FileSystemStorageProvider"

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerFactoryTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Localization;
 public class PortableObjectStringLocalizerFactoryTests
 {
     [Fact]
-    public async Task LocalizerReturnsTranslationFromInnerClass()
+    public async Task LocalizerReturnsTranslationFromInnerClass_Default_Succeeds()
         => await StartupRunner.Run(typeof(PortableObjectStringLocalizerFactory), "ar", "مرحبا");
 
     public class PortableObjectStringLocalizerFactory

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -15,7 +15,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerReturnsTranslationsFromProvidedDictionary()
+    public void LocalizerReturnsTranslationsFromProvidedDictionary_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
@@ -32,7 +32,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerReturnsOriginalTextIfTranslationsDoesntExistInProvidedDictionary()
+    public void LocalizerReturnsOriginalTextIfTranslationsDoesntExistInProvidedDictionary_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
@@ -48,7 +48,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerReturnsOriginalTextIfDictionaryIsEmpty()
+    public void LocalizerReturnsOriginalTextIfDictionaryIsEmpty_Default_Succeeds()
     {
         SetupDictionary("cs", Array.Empty<CultureDictionaryRecord>());
 
@@ -62,7 +62,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerFallbacksToParentCultureIfTranslationDoesntExistInSpecificCulture()
+    public void LocalizerFallbacksToParentCultureIfTranslationDoesntExistInSpecificCulture_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
@@ -82,7 +82,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerReturnsTranslationFromSpecificCultureIfItExists()
+    public void LocalizerReturnsTranslationFromSpecificCultureIfItExists_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
@@ -102,7 +102,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerReturnsTranslationWithSpecificContext()
+    public void LocalizerReturnsTranslationWithSpecificContext_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
@@ -119,7 +119,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerReturnsTranslationWithoutContextIfTranslationWithContextDoesntExist()
+    public void LocalizerReturnsTranslationWithoutContextIfTranslationWithContextDoesntExist_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
@@ -136,7 +136,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void LocalizerReturnsFormattedTranslation()
+    public void LocalizerReturnsFormattedTranslation_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("The page (ID:{0}) was deleted.", "Stránka (ID:{0}) byla smazána."),
@@ -152,7 +152,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public void HtmlLocalizerDoesNotFormatTwiceIfFormattedTranslationContainsCurlyBraces()
+    public void HtmlLocalizerDoesNotFormatTwiceIfFormattedTranslationContainsCurlyBraces_Default_Succeeds()
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("The page (ID:{0}) was deleted.", "Stránka (ID:{0}) byla smazána."),
@@ -184,7 +184,7 @@ public class PortableObjectStringLocalizerTests
     [Theory]
     [InlineData("car", 1)]
     [InlineData("cars", 2)]
-    public void LocalizerReturnsOriginalTextForPluralIfTranslationDoesntExist(string expected, int count)
+    public void LocalizerReturnsOriginalTextForPluralIfTranslationDoesntExist_Default_Succeeds(string expected, int count)
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
@@ -201,7 +201,7 @@ public class PortableObjectStringLocalizerTests
     [Theory]
     [InlineData("zh-Hans", "球", 1, new string[] { "球" })]
     [InlineData("zh-Hans", "球", 2, new string[] { "球" })]
-    public void LocalizerReturnsCorrectTranslationForPluralIfNoPluralFormsSpecified(string culture, string expected, int count, string[] translations)
+    public void LocalizerReturnsCorrectTranslationForPluralIfNoPluralFormsSpecified_Default_Succeeds(string culture, string expected, int count, string[] translations)
     {
         using var cultureScope = CultureScope.Create(culture);
 
@@ -222,7 +222,7 @@ public class PortableObjectStringLocalizerTests
     [InlineData("míč", 1)]
     [InlineData("2 míče", 2)]
     [InlineData("5 míčů", 5)]
-    public void LocalizerReturnsTranslationInCorrectPluralForm(string expected, int count)
+    public void LocalizerReturnsTranslationInCorrectPluralForm_Default_Succeeds(string expected, int count)
     {
         SetupDictionary("cs", new[] {
             new CultureDictionaryRecord("ball", "míč", "{0} míče", "{0} míčů"),
@@ -241,7 +241,7 @@ public class PortableObjectStringLocalizerTests
     [InlineData("míč", 1)]
     [InlineData("2 míče", 2)]
     [InlineData("5 míčů", 5)]
-    public void LocalizerReturnsOriginalValuesIfTranslationDoesntExistAndMultiplePluraflFormsAreSpecified(string expected, int count)
+    public void LocalizerReturnsOriginalValuesIfTranslationDoesntExistAndMultiplePluraflFormsAreSpecified_Default_Succeeds(string expected, int count)
     {
         SetupDictionary("en", Array.Empty<CultureDictionaryRecord>());
 
@@ -257,7 +257,7 @@ public class PortableObjectStringLocalizerTests
     [Theory]
     [InlineData("ball", 1)]
     [InlineData("2 balls", 2)]
-    public void LocalizerReturnsCorrectPluralFormIfMultiplePluraflFormsAreSpecified(string expected, int count)
+    public void LocalizerReturnsCorrectPluralFormIfMultiplePluraflFormsAreSpecified_Default_Succeeds(string expected, int count)
     {
         SetupDictionary("en", new CultureDictionaryRecord[]
         {
@@ -276,7 +276,7 @@ public class PortableObjectStringLocalizerTests
     [Theory]
     [InlineData(false, "hello", "hello")]
     [InlineData(true, "hello", "مرحبا")]
-    public void LocalizerFallBackToParentCultureIfFallBackToParentUICulturesIsTrue(bool fallBackToParentCulture, string resourceKey, string expected)
+    public void LocalizerFallBackToParentCultureIfFallBackToParentUICulturesIsTrue_Default_Succeeds(bool fallBackToParentCulture, string resourceKey, string expected)
     {
         SetupDictionary("ar", new CultureDictionaryRecord[]
         {
@@ -297,7 +297,7 @@ public class PortableObjectStringLocalizerTests
     [Theory]
     [InlineData(false, new[] { "مدونة", "منتج" })]
     [InlineData(true, new[] { "مدونة", "منتج", "قائمة", "صفحة", "مقالة" })]
-    public void LocalizerReturnsGetAllStrings(bool includeParentCultures, string[] expected)
+    public void LocalizerReturnsGetAllStrings_Default_Succeeds(bool includeParentCultures, string[] expected)
     {
         SetupDictionary("ar", new CultureDictionaryRecord[]
         {
@@ -323,7 +323,7 @@ public class PortableObjectStringLocalizerTests
     }
 
     [Fact]
-    public async Task PortableObjectStringLocalizerShouldRegisterIStringLocalizerOfT()
+    public async Task PortableObjectStringLocalizer_Default_RegisterIStringLocalizerOfT()
         => await StartupRunner.Run(typeof(PortableObjectLocalizationStartup), "en", "Hello");
 
     [Theory]
@@ -331,7 +331,7 @@ public class PortableObjectStringLocalizerTests
     [InlineData("ar-YE", 2)]
     [InlineData("zh-Hans-CN", 3)]
     [InlineData("zh-Hant-TW", 3)]
-    public void LocalizerWithContextShouldCallGetDictionaryOncePerCulture(string culture, int expectedCalls)
+    public void LocalizerWithContext_Default_CallGetDictionaryOncePerCulture(string culture, int expectedCalls)
     {
         // Arrange
         SetupDictionary(culture, Array.Empty<CultureDictionaryRecord>());

--- a/test/OrchardCore.Tests/Locking/LocalLockTests.cs
+++ b/test/OrchardCore.Tests/Locking/LocalLockTests.cs
@@ -8,7 +8,7 @@ public class LocalLockTests
     private static LocalLock CreateLockService() => new LocalLock(NullLogger<LocalLock>.Instance);
 
     [Fact]
-    public async Task Acquire_Then_TryAcquire_SameKey_EnforcesExclusivity()
+    public async Task Acquire_ThenTryAcquireSameKey_EnforcesExclusivity()
     {
         using var localLock = CreateLockService();
 
@@ -33,7 +33,7 @@ public class LocalLockTests
     }
 
     [Fact]
-    public async Task TryAcquire_With_Timeout_Fails_When_Lock_Is_Held()
+    public async Task TryAcquire_TimeoutFailsWhenLockIsHeld_Succeeds()
     {
         using var localLock = CreateLockService();
 
@@ -50,7 +50,7 @@ public class LocalLockTests
     }
 
     [Fact]
-    public async Task Acquire_With_Expiration_Auto_Releases()
+    public async Task Acquire_ExpirationAutoReleases_Succeeds()
     {
         using var localLock = CreateLockService();
 
@@ -76,7 +76,7 @@ public class LocalLockTests
     }
 
     [Fact]
-    public async Task TryAcquire_With_InfiniteTimeout_Succeeds_When_Free()
+    public async Task TryAcquire_InfiniteTimeoutSucceedsWhenFree_Succeeds()
     {
         using var localLock = CreateLockService();
 
@@ -87,7 +87,7 @@ public class LocalLockTests
     }
 
     [Fact]
-    public async Task Different_Keys_Are_Independent()
+    public async Task Different_KeysAre_Independent()
     {
         using var localLock = CreateLockService();
 
@@ -100,7 +100,7 @@ public class LocalLockTests
     }
 
     [Fact]
-    public async Task IsLockAcquired_ReturnsFalse_When_NotHeld()
+    public async Task IsLockAcquired_NotHeld_ReturnsFalse()
     {
         using var localLock = CreateLockService();
 
@@ -114,7 +114,7 @@ public class LocalLockTests
     }
 
     [Fact]
-    public async Task Dispose_LocalLock_Throws_On_Public_Members()
+    public async Task DisposeLocalLock_PublicMembers_Throws()
     {
         var localLock = CreateLockService();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.AuditTrail/DateTimeParserTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.AuditTrail/DateTimeParserTests.cs
@@ -16,7 +16,7 @@ public class DateTimeRangeTests
     //[InlineData(">2019-10-12", ">2019-10-12T00:00:00.0000000")]
     //[InlineData("2017-01-01T01:00:00+07:00", "2017-01-01T01:00:00.0000000+07:00")]
     //[InlineData("2017-01-01T01:00:00+07:00..2017-01-01T01:00:00+07:00", "2017-01-01T01:00:00.0000000+07:00..2017-01-01T01:00:00.0000000+07:00")]
-    public void DateParserTests(string text, string expected)
+    public void DateParser_Default_Succeeds(string text, string expected)
     {
         var context = new DateTimeParseContext(CultureInfo.InvariantCulture, Mock.Of<IClock>(), Mock.Of<ITimeZone>(), new Scanner(text));
         Assert.True(DateTimeParser.Parser.TryParse(context, out var result, out _));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.ContentFields/Settings/SettingsDisplayDriverTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.ContentFields/Settings/SettingsDisplayDriverTests.cs
@@ -41,7 +41,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task BooleanFieldSettingsShouldDeserialize()
+    public async Task BooleanFieldSettings_Default_Deserialize()
     {
         var settings = new BooleanFieldSettings
         {
@@ -62,7 +62,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task DateFieldSettingsShouldDeserialize()
+    public async Task DateFieldSettings_Default_Deserialize()
     {
         var settings = new DateFieldSettings
         {
@@ -81,7 +81,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task DateTimeFieldSettingsShouldDeserialize()
+    public async Task DateTimeFieldSettings_Default_Deserialize()
     {
         var settings = new DateTimeFieldSettings
         {
@@ -100,7 +100,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task LinkFieldSettingsShouldDeserialize()
+    public async Task LinkFieldSettings_Default_Deserialize()
     {
         var settings = new LinkFieldSettings
         {
@@ -133,7 +133,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task LocalizationSetContentPickerFieldSettingsShouldDeserialize()
+    public async Task LocalizationSetContentPickerFieldSettings_Default_Deserialize()
     {
         var settings = new LocalizationSetContentPickerFieldSettings
         {
@@ -156,7 +156,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task NumericFieldSettingsShouldDeserialize()
+    public async Task NumericFieldSettings_Default_Deserialize()
     {
         var settings = new NumericFieldSettings
         {
@@ -185,7 +185,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task TextFieldSettingsShouldDeserialize()
+    public async Task TextFieldSettings_Default_Deserialize()
     {
         var settings = new TextFieldSettings
         {
@@ -220,7 +220,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task TimeFieldSettingsShouldDeserialize()
+    public async Task TimeFieldSettings_Default_Deserialize()
     {
         var settings = new TimeFieldSettings
         {
@@ -241,7 +241,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task YouTubeFieldSettingsShouldDeserialize()
+    public async Task YouTubeFieldSettings_Default_Deserialize()
     {
         var settings = new YoutubeFieldSettings
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/ContentShapeAlternatesFactoryTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/ContentShapeAlternatesFactoryTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Contents;
 public class ContentShapeAlternatesFactoryTests
 {
     [Fact]
-    public void GetEntry_ShouldReturnCachedInstance_ForSameKey()
+    public void GetEntry_SameKey_ReturnsCachedInstance()
     {
         var entry = ContentShapeAlternatesFactory.GetEntry("BlogPost", "Summary");
         var cachedEntry = ContentShapeAlternatesFactory.GetEntry("BlogPost", "Summary");
@@ -14,7 +14,7 @@ public class ContentShapeAlternatesFactoryTests
     }
 
     [Fact]
-    public void GetEntry_ShouldProduceCorrectAlternates_WhenAssembledWithContentItemId()
+    public void GetEntry_AssembledWithContentItemId_ProducesCorrectAlternates()
     {
         var entry = ContentShapeAlternatesFactory.GetEntry("BlogPost", "Summary");
 
@@ -24,7 +24,7 @@ public class ContentShapeAlternatesFactoryTests
     }
 
     [Fact]
-    public void GetEntry_ShouldReturnDifferentInstances_ForDifferentKeys()
+    public void GetEntry_DifferentKeys_ReturnsDifferentInstances()
     {
         var entryA = ContentShapeAlternatesFactory.GetEntry("BlogPost", "Summary");
         var entryB = ContentShapeAlternatesFactory.GetEntry("Article", "Detail");

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
@@ -12,7 +12,7 @@ public class RssFeedTests
     [Theory]
     [InlineData("rss")]
     [InlineData("non rss")]
-    public async Task AvoidDoubleEncodeCDATA(string format)
+    public async Task AvoidDoubleEncodeCDATA_Default_Succeeds(string format)
     {
         // Arrange
         var contentManagerMock = new Mock<IContentManager>();
@@ -48,7 +48,7 @@ public class RssFeedTests
     [Theory]
     [InlineData("rss")]
     [InlineData("non rss")]
-    public async Task ShouldOnlyHtmlEntityEscapeFeedTitle(string format)
+    public async Task Only_HtmlEntityEscapeFeedTitle_Succeeds(string format)
     {
         // Arrange
         var contentManagerMock = new Mock<IContentManager>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/VersionPruning/ContentVersionPruningSelectorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/VersionPruning/ContentVersionPruningSelectorTests.cs
@@ -19,7 +19,7 @@ public class ContentVersionPruningSelectorTests
     }
 
     [Fact]
-    public void SelectForDeletion_SingleVersion_Keep1_ReturnsEmpty()
+    public void SelectForDeletion_SingleVersionKeep1_ReturnsEmpty()
     {
         var versions = new List<ContentItem>
         {
@@ -115,7 +115,7 @@ public class ContentVersionPruningSelectorTests
     }
 
     [Fact]
-    public void SelectForDeletion_FiltersOutLatestAndPublished()
+    public void SelectForDeletion_FiltersOutLatestAndPublished_Succeeds()
     {
         var versions = new List<ContentItem>
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/VersionPruning/ContentVersionPruningServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/VersionPruning/ContentVersionPruningServiceTests.cs
@@ -84,7 +84,7 @@ public class ContentVersionPruningServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task PruneVersionsAsync_KeepsNewestAndVersionsWithinRetention()
+    public async Task PruneVersionsAsync_Default_KeepssNewestAndVersionsWithinRetention()
     {
         await SaveVersionsAsync(
             Version("item-1", "v1", "Blog", _now.AddDays(-90)),
@@ -107,7 +107,7 @@ public class ContentVersionPruningServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task PruneVersionsAsync_OnlyPrunesSelectedContentTypes()
+    public async Task PruneVersionsAsync_LyPrunesSelectedContentTypes_Succeeds()
     {
         await SaveVersionsAsync(
             Version("blog-1", "b1", "Blog", _now.AddDays(-90)),
@@ -131,7 +131,7 @@ public class ContentVersionPruningServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task PruneVersionsAsync_NeverDeletesLatestOrPublished()
+    public async Task PruneVersionsAsync_NeverDeletesLatestOrPublished_Succeeds()
     {
         await SaveVersionsAsync(
             new ContentItem { ContentItemId = "item-1", ContentItemVersionId = "v-latest", ContentType = "Blog", ModifiedUtc = _now.AddDays(-90), Latest = true },
@@ -174,7 +174,7 @@ public class ContentVersionPruningServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task PruneVersionsAsync_ProcessesMoreThanOneBatch()
+    public async Task PruneVersionsAsync_ProcessesMoreThanOneBatch_Succeeds()
     {
         // Exercises the deletion batching/flush path with more candidates than the internal batch size.
         const int versionCount = 250;
@@ -200,7 +200,7 @@ public class ContentVersionPruningServiceTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task PruneVersionsAsync_ProcessesManyContentItemsAcrossBatches()
+    public async Task PruneVersionsAsync_ProcessesManyContentItemsAcrossBatches_Succeeds()
     {
         // Spans more content items than the per-query content item batch size to verify that the
         // "keep N newest" rule is correctly applied per item across batch boundaries.

--- a/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/DataLocalizationProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/DataLocalizationProviderTests.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.DataLocalization.Services.Tests;
 public class DataLocalizationProviderTests
 {
     [Fact]
-    public async Task ContentTypeDataLocalizationProvider_GetLocalizedStrings()
+    public async Task ContentTypeDataLocalizationProvider_GetLocalizedStrings_Succeeds()
     {
         var contentDefinitionManager = new Mock<IContentDefinitionManager>();
         contentDefinitionManager.Setup(cds => cds.ListTypeDefinitionsAsync())
@@ -26,7 +26,7 @@ public class DataLocalizationProviderTests
     }
 
     [Fact]
-    public async Task ContentFieldDataLocalizationProvider_GetLocalizedStrings()
+    public async Task ContentFieldDataLocalizationProvider_GetLocalizedStrings_Succeeds()
     {
         var contentDefinitionManager = new Mock<IContentDefinitionManager>();
         contentDefinitionManager.Setup(cds => cds.ListTypeDefinitionsAsync())

--- a/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/TranslationsManagerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/TranslationsManagerTests.cs
@@ -14,7 +14,7 @@ public class TranslationsManagerTests
     }
 
     [Fact]
-    public async Task GetTranslationsDocument()
+    public async Task GetTranslationsDocument_Default_Succeeds()
     {
         // Arrange & Act
         var translationsDocument = await _translationsManager.Object.GetTranslationsDocumentAsync();
@@ -33,7 +33,7 @@ public class TranslationsManagerTests
     }
 
     [Fact]
-    public async Task GetTranslationsDocument_GroupByContext()
+    public async Task GetTranslationsDocument_GroupByContext_Succeeds()
     {
         // Arrange & Act
         var translationsDocument = await _translationsManager.Object.GetTranslationsDocumentAsync();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
@@ -12,7 +12,7 @@ public class EmailTaskTests
     private static readonly IDictionary<string, object> _emptyDictionary = new Dictionary<string, object>();
 
     [Fact]
-    public async Task ExecuteTask_WhenToAndCcAndBccAreNotSet_ShouldFail()
+    public async Task ExecuteTask_Default_ToAndCcAndBccAreNotSetFail()
     {
         // Arrange
         var emailService = CreateSmtpService(new SmtpOptions()

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Https/HttpsSettingsMigrationsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Https/HttpsSettingsMigrationsTests.cs
@@ -10,7 +10,7 @@ public class HttpsSettingsMigrationsTests
     private const string LegacyEnableStrictTransportSecurityKey = "EnableStrictTransportSecurity";
 
     [Fact]
-    public async Task CreateAsyncMigratesLegacyHstsSetting()
+    public async Task CreateAsyncMigratesLegacyHstsSetting_Default_Succeeds()
     {
         var site = new SiteSettings();
         site.Properties[nameof(HttpsSettings)] = new JsonObject
@@ -33,7 +33,7 @@ public class HttpsSettingsMigrationsTests
     }
 
     [Fact]
-    public async Task CreateAsyncRemovesLegacySettingWithoutOverwritingMigratedValue()
+    public async Task CreateAsyncRemovesLegacySettingWithoutOverwritingMigratedValue_Default_Succeeds()
     {
         var site = new SiteSettings();
         site.Properties[nameof(HttpsSettings)] = new JsonObject

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Liquid/DataProtectionFilterTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Liquid/DataProtectionFilterTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Liquid;
 public class DataProtectionFilterTests
 {
     [Fact]
-    public async Task EncryptFilterShouldReturnNonEmptyBase64String()
+    public async Task EncryptFilter_Default_ReturnsNonEmptyBase64String()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -24,7 +24,7 @@ public class DataProtectionFilterTests
     }
 
     [Fact]
-    public async Task DecryptFilterShouldReturnOriginalValueAfterEncrypt()
+    public async Task DecryptFilter_Default_ReturnsOriginalValueAfterEncrypt()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -39,7 +39,7 @@ public class DataProtectionFilterTests
     }
 
     [Fact]
-    public async Task DecryptFilterShouldReturnEmptyForEmptyInput()
+    public async Task DecryptFilter_Default_ReturnsEmptyForEmptyInput()
     {
         var context = new SiteContext();
         await context.InitializeAsync();
@@ -54,7 +54,7 @@ public class DataProtectionFilterTests
     }
 
     [Fact]
-    public async Task DecryptFilterShouldReturnNilForInvalidCiphertext()
+    public async Task DecryptFilter_Default_ReturnsNilForInvalidCiphertext()
     {
         var context = new SiteContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Liquid/SlugifyFilterTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Liquid/SlugifyFilterTests.cs
@@ -9,7 +9,7 @@ public class SlugifyFilterTests
     [Theory]
     [InlineData("Æneid Æneid", "æneid-æneid")]
     [InlineData("Aeneid Aeneid", "aeneid-aeneid")]
-    public async Task SlugifyFilterShouldReturnSlugifiedString(string text, string expected)
+    public async Task SlugifyFilter_Default_ReturnsSlugifiedString(string text, string expected)
     {
         // Arrange
         var context = new SiteContext();
@@ -31,7 +31,7 @@ public class SlugifyFilterTests
     }
 
     [Fact]
-    public async Task SlugifyThenTransliterateFilterShouldReturnSlugifiedTransliteratedString()
+    public async Task SlugifyThenTransliterateFilter_Default_ReturnsSlugifiedTransliteratedString()
     {
         // Arrange
         var context = new SiteContext();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Liquid/TransliterateFilterTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Liquid/TransliterateFilterTests.cs
@@ -13,7 +13,7 @@ public class TransliterateFilterTests
     [InlineData("aeneid", "aeneid")]
     [InlineData("Ελληνικά", "Ellinika")]
     [InlineData("джинсы_клеш", "dzhinsy_klesh")]
-    public async Task TransliterateFilterShouldReturnTransliteratedString(string text, string expected)
+    public async Task TransliterateFilter_Default_ReturnsTransliteratedString(string text, string expected)
     {
         // Arrange
         var context = new SiteContext();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Lists/Handlers/ContainedPartHandlerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Lists/Handlers/ContainedPartHandlerTests.cs
@@ -33,7 +33,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldNotFail_WhenContentTypeIsNotContained()
+    public async Task ValidatingAsync_ContentTypeIsNotContained_NotFail()
     {
         _contentDefinitionManager
             .Setup(m => m.ListTypeDefinitionsAsync())
@@ -48,7 +48,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldNotFail_WhenContainedTypeHasNoContainedPart()
+    public async Task ValidatingAsync_ContainedTypeHasNoContainedPart_NotFail()
     {
         SetupBlogWithBlogPostContainedType();
 
@@ -61,7 +61,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldFail_WhenListContentItemIdIsEmpty()
+    public async Task ValidatingAsync_ListContentItemIdIsEmpty_Failss()
     {
         SetupBlogWithBlogPostContainedType();
 
@@ -81,7 +81,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldNotFail_WhenListContentTypeIsEmpty()
+    public async Task ValidatingAsync_ListContentTypeIsEmpty_NotFail()
     {
         SetupBlogWithBlogPostContainedType();
 
@@ -101,7 +101,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldNotFail_WhenContainedPartIsValid()
+    public async Task ValidatingAsync_ContainedPartIsValid_NotFail()
     {
         SetupBlogWithBlogPostContainedType();
 
@@ -121,7 +121,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldNotFail_WhenContentTypeIsNotInContainedTypes()
+    public async Task ValidatingAsync_ContentTypeIsNotInContainedTypes_NotFail()
     {
         SetupBlogWithBlogPostContainedType();
 
@@ -134,7 +134,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldNotFail_WhenContentTypeIsCreatableWithoutContainedPart()
+    public async Task ValidatingAsync_ContentTypeIsCreatableWithoutContainedPart_NotFail()
     {
         SetupBlogWithBlogPostContainedType(creatable: true);
 
@@ -147,7 +147,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldNotFail_WhenCreatableTypeHasEmptyContainedPart()
+    public async Task ValidatingAsync_CreatableTypeHasEmptyContainedPart_NotFail()
     {
         SetupBlogWithBlogPostContainedType(creatable: true);
 
@@ -166,7 +166,7 @@ public class ContainedPartHandlerTests
     }
 
     [Fact]
-    public async Task ValidatingAsync_ShouldFail_WhenNotCreatableTypeHasPartialContainedPartData()
+    public async Task ValidatingAsync_NotCreatableTypeHasPartialContainedPartData_Failss()
     {
         SetupBlogWithBlogPostContainedType(creatable: false);
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Lucene/BooleanQueryProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Lucene/BooleanQueryProviderTests.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Lucene;
 public partial class BooleanQueryProviderTests
 {
     [Fact]
-    public void BoolQueryFilterAsArrayDoesNotThrow()
+    public void BoolQueryFilterAsArrayDoesNotThrow_Default_Succeeds()
     {
         var arrayFilter = JsonNode.Parse("""
         {
@@ -23,7 +23,7 @@ public partial class BooleanQueryProviderTests
     }
 
     [Fact]
-    public void BoolQueryFilterAsObjectDoesNotThrow()
+    public void BoolQueryFilterAsObjectDoesNotThrow_Default_Succeeds()
     {
         var objectFilter = JsonNode.Parse("""
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Lucene/SettingsDisplayDriverTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Lucene/SettingsDisplayDriverTests.cs
@@ -52,7 +52,7 @@ public partial class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task ContentPickerFieldLuceneEditorSettingsShouldDeserialize()
+    public async Task ContentPickerFieldLuceneEditorSettings_Default_Deserialize()
     {
         await (await CreateShellContext().CreateScopeAsync()).UsingAsync(async scope =>
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Markdown/MarkdownTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Markdown/MarkdownTests.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Markdown;
 public class MarkdownTests
 {
     [Fact]
-    public void ShouldConfigureMarkdownPipeline()
+    public void Configure_MarkdownPipeline_Succeeds()
     {
         var services = CreateServiceCollection();
         var markdownService = services.BuildServiceProvider().GetService<IMarkdownService>();
@@ -23,7 +23,7 @@ public class MarkdownTests
     }
 
     [Fact]
-    public void ShouldReconfigureMarkdownPipeline()
+    public void Reconfigure_MarkdownPipeline_Succeeds()
     {
         // Setup. With defaults.
         var services = CreateServiceCollection();
@@ -44,7 +44,7 @@ public class MarkdownTests
     }
 
     [Fact]
-    public async Task ShouldConvertMarkdownToHtmlAsync()
+    public async Task Convert_MarkdownToHtmlAsync_Succeeds()
     {
         // Arrange
         var services = CreateServiceCollection();
@@ -90,7 +90,7 @@ public class MarkdownTests
     [InlineData("<script>alert('xss')</script>", "<p>&lt;script&gt;alert('xss')&lt;/script&gt;</p>\n")]
     [InlineData("<img src=x onerror=alert(1)>", "<p>&lt;img src=x onerror=alert(1)&gt;</p>\n")]
     [InlineData("<a href=\"javascript:alert(1)\">click</a>", "<p>&lt;a href=&quot;javascript:alert(1)&quot;&gt;click&lt;/a&gt;</p>\n")]
-    public void DefaultMarkdownPipeline_ShouldEscapeHtmlTags(string maliciousMarkdown, string expected)
+    public void DefaultMarkdownPipeline_Default_EscapeHtmlTags(string maliciousMarkdown, string expected)
     {
         // The default 'nohtml' pipeline escapes all raw HTML, making it display as text.
         var services = CreateServiceCollection();
@@ -111,7 +111,7 @@ public class MarkdownTests
     [InlineData("<a href=\"javascript:alert(1)\">click</a>")]
     [InlineData("<iframe src=\"evil.com\"></iframe>")]
     [InlineData("<object data=\"evil.swf\"></object>")]
-    public async Task MarkdownifyFilter_ShouldSanitizeXssPayloads_WhenNoHtmlIsDisabled(string maliciousMarkdown)
+    public async Task MarkdownifyFilter_NoHtmlIsDisabled_SanitizeXssPayloads(string maliciousMarkdown)
     {
         // Even when 'nohtml' is removed from the pipeline (allowing raw HTML),
         // the markdownify filter must still sanitize dangerous HTML.
@@ -143,7 +143,7 @@ public class MarkdownTests
     }
 
     [Fact]
-    public async Task MarkdownifyFilter_ShouldPreserveSafeMarkdown()
+    public async Task MarkdownifyFilter_Default_PreservesSafeMarkdown()
     {
         var services = new ServiceCollection();
         services.AddOptions<MarkdownPipelineOptions>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media.Azure/BlobContainerNameValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media.Azure/BlobContainerNameValidatorTests.cs
@@ -10,7 +10,7 @@ public class BlobContainerNameValidatorTests
     [InlineData("tenant1-media")]
     [InlineData("a1-b2-c3")]
     [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")] // 63 chars
-    public void Valid(string name)
+    public void Valid_Default_Succeeds(string name)
         => Assert.True(BlobContainerNameValidator.IsValid(name));
 
     [Theory]
@@ -24,6 +24,6 @@ public class BlobContainerNameValidatorTests
     [InlineData("-leading")]                        // starts with hyphen
     [InlineData("trailing-")]                       // ends with hyphen
     [InlineData("double--hyphen")]                  // consecutive hyphens
-    public void Invalid(string name)
+    public void Invalid_Default_Succeeds(string name)
         => Assert.False(BlobContainerNameValidator.IsValid(name));
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media.Azure/MediaBlobStorageOptionsConfigurationTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media.Azure/MediaBlobStorageOptionsConfigurationTests.cs
@@ -14,7 +14,7 @@ public class MediaBlobStorageOptionsConfigurationTests
     private const string ValidConnectionString = "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
 
     [Fact]
-    public void ParsesLiquidTemplate_AndLowercasesContainerName()
+    public void ParsesLiquidTemplate_LowercasesContainerName_Succeeds()
     {
         var (config, logger) = CreateConfiguration(new Dictionary<string, string>
         {
@@ -69,7 +69,7 @@ public class MediaBlobStorageOptionsConfigurationTests
     }
 
     [Fact]
-    public void CreateContainer_RoundTripsFromConfig_WhenFalse()
+    public void CreateContainer_False_RoundTripsFromConfig()
     {
         var (config, _) = CreateConfiguration(new Dictionary<string, string>
         {
@@ -85,7 +85,7 @@ public class MediaBlobStorageOptionsConfigurationTests
     }
 
     [Fact]
-    public void RemoveContainer_AndRemoveFilesFromBasePath_RoundTripFromConfig()
+    public void RemoveContainer_RemoveFilesFromBasePath_RoundTripFromConfig()
     {
         var (config, _) = CreateConfiguration(new Dictionary<string, string>
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/AssetUrlShortcodeTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/AssetUrlShortcodeTests.cs
@@ -27,7 +27,7 @@ public class AssetUrlShortcodeTests
     [InlineData("", @"foo [asset_url]foo bar.jpg[/asset_url] baz", @"foo /media/foo%20bar.jpg baz")]
     [InlineData("", @"foo [asset_url]my folder/foo bar.jpg[/asset_url] baz", @"foo /media/my%20folder/foo%20bar.jpg baz")]
     [InlineData("", @"foo <a href=""[asset_url]foo bar.jpg[/asset_url]"">baz</a>", @"foo <a href=""/media/foo%20bar.jpg"">baz</a>")]
-    public async Task ShouldProcess(string cdnBaseUrl, string text, string expected)
+    public async Task Process_Default_Succeeds(string cdnBaseUrl, string text, string expected)
     {
         var fileStore = new DefaultMediaFileStore(
             Mock.Of<IFileStore>(),
@@ -56,7 +56,7 @@ public class AssetUrlShortcodeTests
     [InlineData(@"foo <a href=""[asset_url]bàr.jpeg[/asset_url]"">baz</a>", @"foo <a href=""[asset_url]bàr.jpeg[/asset_url]"">baz</a>")]
     // Sanitizing strips the closing shortcode tag when it finds onload. This is fine, as the user cannot expect a good shortcode when they attempt xss
     [InlineData(@"foo <a href=""[asset_url]bàr.jpeg?width=100 onload=""javascript: alert('XSS')""[/asset_url]"">baz</a>", @"foo <a href=""[asset_url]bàr.jpeg?width=100 onload="">baz</a>")]
-    public void ShouldSanitizeUnprocessed(string text, string expected)
+    public void Sanitize_Unprocessed_Succeeds(string text, string expected)
     {
         // The html parts santize on save, so do not process the shortcode first.
         var sanitizer = new HtmlSanitizerService(Options.Create(new HtmlSanitizerOptions()));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/ClamAVFileEventHandlerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/ClamAVFileEventHandlerTests.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public class ClamAvFileEventHandlerTests
 {
     [Fact]
-    public async Task CreatingAsync_ReturnsSeekableStream_WhenClamAvReturnsOk()
+    public async Task CreatingAsync_ClamAvReturnsOk_ReturnsSeekableStream()
     {
         await using var server = await FakeClamAvServer.StartAsync("stream: OK\n");
         using var factory = CreateFactory();
@@ -26,7 +26,7 @@ public class ClamAvFileEventHandlerTests
     }
 
     [Fact]
-    public async Task CreatingAsync_BuffersNonSeekableStreams()
+    public async Task CreatingAsync_BuffersNonSeekableStreams_Succeeds()
     {
         await using var server = await FakeClamAvServer.StartAsync("stream: OK\n");
         using var factory = CreateFactory();
@@ -46,7 +46,7 @@ public class ClamAvFileEventHandlerTests
     }
 
     [Fact]
-    public async Task CreatingAsync_ReturnsFailedResult_WhenClamAvFindsMalware()
+    public async Task CreatingAsync_ClamAvFindsMalware_ReturnsFailedResult()
     {
         await using var server = await FakeClamAvServer.StartAsync("stream: Eicar-Test-Signature FOUND\n");
         using var factory = CreateFactory();
@@ -59,7 +59,7 @@ public class ClamAvFileEventHandlerTests
     }
 
     [Fact]
-    public async Task CreatingAsync_Throws_WhenClamAvReturnsError()
+    public async Task CreatingAsync_ClamAvReturnsError_Throws()
     {
         await using var server = await FakeClamAvServer.StartAsync("INSTREAM size limit exceeded. ERROR\n");
         using var factory = CreateFactory();
@@ -72,7 +72,7 @@ public class ClamAvFileEventHandlerTests
     }
 
     [Fact]
-    public async Task CreatingAsync_Throws_WhenHostIsMissing()
+    public async Task CreatingAsync_HostIsMissing_Throws()
     {
         using var factory = CreateFactory();
         var handler = new ClamAvFileEventHandler(
@@ -90,7 +90,7 @@ public class ClamAvFileEventHandlerTests
     }
 
     [Fact]
-    public async Task CreatingAsync_ReusesTheSameTcpConnection()
+    public async Task CreatingAsync_ReusesTheSameTcpConnection_Succeeds()
     {
         await using var server = await FakeClamAvServer.StartAsync("stream: OK\n", "stream: OK\n");
         using var factory = CreateFactory();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/DefaultMediaFileStoreTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/DefaultMediaFileStoreTests.cs
@@ -14,7 +14,7 @@ public class DefaultMediaFileStoreTests
     [InlineData("日本語.jpg", "/media/%E6%97%A5%E6%9C%AC%E8%AA%9E.jpg")]
     [InlineData("simple.jpg", "/media/simple.jpg")]
     [InlineData("sub/dir/file.jpg", "/media/sub/dir/file.jpg")]
-    public void MapPathToPublicUrl_ReturnsUrlEncodedPath(string path, string expected)
+    public void MapPathToPublicUrl_Default_ReturnsUrlEncodedPath(string path, string expected)
     {
         var store = new DefaultMediaFileStore(
             Mock.Of<IFileStore>(),
@@ -32,7 +32,7 @@ public class DefaultMediaFileStoreTests
     [Theory]
     [InlineData("https://cdn.example.com", "foo bar.jpg", "https://cdn.example.com/media/foo%20bar.jpg")]
     [InlineData("https://cdn.example.com", "bàr.jpeg", "https://cdn.example.com/media/b%C3%A0r.jpeg")]
-    public void MapPathToPublicUrl_WithCdnBaseUrl_ReturnsUrlEncodedPath(string cdnBaseUrl, string path, string expected)
+    public void MapPathToPublicUrl_CdnBaseUrl_ReturnsUrlEncodedPath(string cdnBaseUrl, string path, string expected)
     {
         var store = new DefaultMediaFileStore(
             Mock.Of<IFileStore>(),
@@ -73,7 +73,7 @@ public class DefaultMediaFileStoreTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_HandlerReturnsInputStream_PassesInputStreamToFileStore()
+    public async Task CreateFileFromStreamAsync_HandlerReturnsInputStream_PassesesesInputStreamToFileStore()
     {
         var fileStoreMock = new Mock<IFileStore>();
         var loggerMock = new Mock<ILogger<DefaultMediaFileStore>>();
@@ -103,7 +103,7 @@ public class DefaultMediaFileStoreTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_HandlersCreateNewStreams_PassesCorrectStreams()
+    public async Task CreateFileFromStreamAsync_HandlersCreateNewStreams_PassesesesCorrectStreams()
     {
         var fileStoreMock = new Mock<IFileStore>();
         var loggerMock = new Mock<ILogger<DefaultMediaFileStore>>();
@@ -185,7 +185,7 @@ public class DefaultMediaFileStoreTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_MediaReplacementStreamLivesThroughStorage()
+    public async Task CreateFileFromStreamAsync_MediaReplacementStreamLivesThroughStorage_Succeeds()
     {
         var fileStoreMock = new Mock<IFileStore>();
         var loggerMock = new Mock<ILogger<DefaultMediaFileStore>>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/FileCreationServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/FileCreationServiceTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public class FileCreationServiceTests
 {
     [Fact]
-    public async Task CreateAsync_DisposesReplacementStream_WhenLaterHandlerThrows()
+    public async Task CreateAsyncDisposesReplacementStream_LaterHandlerThrows_Succeeds()
     {
         var originalStream = new TrackingStream();
         var replacementStream = new TrackingStream();
@@ -63,7 +63,7 @@ public class FileCreationServiceTests
     }
 
     [Fact]
-    public async Task CreateAsync_LeavesOriginalStreamOpen_WhenRequested()
+    public async Task CreateAsyncLeavesOriginalStreamOpen_Requested_Succeeds()
     {
         var originalStream = new TrackingStream();
         var service = new FileCreationService([]);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageSharpImageProcessingEngineTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageSharpImageProcessingEngineTests.cs
@@ -49,7 +49,7 @@ public sealed class ImageSharpImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_CropMode_ProducesExactDimensions()
+    public async Task Process_CropMode_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands { Width = 60, Height = 60, ResizeMode = ResizeMode.Crop };
@@ -59,7 +59,7 @@ public sealed class ImageSharpImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_CropMode_WithFocalPoint_ProducesExactDimensions()
+    public async Task Process_CropModeWithFocalPoint_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands
@@ -76,7 +76,7 @@ public sealed class ImageSharpImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_StretchMode_ProducesExactDimensions()
+    public async Task Process_StretchMode_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands { Width = 100, Height = 80, ResizeMode = ResizeMode.Stretch };
@@ -86,7 +86,7 @@ public sealed class ImageSharpImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_PadMode_ProducesExactDimensions()
+    public async Task Process_PadMode_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands
@@ -160,7 +160,7 @@ public sealed class ImageSharpImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_AutoOrientDisabled_ProducesOutput()
+    public async Task Process_AutoOrientDisabled_ProducessOutput()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands { Width = 100, ResizeMode = ResizeMode.Max, AutoOrient = false };
@@ -170,7 +170,7 @@ public sealed class ImageSharpImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_OutputIsNonEmpty()
+    public async Task Process_OutputIsNonEmpty_Succeeds()
     {
         using var input = CreateTestPng(100, 50);
         var commands = new ImageProcessingCommands { Width = 50, Format = Format.Png };

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageSharpV3StartupTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageSharpV3StartupTests.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public sealed class ImageSharpV3StartupTests
 {
     [Fact]
-    public void ConfigureServices_ReplacesDefaultEngineWithImageSharp()
+    public void ConfigureServices_ReplacesDefaultEngineWithImageSharp_Succeeds()
     {
         var services = new ServiceCollection();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageShortcodeTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageShortcodeTests.cs
@@ -35,7 +35,7 @@ public class ImageShortcodeTests
     [InlineData("", "foo [media]bar[/media] baz foo [image]bar[/image] baz", @"foo <img src=""/media/bar""> baz foo <img src=""/media/bar""> baz")]
     [InlineData("", "foo [image]bàr.jpeg?width=100[/image] baz", @"foo <img src=""/media/b%C3%A0r.jpeg?width=100""> baz")]
     [InlineData("", "foo [image]bàr.jpeg?width=100 onload=\"javascript: alert('XSS')\"[/image] baz", @"foo <img src=""/media/b%C3%A0r.jpeg?width=100 onload=""> baz")]
-    public async Task ShouldProcess(string cdnBaseUrl, string text, string expected)
+    public async Task Process_Default_Succeeds(string cdnBaseUrl, string text, string expected)
     {
         var sanitizerOptions = new HtmlSanitizerOptions();
         sanitizerOptions.Configure.Add(opt => opt.AllowedAttributes.Add("class"));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCommandParserTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCommandParserTests.cs
@@ -66,7 +66,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_SupportedWidth_NoToken_ReturnsCommands()
+    public void Parse_SupportedWidthNoToken_ReturnsCommands()
     {
         var parser = CreateParser();
         var ctx = CreateContext(("width", "1024"));
@@ -77,7 +77,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_UnsupportedWidth_NoToken_ReturnsNull()
+    public void Parse_UnsupportedWidthNoToken_ReturnsNull()
     {
         var parser = CreateParser();
         var ctx = CreateContext(("width", "999"));
@@ -85,7 +85,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_UnsupportedWidth_ValidToken_ReturnsCommands()
+    public void Parse_UnsupportedWidthValidToken_ReturnsCommands()
     {
         var parser = CreateParser(validateToken: true);
         var ctx = CreateContext(("width", "999"), ("token", "sometoken"));
@@ -104,7 +104,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_FocalPoint_NoToken_IsStripped()
+    public void Parse_FocalPointNoToken_IsStripped()
     {
         var parser = CreateParser();
         var ctx = CreateContext(("width", "1024"), ("rxy", "0.5,0.5"));
@@ -115,7 +115,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_FocalPoint_ValidToken_IsPreserved()
+    public void Parse_FocalPointValidToken_IsPreserved()
     {
         var parser = CreateParser(validateToken: true);
         var ctx = CreateContext(("width", "1024"), ("rxy", "0.7,0.3"), ("token", "tok"));
@@ -125,7 +125,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_BackgroundColor_NoToken_IsStripped()
+    public void Parse_BackgroundColorNoToken_IsStripped()
     {
         var parser = CreateParser();
         var ctx = CreateContext(("width", "1024"), ("bgcolor", "ff0000"));
@@ -135,7 +135,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_BackgroundColor_ValidToken_IsPreserved()
+    public void Parse_BackgroundColorValidToken_IsPreserved()
     {
         var parser = CreateParser(validateToken: true);
         var ctx = CreateContext(("width", "600"), ("bgcolor", "0000ff"), ("token", "tok"));
@@ -145,7 +145,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_DefaultResizeModeIsMax()
+    public void Parse_DefaultResizeModeIsMax_Succeeds()
     {
         var parser = CreateParser();
         var ctx = CreateContext(("width", "600"));
@@ -154,7 +154,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_ExplicitResizeMode_Preserved()
+    public void Parse_ExplicitResizeMode_Preservesd()
     {
         var parser = CreateParser(validateToken: true);
         var ctx = CreateContext(("width", "600"), ("rmode", "crop"), ("token", "tok"));
@@ -163,7 +163,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_FormatOnly_ReturnsCommands()
+    public void Parse_MatOnly_ReturnsCommands()
     {
         var parser = CreateParser();
         var ctx = CreateContext(("format", "png"));
@@ -183,7 +183,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_SupportedHeightWithUnsupportedWidth_KeepsHeight()
+    public void Parse_SupportedHeightWithUnsupportedWidth_KeepssHeight()
     {
         var parser = CreateParser();
         // width=999 stripped, height=600 kept → commands not null
@@ -195,7 +195,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_BothDimensionsUnsupported_NoToken_ReturnsNull()
+    public void Parse_BothDimensionsUnsupportedNoToken_ReturnsNull()
     {
         var parser = CreateParser();
         var ctx = CreateContext(("width", "999"), ("height", "300"));
@@ -203,7 +203,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_TokenizationDisabled_SupportedSize_ReturnsCommands()
+    public void Parse_TokenizationDisabledSupportedSize_ReturnsCommands()
     {
         var parser = CreateParser(useTokenizedQueryString: false);
         var ctx = CreateContext(("width", "1024"));
@@ -213,7 +213,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_TokenizationDisabled_UnsupportedSize_ReturnsNull()
+    public void Parse_TokenizationDisabledUnsupportedSize_ReturnsNull()
     {
         var parser = CreateParser(useTokenizedQueryString: false);
         var ctx = CreateContext(("width", "999"));
@@ -221,7 +221,7 @@ public sealed class MediaCommandParserTests
     }
 
     [Fact]
-    public void Parse_TokenizationDisabled_FocalPoint_IsStripped()
+    public void Parse_TokenizationDisabledFocalPoint_IsStripped()
     {
         var parser = CreateParser(useTokenizedQueryString: false);
         var ctx = CreateContext(("width", "1024"), ("rxy", "0.5,0.5"));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCommandsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCommandsTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public class MediaCommandsTests
 {
     [Fact]
-    public void GetValues_OnNewInstance_IsEmpty()
+    public void GetValues_NewInstance_IsEmpty()
     {
         var commands = new MediaCommands();
 
@@ -15,7 +15,7 @@ public class MediaCommandsTests
     }
 
     [Fact]
-    public void IndividualSetters_Then_GetValues_ReturnsExpectedPairs_InSortedOrder()
+    public void IndividualSetters_ThenGetValuesReturnsExpectedPairs_InSortedOrder()
     {
         var commands = new MediaCommands();
 
@@ -45,7 +45,7 @@ public class MediaCommandsTests
     }
 
     [Fact]
-    public void SetCommands_WithShuffledInput_IgnoresUnknowns_AndReturnsSorted()
+    public void SetCommands_ShuffledInputIgnoresUnknowns_AndReturnsSorted()
     {
         var commands = new MediaCommands();
 
@@ -78,7 +78,7 @@ public class MediaCommandsTests
     }
 
     [Fact]
-    public void SettingSameCommandTwice_OverwritesPreviousValue()
+    public void SettingSameCommandTwice_Default_OverwritesPreviousValue()
     {
         var commands = new MediaCommands();
 
@@ -93,7 +93,7 @@ public class MediaCommandsTests
     }
 
     [Fact]
-    public void SettingCommandToNull_RemovesValue()
+    public void SettingCommandToNull_Default_RemovesValue()
     {
         var commands = new MediaCommands();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public class MediaEventTests
 {
     [Fact]
-    public async Task DisposesMediaCreatingStreams()
+    public async Task DisposesMediaCreatingStreams_Default_Succeeds()
     {
         var streams = new List<Stream>();
         var creatingEventHandlers = new List<IMediaCreatingEventHandler>()

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaFileStoreExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaFileStoreExtensionsTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public class MediaFileStoreExtensionsTests
 {
     [Fact]
-    public async Task CreateFileFromStreamAsync_FileEventHandlerCanReplaceStreamBeforeSaving()
+    public async Task CreateFileFromStreamAsync_FileEventHandlerCanReplaceStreamBeforeSaving_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var mediaFileStoreMock = new Mock<IMediaFileStore>();
@@ -42,7 +42,7 @@ public class MediaFileStoreExtensionsTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_FileEventHandlerCanRejectFile()
+    public async Task CreateFileFromStreamAsync_FileEventHandlerCanRejectFile_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var mediaFileStoreMock = new Mock<IMediaFileStore>(MockBehavior.Strict);
@@ -65,7 +65,7 @@ public class MediaFileStoreExtensionsTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_FileEventHandlersRunCreatedAfterTheFileIsStored()
+    public async Task CreateFileFromStreamAsync_FileEventHandlersRunCreatedAfterTheFileIsStored_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var mediaFileStoreMock = new Mock<IMediaFileStore>();
@@ -93,7 +93,7 @@ public class MediaFileStoreExtensionsTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_FileEventHandlersRunBeforeMediaCreatingHandlers()
+    public async Task CreateFileFromStreamAsync_FileEventHandlersRunBeforeMediaCreatingHandlers_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var fileStoreMock = new Mock<IFileStore>();
@@ -143,7 +143,7 @@ public class MediaFileStoreExtensionsTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_FileEventHandlerRejectionStopsMediaProcessing()
+    public async Task CreateFileFromStreamAsync_FileEventHandlerRejectionStopsMediaProcessing_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var loggerMock = new Mock<ILogger<DefaultMediaFileStore>>();
@@ -176,7 +176,7 @@ public class MediaFileStoreExtensionsTests
     }
 
     [Fact]
-    public async Task CreateFileFromStreamAsync_FileEventReplacementStreamLivesThroughMediaProcessingAndStorage()
+    public async Task CreateFileFromStreamAsync_FileEventReplacementStreamLivesThroughMediaProcessingAndStorage_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var fileStoreMock = new Mock<IFileStore>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaOrchardHelperExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaOrchardHelperExtensionsTests.cs
@@ -13,7 +13,7 @@ public class MediaOrchardHelperExtensionsTests
     [InlineData("bàr.jpeg", "/media/b%C3%A0r.jpeg")]
     [InlineData("日本語.jpg", "/media/%E6%97%A5%E6%9C%AC%E8%AA%9E.jpg")]
     [InlineData("simple.jpg", "/media/simple.jpg")]
-    public async Task AssetProfileUrlAsync_ReturnsUrlEncodedPath(string path, string expected)
+    public async Task AssetProfileUrlAsync_Default_ReturnsUrlEncodedPath(string path, string expected)
     {
         var orchardHelper = CreateOrchardHelper();
 
@@ -26,7 +26,7 @@ public class MediaOrchardHelperExtensionsTests
     [InlineData("foo bar.jpg", 100, "/media/foo%20bar.jpg?width=100")]
     [InlineData("bàr.jpeg", 200, "/media/b%C3%A0r.jpeg?width=200")]
     [InlineData("my folder/foo bar.jpg", 50, "/media/my%20folder/foo%20bar.jpg?width=50")]
-    public async Task AssetProfileUrlAsync_WithWidth_ReturnsUrlEncodedPathWithQueryString(string path, int width, string expected)
+    public async Task AssetProfileUrlAsync_Width_ReturnsUrlEncodedPathWithQueryString(string path, int width, string expected)
     {
         var orchardHelper = CreateOrchardHelper();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
@@ -90,7 +90,7 @@ public class MediaTokenTests
     [Theory]
     [InlineData("/media/blog.jpg?width=100&height=100", "/media/blog.jpg?width=100&height=100&token=eVmmj09NoysPASEiuhCuUHJR%2BSrUtSafBo738SuL2eU%3D")]
     [InlineData("/media/blog.jpg?width=100&height=100&foo=bar", "/media/blog.jpg?width=100&height=100&token=eVmmj09NoysPASEiuhCuUHJR%2BSrUtSafBo738SuL2eU%3D&foo=bar")]
-    public void ShouldAddToken(string path, string expected)
+    public void Add_Token_Succeeds(string path, string expected)
     {
         var serviceProvider = CreateServiceProvider();
         var mediaTokenService = serviceProvider.GetRequiredService<IMediaTokenService>();
@@ -106,7 +106,7 @@ public class MediaTokenTests
     [Theory]
     [InlineData("/media/blog.jpg?v=version")]
     [InlineData("/media/blog.jpg")]
-    public void ShouldNotAddTokens(string path)
+    public void Not_AddTokens_Succeeds(string path)
     {
         var serviceProvider = CreateServiceProvider();
         var mediaTokenService = serviceProvider.GetRequiredService<IMediaTokenService>();
@@ -116,7 +116,7 @@ public class MediaTokenTests
     }
 
     [Fact]
-    public void ShouldGenerateConsistentToken()
+    public void Generate_ConsistentToken_Succeeds()
     {
         var sp1 = CreateServiceProvider();
         var sp2 = CreateServiceProvider();
@@ -130,7 +130,7 @@ public class MediaTokenTests
     }
 
     [Fact]
-    public void ShouldExcludeVersionFromTokenButPreserveItInPath()
+    public void Exclude_VersionFromTokenButPreserveItInPath_Succeeds()
     {
         var serviceProvider = CreateServiceProvider();
         var mediaTokenService = serviceProvider.GetRequiredService<IMediaTokenService>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MoveAttachedMediaFieldsStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MoveAttachedMediaFieldsStepTests.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public class MoveAttachedMediaFieldsStepTests
 {
     [Fact]
-    public async Task MoveAttachedMediaFieldsStep_MovesOnlySelectedContentTypes()
+    public async Task MoveAttachedMediaFieldsStep_Default_MovesOnlySelectedContentTypes()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();
@@ -37,7 +37,7 @@ public class MoveAttachedMediaFieldsStepTests
     }
 
     [Fact]
-    public async Task MoveAttachedMediaFieldsStep_EvaluatesAllContentTypes_WhenFilterIsMissing()
+    public async Task MoveAttachedMediaFieldsStepEvaluatesAllContentTypes_FilterIsMissing_Succeeds()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/SecureMedia/ViewMediaFolderAuthorizationHandlerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/SecureMedia/ViewMediaFolderAuthorizationHandlerTests.cs
@@ -32,7 +32,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
     [InlineData("ManageMediaFolder", "/")]
     [InlineData("ManageMediaFolder", "filename.png")]
     [InlineData("ManageMediaFolder", "/filename.png")]
-    public async Task GrantsRootViewPermission(string permission, string resource)
+    public async Task GrantsRootViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -74,7 +74,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
     [InlineData("ViewRootMediaContent", "/" + MediafieldsFolder)]
     [InlineData("ViewRootMediaContent", MediafieldsFolder + "/filename.png")]
     [InlineData("ViewRootMediaContent", "/" + MediafieldsFolder + "/filename.png")]
-    public async Task DoesNotGrantRootViewPermission(string permission, string resource)
+    public async Task DoesNotGrantRootViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -106,7 +106,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
 
     [InlineData("ManageMediaFolder", "non-existent-folder")]
     [InlineData("ManageMediaFolder", "non-existent-folder/filename.png")]
-    public async Task GrantsAllFoldersViewPermission(string permission, string resource)
+    public async Task GrantsAllFoldersViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -127,7 +127,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
     [InlineData("ViewMediaContent", UsersFolder + "/filename.png")]
     [InlineData("ViewMediaContent", MediafieldsFolder)]
     [InlineData("ViewMediaContent", MediafieldsFolder + "/filename.png")]
-    public async Task DoesNotGrantSpecialFoldersViewPermission(string permission, string resource)
+    public async Task DoesNotGrantSpecialFoldersViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -145,7 +145,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
     [InlineData("ViewMediaContent_folder", "folder/filename.png")]
     [InlineData("ViewMediaContent_folder", "/folder")]
     [InlineData("ViewMediaContent_folder", "/folder/filename.png")]
-    public async Task GrantsFolderViewPermission(string permission, string resource)
+    public async Task GrantsFolderViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -179,7 +179,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
 
     [InlineData("ViewMediaContent_folder", MediafieldsFolder)]
     [InlineData("ViewMediaContent_folder", MediafieldsFolder + "/filename.png")]
-    public async Task DoesNotGrantFolderViewPermission(string permission, string resource)
+    public async Task DoesNotGrantFolderViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -197,7 +197,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
     [Theory]
     [InlineData("ViewContent", MediafieldsFolder + "/content-type/content-item-id")]
     [InlineData("ViewContent", MediafieldsFolder + "/content-type/content-item-id" + "/filename.png")]
-    public async Task GrantsMediafieldsFolderViewPermission(string permission, string resource)
+    public async Task GrantsMediafieldsFolderViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -219,7 +219,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
 
     [InlineData("ManageMediaFolder", MediafieldsFolder)]
     [InlineData("ManageMediaFolder", MediafieldsFolder + "/filename.png")]
-    public async Task DoesNotGrantMediafieldsFolderViewPermission(string permission, string resource)
+    public async Task DoesNotGrantMediafieldsFolderViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -240,7 +240,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
 
     [InlineData("ViewOwnMediaContent", MediafieldsFolder + "/temp/user-folder/")]
     [InlineData("ViewOwnMediaContent", MediafieldsFolder + "/temp/user-folder/filename.png")]
-    public async Task GrantsOwnUserFolderViewPermission(string permission, string resource)
+    public async Task GrantsOwnUserFolderViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -259,7 +259,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
 
     [InlineData("ViewOwnMediaContent", MediafieldsFolder + "/temp/other-user-folder/")]
     [InlineData("ViewOwnMediaContent", MediafieldsFolder + "/temp/other-user-folder/filename.png")]
-    public async Task DoesNotGrantOwnUserFolderViewPermission(string permission, string resource)
+    public async Task DoesNotGrantOwnUserFolderViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();
@@ -284,7 +284,7 @@ public class ViewMediaFolderAuthorizationHandlerTests
 
     [InlineData("ViewOthersMediaContent", MediafieldsFolder + "/temp/other-user-folder/")]
     [InlineData("ViewOthersMediaContent", MediafieldsFolder + "/temp/other-user-folder/filename.png")]
-    public async Task GrantsOtherUserFolderViewPermission(string permission, string resource)
+    public async Task GrantsOtherUserFolderViewPermission_Default_Succeeds(string permission, string resource)
     {
         // Arrange
         var handler = CreateHandler();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/SingleFlightTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/SingleFlightTests.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public sealed class SingleFlightTests
 {
     [Fact]
-    public async Task ScheduleAsync_CoalescesConcurrentCallsForSameKey()
+    public async Task ScheduleAsync_CoalescesConcurrentCallsForSameKey_Succeeds()
     {
         var singleFlight = new SingleFlight<string, string>();
         var invocations = 0;
@@ -37,7 +37,7 @@ public sealed class SingleFlightTests
     }
 
     [Fact]
-    public async Task ScheduleAsync_RunsFactoryAgainAfterCompletion()
+    public async Task ScheduleAsync_RunsFactoryAgainAfterCompletion_Succeeds()
     {
         var singleFlight = new SingleFlight<string, string>();
         var invocations = 0;
@@ -57,7 +57,7 @@ public sealed class SingleFlightTests
     }
 
     [Fact]
-    public async Task ScheduleAsync_DifferentKeysRunIndependently()
+    public async Task ScheduleAsync_DifferentKeysRunIndependently_Succeeds()
     {
         var singleFlight = new SingleFlight<string, string>();
         var invocations = 0;
@@ -78,7 +78,7 @@ public sealed class SingleFlightTests
     }
 
     [Fact]
-    public async Task ScheduleAsync_FailureIsNotCachedAndAllWaitersObserveException()
+    public async Task ScheduleAsync_FailureIsNotCachedAndAllWaitersObserveException_Succeeds()
     {
         var singleFlight = new SingleFlight<string, string>();
         var invocations = 0;

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/SlugifyMediaNameNormalizerServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/SlugifyMediaNameNormalizerServiceTests.cs
@@ -13,7 +13,7 @@ public class SlugifyMediaNameNormalizerServiceTests
     private readonly SlugService _slugService = new();
 
     [Fact]
-    public void ShouldNormalizeFolderNameWithTransliterationEnabledByDefault()
+    public void Normalize_FolderNameWithTransliterationEnabledByDefault_Succeeds()
     {
         var options = new MediaSlugifyOptions();
         var service = new SlugifyMediaNameNormalizerService(_slugService, Options.Create(options));
@@ -24,7 +24,7 @@ public class SlugifyMediaNameNormalizerServiceTests
     }
 
     [Fact]
-    public void ShouldNormalizeFileNameWithoutTransliterationWhenDisabled()
+    public void Normalize_Disabled_Succeeds()
     {
         var options = new MediaSlugifyOptions
         {
@@ -38,7 +38,7 @@ public class SlugifyMediaNameNormalizerServiceTests
     }
 
     [Fact]
-    public void ShouldDefaultTransliterationToTrueWhenConfigurationIsMissing()
+    public void Default_ConfigurationIsMissing_Succeeds()
     {
         var options = new MediaSlugifyOptions
         {
@@ -54,7 +54,7 @@ public class SlugifyMediaNameNormalizerServiceTests
     }
 
     [Fact]
-    public void ShouldReadTransliterationFromConfiguration()
+    public void Read_TransliterationFromConfiguration_Succeeds()
     {
         var shellConfiguration = CreateShellConfiguration(
         [

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/VipsImageProcessingEngineTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/VipsImageProcessingEngineTests.cs
@@ -51,7 +51,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_CropMode_ProducesExactDimensions()
+    public async Task Process_CropMode_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands { Width = 60, Height = 60, ResizeMode = ResizeMode.Crop };
@@ -61,7 +61,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_CropMode_WithFocalPoint_ProducesExactDimensions()
+    public async Task Process_CropModeWithFocalPoint_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands
@@ -78,7 +78,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_StretchMode_ProducesExactDimensions()
+    public async Task Process_StretchMode_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands { Width = 100, Height = 80, ResizeMode = ResizeMode.Stretch };
@@ -90,7 +90,7 @@ public sealed class VipsImageProcessingEngineTests
     [Theory]
     [InlineData(200, 100, 50, null, 50, 100)]  // width-only: height is left unchanged
     [InlineData(200, 100, null, 40, 200, 40)]  // height-only: width is left unchanged
-    public async Task Process_StretchMode_SingleAxis_LeavesOtherAxisUnchanged(
+    public async Task Process_StretchModeSingleAxis_LeavesOtherAxisUnchanged(
         int srcW, int srcH, int? reqW, int? reqH, int expW, int expH)
     {
         using var input = CreateTestPng(srcW, srcH);
@@ -101,7 +101,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_CropMode_WithFocalPoint_SingleAxis_LeavesOtherAxisUnchanged()
+    public async Task Process_CropModeWithFocalPointSingleAxis_LeavesOtherAxisUnchanged()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands
@@ -119,7 +119,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_PadMode_ProducesExactDimensions()
+    public async Task Process_PadMode_ProducessExactDimensions()
     {
         // Input 200x100 → pad to portrait 100x200; thumbnail shrinks to 100x50, rest is padding.
         using var input = CreateTestPng(200, 100);
@@ -205,7 +205,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_PadMode_RgbaSource_ProducesExactDimensions()
+    public async Task Process_PadModeRgbaSource_ProducessExactDimensions()
     {
         // A 4-band (RGBA) source must pad without a band-count mismatch on the background color.
         using var rgba = Image.Black(200, 100, bands: 4);
@@ -224,7 +224,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_PadMode_GrayscaleSource_ProducesExactDimensions()
+    public async Task Process_PadModeGrayscaleSource_ProducessExactDimensions()
     {
         // A single-band (grayscale) source must pad without a band-count mismatch.
         using var gray = Image.Black(200, 100, bands: 1);
@@ -243,7 +243,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_BoxPadMode_ProducesExactDimensions()
+    public async Task Process_BoxPadMode_ProducessExactDimensions()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands
@@ -259,7 +259,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_AutoOrientDisabled_ProducesOutput()
+    public async Task Process_AutoOrientDisabled_ProducessOutput()
     {
         using var input = CreateTestPng(200, 100);
         var commands = new ImageProcessingCommands { Width = 100, ResizeMode = ResizeMode.Max, AutoOrient = false };
@@ -280,7 +280,7 @@ public sealed class VipsImageProcessingEngineTests
     }
 
     [Fact]
-    public async Task Process_OutputIsNonEmpty()
+    public async Task Process_OutputIsNonEmpty_Succeeds()
     {
         using var input = CreateTestPng(100, 50);
         var commands = new ImageProcessingCommands { Width = 50, Format = Format.Png };

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/ApplicationControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/ApplicationControllerTests.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId;
 public class ApplicationControllerTests
 {
     [Fact]
-    public async Task UsersShouldNotBeAbleToCreateIfNotAllowed()
+    public async Task Users_Default_NotBeAbleToCreateIfNotAllowed()
     {
         var controller = new ApplicationController(
             Mock.Of<IShapeFactory>(),
@@ -29,7 +29,7 @@ public class ApplicationControllerTests
     }
 
     [Fact]
-    public async Task UsersShouldBeAbleToCreateApplicationIfAllowed()
+    public async Task Users_Default_BeAbleToCreateApplicationIfAllowed()
     {
         var mockOpenIdScopeManager = new Mock<IOpenIdScopeManager>();
         var mockData = Array.Empty<object>();
@@ -59,7 +59,7 @@ public class ApplicationControllerTests
     [InlineData(OpenIddictConstants.ClientTypes.Public, "", true, false, true)]
     [InlineData(OpenIddictConstants.ClientTypes.Confidential, "ClientSecret", true, false, true)]
     [InlineData(OpenIddictConstants.ClientTypes.Confidential, "", true, false, false)]
-    public async Task ConfidentialClientNeedsSecret(string clientType, string clientSecret, bool allowAuthFlow, bool allowPasswordFlow, bool expectValidModel)
+    public async Task ConfidentialClientNeedsSecret_Default_Succeeds(string clientType, string clientSecret, bool allowAuthFlow, bool allowPasswordFlow, bool expectValidModel)
     {
         var controller = new ApplicationController(
             Mock.Of<IShapeFactory>(),
@@ -99,7 +99,7 @@ public class ApplicationControllerTests
     [InlineData("nonUrlString", false)]
     [InlineData("http://localhost http://localhost:8080 nonUrlString", false)]
     [InlineData("http://localhost http://localhost:8080", true)]
-    public async Task RedirectUrisAreValid(string uris, bool expectValidModel)
+    public async Task RedirectUrisAreValid_Default_Succeeds(string uris, bool expectValidModel)
     {
         // Arrange
         var controller = new ApplicationController(

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
@@ -12,7 +12,7 @@ public class OpenIdApplicationStepTests
 {
     [Theory]
     [ClassData(typeof(OpenIdApplicationStepTestsData))]
-    public async Task OpenIdApplicationCanBeParsed(string recipeName, OpenIdApplicationDescriptor expected)
+    public async Task OpenIdApplicationCanBeParsed_Default_Succeeds(string recipeName, OpenIdApplicationDescriptor expected)
     {
         // Arrange
         OpenIdApplicationDescriptor actual = null;
@@ -67,7 +67,7 @@ public class OpenIdApplicationStepTests
     }
 
     [Fact]
-    public async Task OpenIdApplicationCanBeUpdated()
+    public async Task OpenIdApplicationCanBeUpdated_Default_Succeeds()
     {
         // Arrange
         var recipeName = "app-recipe3";

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
@@ -319,7 +319,7 @@ public class OpenIdAuthenticationTests
     }
 
     [Fact]
-    public async Task OpenId_PasswordGrant_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task OpenIdPasswordGrant_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         var context = new SiteContext();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdScopeStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdScopeStepTests.cs
@@ -30,7 +30,7 @@ public class OpenIdScopeStepTests
     }
 
     [Fact]
-    public async Task OpenIdScopeCanBeParsed()
+    public async Task OpenIdScopeCanBeParsed_Default_Succeeds()
     {
         // Arrange
 
@@ -83,7 +83,7 @@ public class OpenIdScopeStepTests
     }
 
     [Fact]
-    public async Task OpenIdScopeCanBeUpdated()
+    public async Task OpenIdScopeCanBeUpdated_Default_Succeeds()
     {
         // Arrange
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId;
 public class OpenIdServerDeploymentSourceTests
 {
     [Fact]
-    public async Task ServerDeploymentSourceIsReadableByRecipe()
+    public async Task ServerDeploymentSourceIsReadableByRecipe_Default_Succeeds()
     {
         // Arrange
         var settings = CreateSettings("https://deploy.localhost", OpenIdServerSettings.TokenFormat.JsonWebToken, true);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/AdminControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/AdminControllerTests.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.RateLimits;
 public class AdminControllerTests
 {
     [Fact]
-    public async Task EditPostShouldSaveEnabledPolicyMetadataWithoutReloadingShell()
+    public async Task EditPost_Default_SavessEnabledPolicyMetadataWithoutReloadingShell()
     {
         const string policyId = "policy-id";
         var enabledUtc = DateTime.UtcNow;
@@ -81,7 +81,7 @@ public class AdminControllerTests
     }
 
     [Fact]
-    public async Task EnableShouldReloadShellWhenEnablingDisabledPolicy()
+    public async Task Enable_EnablingDisabledPolicy_ReloadShell()
     {
         const string policyId = "policy-id";
         var existingPolicy = new RateLimitPolicy
@@ -111,7 +111,7 @@ public class AdminControllerTests
     }
 
     [Fact]
-    public async Task CloneShouldCreateDisabledPolicyWithUniqueIncrementedName()
+    public async Task Clone_Default_CreatesDisabledPolicyWithUniqueIncrementedName()
     {
         const string policyId = "policy-id";
         var sourcePolicy = new RateLimitPolicy

--- a/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/RateLimiterMiddlewareTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/RateLimiterMiddlewareTests.cs
@@ -21,7 +21,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.RateLimits;
 public class RateLimiterMiddlewareTests
 {
     [Fact]
-    public async Task ShouldNotCountStaticAssetsAgainstGlobalRateLimit()
+    public async Task Not_CountStaticAssetsAgainstGlobalRateLimit_Succeeds()
     {
         using var staticAssetDirectory = new StaticAssetDirectory();
         using var host = await CreateHostAsync(
@@ -54,7 +54,7 @@ public class RateLimiterMiddlewareTests
     }
 
     [Fact]
-    public async Task ShouldApplyShortRouteLimitToNamedTenantRoute()
+    public async Task Apply_ShortRouteLimitToNamedTenantRoute_Succeeds()
     {
         using var staticAssetDirectory = new StaticAssetDirectory();
         using var host = await CreateHostAsync(
@@ -89,7 +89,7 @@ public class RateLimiterMiddlewareTests
     }
 
     [Fact]
-    public async Task ShouldApplyEndpointSpecificPoliciesWithoutGlobalPolicies()
+    public async Task Apply_EndpointSpecificPoliciesWithoutGlobalPolicies_Succeeds()
     {
         using var staticAssetDirectory = new StaticAssetDirectory();
         using var host = await CreateHostAsync(
@@ -116,7 +116,7 @@ public class RateLimiterMiddlewareTests
     }
 
     [Fact]
-    public async Task ShouldApplyGroupSpecificPoliciesToGroupedEndpoints()
+    public async Task Apply_GroupSpecificPoliciesToGroupedEndpoints_Succeeds()
     {
         using var staticAssetDirectory = new StaticAssetDirectory();
         using var host = await CreateHostAsync(

--- a/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/RateLimiterOptionsConfigurationsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.RateLimits/RateLimiterOptionsConfigurationsTests.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.RateLimits;
 public class RateLimiterOptionsConfigurationsTests
 {
     [Fact]
-    public async Task ShouldApplyCustomRouteLimitForMatchingRouteNameAndMethod()
+    public async Task Apply_CustomRouteLimitForMatchingRouteNameAndMethod_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var rateLimitsOptions = new RateLimitsOptions();
@@ -31,7 +31,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldOnlyApplyCustomRouteLimitToMatchingHttpMethods()
+    public async Task Only_ApplyCustomRouteLimitToMatchingHttpMethods_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var rateLimitsOptions = new RateLimitsOptions();
@@ -52,7 +52,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldApplyCustomRouteLimitToEndpointNameMetadata()
+    public async Task Apply_CustomRouteLimitToEndpointNameMetadata_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var rateLimitsOptions = new RateLimitsOptions();
@@ -68,7 +68,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldApplyCustomGroupLimitToMatchingEndpointGroup()
+    public async Task Apply_CustomGroupLimitToMatchingEndpointGroup_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var rateLimitsOptions = new RateLimitsOptions();
@@ -86,7 +86,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldApplyEnabledGlobalPolicy()
+    public async Task Apply_EnabledGlobalPolicy_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
 
@@ -105,7 +105,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldIgnoreDisabledPolicies()
+    public async Task Ignore_DisabledPolicies_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var disabledPolicy = CreateGlobalFixedWindowPolicy("Disabled", 1, 60);
@@ -122,7 +122,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldApplyEnabledEndpointPolicy()
+    public async Task Apply_EnabledEndpointPolicy_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var policy = CreateGlobalFixedWindowPolicy("Api", 1, 60);
@@ -143,7 +143,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldApplyEnabledGroupPolicyToAnyMatchingGroup()
+    public async Task Apply_EnabledGroupPolicyToAnyMatchingGroup_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var policy = CreateGlobalFixedWindowPolicy("Authentication", 1, 60);
@@ -162,7 +162,7 @@ public class RateLimiterOptionsConfigurationsTests
     }
 
     [Fact]
-    public async Task ShouldHandleEnabledPoliciesWithStringifiedNumericLimiterValues()
+    public async Task Handle_EnabledPoliciesWithStringifiedNumericLimiterValues_Succeeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var limiter = new RateLimitLimiter

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Redis/RedisCacheWrapperTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Redis/RedisCacheWrapperTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Redis;
 public class RedisCacheWrapperTests
 {
     [Fact]
-    public void RedisCacheWrapperMustNotDisposeInnerCache()
+    public void RedisCacheWrapper_Default_NotDisposeInnerCache()
     {
         var redisCache = new Mock<IDistributedCache>();
         var disposable = redisCache.As<IDisposable>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
@@ -31,7 +31,7 @@ public class SubResourceIntegrityTests
         await ValidateSubResourceIntegrityAsync("script");
         await ValidateSubResourceIntegrityAsync("style");
 
-        async Task ValidateSubResourceIntegrityAsync_Default_Succeeds(string resourceType)
+        async Task ValidateSubResourceIntegrityAsync(string resourceType)
         {
             foreach (var resource in resourceManifest.GetResources(resourceType))
             {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
@@ -31,7 +31,7 @@ public class SubResourceIntegrityTests
         await ValidateSubResourceIntegrityAsync("script");
         await ValidateSubResourceIntegrityAsync("style");
 
-        async Task ValidateSubResourceIntegrityAsync(string resourceType)
+        async Task ValidateSubResourceIntegrityAsync_Default_Succeeds(string resourceType)
         {
             foreach (var resource in resourceManifest.GetResources(resourceType))
             {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Roles/PermissionHandlerHelperTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Roles/PermissionHandlerHelperTests.cs
@@ -12,7 +12,7 @@ public class PermissionHandlerHelperTests
     [InlineData("AllowAnonymous", false, true)]
     [InlineData("AllowAuthenticated", true, true)]
     [InlineData("AllowAuthenticated", false, false)]
-    public async Task GrantsRolesPermissions(string required, bool authenticated, bool success)
+    public async Task GrantsRolesPermissions_Default_Succeeds(string required, bool authenticated, bool success)
     {
         // Arrange
         var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission(required), authenticated: authenticated);
@@ -44,7 +44,7 @@ public class PermissionHandlerHelperTests
     }
 
     [Fact]
-    public async Task DoNotRevokeExistingGrants()
+    public async Task DoNotRevokeExistingGrants_Default_Succeeds()
     {
         // Arrange
         var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Required"), ["Other"], true);
@@ -61,7 +61,7 @@ public class PermissionHandlerHelperTests
     }
 
     [Fact]
-    public async Task GrantsInheritedPermissions()
+    public async Task GrantsInheritedPermissions_Default_Succeeds()
     {
         // Arrange
         var level2 = new Permission("Implicit2");
@@ -91,7 +91,7 @@ public class PermissionHandlerHelperTests
     [Theory]
     [InlineData("AllowAnonymous", true)]
     [InlineData("AllowAuthenticated", true)]
-    public async Task IsCaseInsensitive(string required, bool authenticated)
+    public async Task IsCaseInsensitive_Default_Succeeds(string required, bool authenticated)
     {
         // Arrange
         var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission(required), authenticated: authenticated);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Rules/RuleTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Rules/RuleTests.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Rules;
 public class RuleTests
 {
     [Fact]
-    public async Task ShouldEvaluateRuleFalseWhenNoConditions()
+    public async Task Evaluate_NoConditions_Succeeds()
     {
         var rule = new Rule();
 
@@ -29,7 +29,7 @@ public class RuleTests
     [InlineData("/notthehomepage", true, false)]
     [InlineData("/", false, false)]
     [InlineData("/notthehomepage", false, true)]
-    public async Task ShouldEvaluateHomepage(string path, bool isHomepage, bool expected)
+    public async Task Evaluate_Homepage_Succeeds(string path, bool isHomepage, bool expected)
     {
         var rule = new Rule
         {
@@ -62,7 +62,7 @@ public class RuleTests
     [Theory]
     [InlineData(true, true)]
     [InlineData(false, false)]
-    public async Task ShouldEvaluateBoolean(bool boolean, bool expected)
+    public async Task Evaluate_Boolean_Succeeds(bool boolean, bool expected)
     {
         var rule = new Rule
         {
@@ -86,7 +86,7 @@ public class RuleTests
     [InlineData(false, true, true)]
     [InlineData(true, true, true)]
     [InlineData(false, false, false)]
-    public async Task ShouldEvaluateAny(bool first, bool second, bool expected)
+    public async Task Evaluate_Any_Succeeds(bool first, bool second, bool expected)
     {
         var rule = new Rule
         {
@@ -117,7 +117,7 @@ public class RuleTests
     [Theory]
     [InlineData("/foo", "/foo", true)]
     [InlineData("/bar", "/foo", false)]
-    public async Task ShouldEvaluateUrlEquals(string path, string requestPath, bool expected)
+    public async Task Evaluate_UrlEquals_Succeeds(string path, string requestPath, bool expected)
     {
         var rule = new Rule
         {
@@ -151,7 +151,7 @@ public class RuleTests
     [Theory]
     [InlineData("isHomepage()", "/", true)]
     [InlineData("isHomepage()", "/foo", false)]
-    public async Task ShouldEvaluateJavascriptCondition(string script, string requestPath, bool expected)
+    public async Task Evaluate_JavascriptCondition_Succeeds(string script, string requestPath, bool expected)
     {
         var rule = new Rule
         {
@@ -185,7 +185,7 @@ public class RuleTests
     }
 
     [Fact]
-    public async Task ShouldEvaluateJavascriptConditionWithAsyncGlobalMethod()
+    public async Task Evaluate_JavascriptConditionWithAsyncGlobalMethod_Succeeds()
     {
         var rule = new Rule
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Scripting/GlobalMethodsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Scripting/GlobalMethodsTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Scripting;
 public class GlobalMethodsTests
 {
     [Fact]
-    public void ShouldBase64EncodeCompressedBase64()
+    public void Base_64EncodeCompressedBase64_Succeeds()
     {
         var gzip = (Func<string, string>)CommonGeneratorMethods._gZip.Method.Invoke(null);
         var source = "H4sIAOCaLmcAA/NIzcnJVwjPL8pJUQQAoxwpHAwAAAA=";
@@ -16,7 +16,7 @@ public class GlobalMethodsTests
     }
 
     [Fact]
-    public void ShouldBase64Decode()
+    public void Base_64Decode_Succeeds()
     {
         var base64encode = (Func<string, string>)CommonGeneratorMethods._base64.Method.Invoke(null);
         var source = Convert.ToBase64String(Encoding.UTF8.GetBytes("Hello World!"));
@@ -26,7 +26,7 @@ public class GlobalMethodsTests
     }
 
     [Fact]
-    public void ShouldHtmlDecode()
+    public void Html_Decode_Succeeds()
     {
         var htmldecode = (Func<string, string>)CommonGeneratorMethods._html.Method.Invoke(null);
         var source = "&lt;Hello&gt;";
@@ -36,7 +36,7 @@ public class GlobalMethodsTests
     }
 
     [Fact]
-    public void ShouldEncryptAndDecrypt()
+    public void Encrypt_Decrypt_Succeeds()
     {
         var services = new ServiceCollection();
         services.AddDataProtection();
@@ -57,7 +57,7 @@ public class GlobalMethodsTests
     }
 
     [Fact]
-    public void ShouldReturnEmptyStringWhenDecryptingEmptyInput()
+    public void Return_DecryptingEmptyInput_Succeeds()
     {
         var services = new ServiceCollection();
         services.AddDataProtection();
@@ -72,7 +72,7 @@ public class GlobalMethodsTests
     }
 
     [Fact]
-    public void ShouldReturnEmptyStringWhenDecryptingInvalidInput()
+    public void Return_DecryptingInvalidInput_Succeeds()
     {
         var services = new ServiceCollection();
         services.AddDataProtection();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Search.AzureAI/NamingTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Search.AzureAI/NamingTests.cs
@@ -8,7 +8,7 @@ public class NamingTests
     private static readonly string _overMaxLength = new('a', 129);
 
     [Fact]
-    public void CreateLengthSafeIndexName()
+    public void CreateLengthSafeIndexName_Default_Succeeds()
     {
 
 
@@ -34,7 +34,7 @@ public class NamingTests
     [InlineData("1234t", "1234t")]
     [InlineData("a", null)]
     [InlineData("___%^&", null)]
-    public void CreateSafeIndexName(string indexName, string expectedName)
+    public void CreateSafeIndexName_Default_Succeeds(string indexName, string expectedName)
     {
         var valid = AzureAISearchIndexNamingHelper.TryGetSafeIndexName(indexName, out var result);
 
@@ -51,7 +51,7 @@ public class NamingTests
     }
 
     [Fact]
-    public void CreateLengthSafeFieldName()
+    public void CreateLengthSafeFieldName_Default_Succeeds()
     {
         var isValid1 = AzureAISearchIndexNamingHelper.TryGetSafeFieldName(_maxName, out var result1);
 
@@ -80,7 +80,7 @@ public class NamingTests
     [InlineData("a1", "a1")]
     [InlineData("azureSearchFieldName", "FieldName")]
     [InlineData("azureSearch_FieldName", "FieldName")]
-    public void CreateSafeFieldName(string indexName, string expectedName)
+    public void CreateSafeFieldName_Default_Succeeds(string indexName, string expectedName)
     {
         var valid = AzureAISearchIndexNamingHelper.TryGetSafeFieldName(indexName, out var result);
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Search.AzureAI/VectorSearchIndexTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Search.AzureAI/VectorSearchIndexTests.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.AzureAI;
 public class VectorSearchIndexTests
 {
     [Fact]
-    public void GetSearchIndex_CreatesDefaultProfileAndAlgorithm_ForVectorField()
+    public void GetSearchIndex_VectorField_CreatesDefaultProfileAndAlgorithm()
     {
         var indexProfile = CreateIndexProfile();
         var metadata = indexProfile.GetOrCreate<AzureAISearchIndexMetadata>();
@@ -39,7 +39,7 @@ public class VectorSearchIndexTests
     }
 
     [Fact]
-    public void GetSearchIndex_UsesConfiguredVectorSearchMetadata()
+    public void GetSearchIndex_Default_UsesConfiguredVectorSearchMetadata()
     {
         var indexProfile = CreateIndexProfile();
         var metadata = indexProfile.GetOrCreate<AzureAISearchIndexMetadata>();
@@ -85,7 +85,7 @@ public class VectorSearchIndexTests
     }
 
     [Fact]
-    public void GetSearchIndex_UsesConfiguredProfileAsFallback_WhenVectorFieldOmitsProfile()
+    public void GetSearchIndex_VectorFieldOmitsProfile_UsesConfiguredProfileAsFallback()
     {
         var indexProfile = CreateIndexProfile();
         var metadata = indexProfile.GetOrCreate<AzureAISearchIndexMetadata>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Search.Elasticsearch/SettingsDisplayDriverTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Search.Elasticsearch/SettingsDisplayDriverTests.cs
@@ -53,7 +53,7 @@ public partial class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task ContentPickerFieldElasticEditorSettingsShouldDeserialize()
+    public async Task ContentPickerFieldElasticEditorSettings_Default_Deserialize()
     {
 
         await (await CreateShellContext().CreateScopeAsync()).UsingAsync(async scope =>

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Security/Extensions/SecurityHeadersApplicationBuilderExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Security/Extensions/SecurityHeadersApplicationBuilderExtensionsTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Security.Extensions.Tests;
 public class SecurityHeadersApplicationBuilderExtensionsTests
 {
     [Fact]
-    public void SecurityHeadersShouldBeAddedWithDefaultValues()
+    public void SecurityHeaders_Default_BeAddedWithDefaultValues()
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -26,7 +26,7 @@ public class SecurityHeadersApplicationBuilderExtensionsTests
     }
 
     [Fact]
-    public void SecurityHeadersShouldAddedAccordingSuppliedOptions()
+    public void SecurityHeaders_Default_AreAddedAccordingToSuppliedOptions()
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -64,7 +64,7 @@ public class SecurityHeadersApplicationBuilderExtensionsTests
     }
 
     [Fact]
-    public void SecurityHeadersShouldBeAddedAccordingBuildConfiguration()
+    public void SecurityHeaders_Default_BeAddedAccordingBuildConfiguration()
     {
         // Arrange
         var context = new DefaultHttpContext();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Security/SecurityHeadersMiddlewareTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Security/SecurityHeadersMiddlewareTests.cs
@@ -47,7 +47,7 @@ public class SecurityMiddlewareTests
 
     [Theory]
     [MemberData(nameof(ContentSecurityPolicies))]
-    public async Task ContentSecurityPolicyHeaderShouldBeAdded(string[] contentSecurityPolicies, string expectedValue)
+    public async Task ContentSecurityPolicyHeader_Default_BeAdded(string[] contentSecurityPolicies, string expectedValue)
     {
         // Arrange
         var options = new SecurityHeadersOptions
@@ -66,7 +66,7 @@ public class SecurityMiddlewareTests
     }
 
     [Fact]
-    public async Task ContentTypeOptionsHeaderShouldBeAdded()
+    public async Task ContentTypeOptionsHeader_Default_BeAdded()
     {
         // Arrange
         var options = new SecurityHeadersOptions
@@ -86,7 +86,7 @@ public class SecurityMiddlewareTests
 
     [Theory]
     [MemberData(nameof(PermissionsPolicies))]
-    public async Task PermissionsPolicyHeaderShouldBeAdded(string[] permissionsPolicies, string expectedValue)
+    public async Task PermissionsPolicyHeader_Default_BeAdded(string[] permissionsPolicies, string expectedValue)
     {
         // Arrange
         var options = new SecurityHeadersOptions
@@ -106,7 +106,7 @@ public class SecurityMiddlewareTests
 
     [Theory]
     [MemberData(nameof(ReferrerPolicies))]
-    public async Task ReferrerPolicyHeaderShouldBeAdded(string policy, string expectedValue)
+    public async Task ReferrerPolicyHeader_Default_BeAdded(string policy, string expectedValue)
     {
         // Arrange
         var options = new SecurityHeadersOptions

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Setup/SetupControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Setup/SetupControllerTests.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Modules.OrchardCore.Setup.Tests;
 public class SetupControllerTests
 {
     [Fact]
-    public async Task IndexShouldKeepDatabaseOptionsVisible_WhenOnlyTablePrefixIsPreset()
+    public async Task Index_LyTablePrefixIsPreset_KeepssDatabaseOptionsVisible()
     {
         // Arrange
         var controller = CreateController(new ShellSettings
@@ -31,7 +31,7 @@ public class SetupControllerTests
     }
 
     [Fact]
-    public async Task IndexShouldHideDatabaseOptions_WhenDatabaseProviderOrConnectionIsPreset()
+    public async Task Index_DatabaseProviderOrConnectionIsPreset_HidessDatabaseOptions()
     {
         // Arrange
         var shellSettings = new ShellSettings();
@@ -53,7 +53,7 @@ public class SetupControllerTests
     }
 
     [Fact]
-    public async Task IndexShouldKeepConnectionOptionsVisible_WhenOnlyDatabaseProviderIsConfigured()
+    public async Task Index_LyDatabaseProviderIsConfigured_KeepssConnectionOptionsVisible()
     {
         // Arrange
         var shellSettings = new ShellSettings();
@@ -73,7 +73,7 @@ public class SetupControllerTests
     }
 
     [Fact]
-    public async Task IndexShouldDefaultSiteTimeZoneToSystemTimeZone()
+    public async Task Index_Default_DefaultSiteTimeZoneToSystemTimeZone()
     {
         // Arrange
         var controller = CreateController(new ShellSettings());
@@ -88,7 +88,7 @@ public class SetupControllerTests
     }
 
     [Fact]
-    public async Task IndexPostShouldUsePresetDatabaseProviderAndPostedConnectionString_WhenOnlyDatabaseProviderIsConfigured()
+    public async Task IndexPost_LyDatabaseProviderIsConfigured_UsesPresetDatabaseProviderAndPostedConnectionString()
     {
         // Arrange
         SetupContext capturedContext = null;

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Shortcodes/LocaleShortcodeTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Shortcodes/LocaleShortcodeTests.cs
@@ -13,7 +13,7 @@ public class LocaleShortcodeTests
     [InlineData("en-CA", "foo [locale en false]bar[/locale][locale fr]far[/locale] baz", @"foo  baz")]
     [InlineData("fr", "foo [locale 'en']bar[/locale][locale 'fr']far[/locale] baz", @"foo far baz")]
     [InlineData("fr", "foo [locale en]bar[/locale][locale fr]far[/locale] baz", @"foo far baz")]
-    public async Task ShouldProcess(string currentCulture, string text, string expected)
+    public async Task Process_Default_Succeeds(string currentCulture, string text, string expected)
     {
         CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(currentCulture);
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Spatial/SettingsDisplayDriverTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Spatial/SettingsDisplayDriverTests.cs
@@ -41,7 +41,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task GeoPointFieldSettingsShouldDeserialize()
+    public async Task GeoPointFieldSettings_Default_Deserialize()
     {
         var settings = new GeoPointFieldSettings
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Taxonomies/SettingsDisplayDriverTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Taxonomies/SettingsDisplayDriverTests.cs
@@ -41,7 +41,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task TaxonomyFieldSettingsShouldDeserialize()
+    public async Task TaxonomyFieldSettings_Default_Deserialize()
     {
         var settings = new TaxonomyFieldSettings
         {
@@ -68,7 +68,7 @@ public class SettingsDisplayDriverTests
     }
 
     [Fact]
-    public async Task TaxonomyFieldTagsEditorSettingsShouldDeserialize()
+    public async Task TaxonomyFieldTagsEditorSettings_Default_Deserialize()
     {
         var settings = new TaxonomyFieldTagsEditorSettings
         {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
@@ -23,7 +23,7 @@ public class ApiControllerTests
     private delegate void TryGetSettingsCallback(string name, out ShellSettings settings);
 
     [Fact]
-    public async Task CallCreateApiMultipleTimes_ShouldCreateTenant_ReturnsSetupToken()
+    public async Task CallCreateApiMultipleTimes_ReturnsSetupToken_CreatesTenant()
     {
         // Arrange
         var controller = CreateController();
@@ -64,7 +64,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task ShouldGetNewTenantSetupToken_WhenThePreviousTokenExpired()
+    public async Task GetNewTenantSetupToken_ThePreviousTokenExpired_Succeeds()
     {
         // Arrange
         var controller = CreateController();
@@ -108,7 +108,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task CreateShouldRejectMissingTablePrefix_WhenRequired()
+    public async Task Create_Required_RejectssMissingTablePrefix()
     {
         // Arrange
         var controller = CreateController(requireTablePrefix: true);
@@ -134,7 +134,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task CreateShouldRejectMissingTablePrefix_WhenRequiredAndDatabaseProviderIsPreset()
+    public async Task Create_RequiredAndDatabaseProviderIsPreset_RejectssMissingTablePrefix()
     {
         // Arrange
         var controller = CreateController(
@@ -162,7 +162,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task CreateShouldUsePresetDatabaseConfiguration_WhenConfigured()
+    public async Task Create_Configured_UsesPresetDatabaseConfiguration()
     {
         // Arrange
         const string presetConnectionString = "Server=localhost;Database=Orchard;";
@@ -197,7 +197,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task CreateShouldUsePresetDatabaseProviderAndPostedConnectionString_WhenOnlyProviderIsConfigured()
+    public async Task Create_LyProviderIsConfigured_UsesPresetDatabaseProviderAndPostedConnectionString()
     {
         // Arrange
         var controller = CreateController(
@@ -226,7 +226,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task EditShouldUsePresetDatabaseConfiguration_WhenConfigured()
+    public async Task Edit_Configured_UsesPresetDatabaseConfiguration()
     {
         // Arrange
         const string presetConnectionString = "Server=localhost;Database=Orchard;";
@@ -262,7 +262,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task CreateShouldReturnGenericError_WhenSavingTenantFails()
+    public async Task Create_SavingTenantFails_ReturnsGenericError()
     {
         // Arrange
         var controller = CreateController(throwOnUpdate: true);
@@ -287,7 +287,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task CreateShouldUseConfiguredTablePrefixPattern_WhenConfigured()
+    public async Task Create_Configured_UsesConfiguredTablePrefixPattern()
     {
         // Arrange
         var controller = CreateController(tablePrefixPattern: "{{ ShellSettings.Name }}", schemaPattern: "dbo");
@@ -314,7 +314,7 @@ public class ApiControllerTests
     }
 
     [Fact]
-    public async Task CreateShouldRejectInvalidConfiguredTablePrefixPattern()
+    public async Task Create_Default_RejectsInvalidConfiguredTablePrefixPattern()
     {
         // Arrange
         var controller = CreateController(tablePrefixPattern: "tenant-{{ ShellSettings.Name }}");

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ProfilesTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ProfilesTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Modules.OrchardCore.Tenants.Tests;
 public class ProfilesTests
 {
     [Fact]
-    public void FeatureProfilesSchemaService_ShouldCreateValidSchema()
+    public void FeatureProfilesSchemaService_Default_CreatesValidSchema()
     {
         var featureProfilesRuleOptions = new FeatureProfilesRuleOptions();
         featureProfilesRuleOptions.Rules["Exclude"] = static (expression, name) => (true, true);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -29,7 +29,7 @@ public class TenantValidatorTests : SiteContext
     [InlineData("Tenant9", "tenant9", "", "Feature Profile", new string[] { })]
     [InlineData("Tenant9", "", "example6.com", "Feature Profile", new string[] { })]
     [InlineData("Tenant9", "tenant9", "example6.com", "Feature Profile", new string[] { })]
-    public async Task TenantValidationFailsIfInvalidConfigurationsWasProvided(string name, string urlPrefix, string hostName, string featureProfile, string[] errorMessages)
+    public async Task TenantValidationFailsIfInvalidConfigurationsWasProvided_Default_Succeeds(string name, string urlPrefix, string hostName, string featureProfile, string[] errorMessages)
     {
         // Arrange
         await ShellHost.InitializeAsync();
@@ -61,7 +61,7 @@ public class TenantValidatorTests : SiteContext
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public async Task DuplicateTenantHostOrPrefixShouldFailValidation(bool isNewTenant)
+    public async Task DuplicateTenantHostOrPrefix_Default_FailssValidation(bool isNewTenant)
     {
         // Arrange
         await ShellHost.InitializeAsync();
@@ -96,7 +96,7 @@ public class TenantValidatorTests : SiteContext
     }
 
     [Fact]
-    public async Task RequireTablePrefixShouldFailValidation_WhenProviderSupportsPrefixes()
+    public async Task RequireTablePrefix_ProviderSupportsPrefixes_FailssValidation()
     {
         // Arrange
         await ShellHost.InitializeAsync();
@@ -122,7 +122,7 @@ public class TenantValidatorTests : SiteContext
     }
 
     [Fact]
-    public async Task RequireTablePrefixShouldNotFailValidation_WhenProviderDoesNotSupportPrefixes()
+    public async Task RequireTablePrefix_ProviderDoesNotSupportPrefixes_NotFailValidation()
     {
         // Arrange
         await ShellHost.InitializeAsync();
@@ -146,7 +146,7 @@ public class TenantValidatorTests : SiteContext
     }
 
     [Fact]
-    public async Task TablePrefixPatternShouldPopulatePrefix_WhenConfigured()
+    public async Task TablePrefixPattern_Configured_PopulatessPrefix()
     {
         // Arrange
         await ShellHost.InitializeAsync();
@@ -170,7 +170,7 @@ public class TenantValidatorTests : SiteContext
     }
 
     [Fact]
-    public async Task InvalidConfiguredTablePrefixPatternShouldFailValidation()
+    public async Task InvalidConfiguredTablePrefixPattern_Default_FailssValidation()
     {
         // Arrange
         await ShellHost.InitializeAsync();
@@ -195,7 +195,7 @@ public class TenantValidatorTests : SiteContext
     }
 
     [Fact]
-    public async Task InvalidSchemaShouldFailValidation()
+    public async Task InvalidSchema_Default_FailssValidation()
     {
         // Arrange
         await ShellHost.InitializeAsync();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Twitter/TwitterClientTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Twitter/TwitterClientTests.cs
@@ -50,7 +50,7 @@ public class TwitterClientTests
     /// Uses data from twitter's example to test the correct OAuth signature generation
     /// https://developer.twitter.com/en/docs/basics/authentication/guides/creating-a-signature.html
     /// </summary>
-    public async Task HttpRequestMessageShouldHaveCorrectSignedOAuthHeader()
+    public async Task HttpRequestMessage_Default_HaveCorrectSignedOAuthHeader()
     {
         HttpRequestMessage message = null;
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/AccountControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/AccountControllerTests.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Users;
 public class AccountControllerTests
 {
     [Fact]
-    public async Task ExternalLoginSignIn_Test()
+    public async Task ExternalLoginSignIn_Default_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings(), true, true, true);
@@ -162,7 +162,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenAllowed_RegisterUser()
+    public async Task Register_AllowedRegisterUser_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings());
@@ -198,7 +198,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenNotAllowed_ReturnNotFound()
+    public async Task Register_NotAllowedReturnNotFound_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings(), false);
@@ -211,7 +211,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenFeatureIsNotEnable_ReturnNotFound()
+    public async Task Register_FeatureIsNotEnableReturnNotFound_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings(), enableRegistrationFeature: false);
@@ -224,7 +224,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenRequireUniqueEmailIsTrue_PreventRegisteringMultipleUsersWithTheSameEmails()
+    public async Task Register_RequireUniqueEmailIsTruePreventRegisteringMultipleUsersWithTheSameEmails_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings());
@@ -268,7 +268,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenRequireUniqueEmailIsFalse_AllowRegisteringMultipleUsersWithTheSameEmails()
+    public async Task Register_RequireUniqueEmailIsFalseAllowRegisteringMultipleUsersWithTheSameEmails_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings(), enableRegistrationFeature: true, requireUniqueEmail: false);
@@ -314,7 +314,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenModeration_RedirectToRegistrationPending()
+    public async Task Register_ModerationRedirectToRegistrationPending_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings()
@@ -354,7 +354,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenRequireEmailConfirmation_RedirectToConfirmEmailSent()
+    public async Task Register_RequireEmailConfirmationRedirectToConfirmEmailSent_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings
@@ -396,7 +396,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Login_WhenUserIsDisabled_RedirectsToLoginWithError()
+    public async Task Login_UserIsDisabledRedirectsToLoginWithError_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings());
@@ -440,7 +440,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Login_WhenUserIsEnabled_Succeeds()
+    public async Task Login_UserIsEnabledSucceeds_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings());
@@ -474,7 +474,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Register_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task Register_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings(), enableRateLimits: true);
@@ -503,7 +503,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Login_WhenUsernameIsInvalid_ReturnsGenericError()
+    public async Task Login_UsernameIsInvalidReturnsGenericError_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings());
@@ -524,7 +524,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Login_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task Login_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings(), enableRateLimits: true);
@@ -545,7 +545,7 @@ public class AccountControllerTests
     }
 
     [Fact]
-    public async Task Login_WhenUserDisabledUnderModeration_DefersToModerationHandler()
+    public async Task Login_UserDisabledUnderModerationDefersToModerationHandler_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(new RegistrationSettings()

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/OrchardCore.Users.Core/DefaultUserClaimsPrincipalProviderFactoryTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/OrchardCore.Users.Core/DefaultUserClaimsPrincipalProviderFactoryTests.cs
@@ -9,7 +9,7 @@ public class DefaultUserClaimsPrincipalProviderFactoryTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task EnsurePrincipalHasExpectedClaims(bool emailVerified)
+    public async Task EnsurePrincipalHasExpectedClaims_Default_Succeeds(bool emailVerified)
     {
         //Arrange
         var userManager = UsersMockHelper.MockUserManager<IUser>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/ResetPasswordControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/ResetPasswordControllerTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Users;
 public class ResetPasswordControllerTests
 {
     [Fact]
-    public async Task ForgotPassword_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task ForgotPassword_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/TwoFactorAuthenticationControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/TwoFactorAuthenticationControllerTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Users;
 public class TwoFactorAuthenticationControllerTests
 {
     [Fact]
-    public async Task LoginWithTwoFactorAuthentication_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task LoginWithTwoFactorAuthentication_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync();
@@ -26,7 +26,7 @@ public class TwoFactorAuthenticationControllerTests
     }
 
     [Fact]
-    public async Task LoginWithRecoveryCode_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task LoginWithRecoveryCode_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/TwoFactorSendCodeEndpointTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/TwoFactorSendCodeEndpointTests.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Users;
 public class TwoFactorSendCodeEndpointTests
 {
     [Fact]
-    public async Task EmailSendCode_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task EmailSendCode_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(UserConstants.Features.EmailAuthenticator);
@@ -26,7 +26,7 @@ public class TwoFactorSendCodeEndpointTests
     }
 
     [Fact]
-    public async Task SmsSendCode_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    public async Task SmsSendCode_RateLimitExceededReturnsTooManyRequests_Succeeds()
     {
         // Arrange
         var context = await GetSiteContextAsync(UserConstants.Features.SmsAuthenticator);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/UserValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/UserValidatorTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Users;
 public class UserValidatorTests
 {
     [Fact]
-    public async Task CanValidateUser()
+    public async Task CanValidateUser_Default_Succeeds()
     {
         // Arrange
         var userManager = UsersMockHelper.MockUserManager<IUser>();
@@ -24,7 +24,7 @@ public class UserValidatorTests
     }
 
     [Fact]
-    public async Task ShouldRequireEmail()
+    public async Task Require_Email_Succeeds()
     {
         // Arrange
         var describer = new IdentityErrorDescriber();
@@ -44,7 +44,7 @@ public class UserValidatorTests
     }
 
     [Fact]
-    public async Task ShouldRequireValidEmail()
+    public async Task Require_ValidEmail_Succeeds()
     {
         // Arrange
         var describer = new IdentityErrorDescriber();
@@ -64,7 +64,7 @@ public class UserValidatorTests
     }
 
     [Fact]
-    public async Task ShouldRequireUniqueEmail()
+    public async Task Require_UniqueEmail_Succeeds()
     {
         // Arrange
         var describer = new IdentityErrorDescriber();
@@ -91,7 +91,7 @@ public class UserValidatorTests
     }
 
     [Fact]
-    public async Task ShouldRequireUserNameIsNotAnEmailAddress()
+    public async Task Require_UserNameIsNotAnEmailAddress_Succeeds()
     {
         // Arrange
         var describer = new IdentityErrorDescriber();
@@ -111,7 +111,7 @@ public class UserValidatorTests
     }
 
     [Fact]
-    public async Task ShouldRequireUniqueUserName()
+    public async Task Require_UniqueUserName_Succeeds()
     {
         // Arrange
         var describer = new IdentityErrorDescriber();

--- a/test/OrchardCore.Tests/Modules/PoweredByMiddlewareTests.cs
+++ b/test/OrchardCore.Tests/Modules/PoweredByMiddlewareTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Modules;
 public class PoweredByMiddlewareTests
 {
     [Fact]
-    public async Task InjectPoweredByHeader()
+    public async Task InjectPoweredByHeader_Default_Succeeds()
     {
         // Arrange
         string key = "X-Powered-By", value = "OrchardCore";
@@ -33,7 +33,7 @@ public class PoweredByMiddlewareTests
     }
 
     [Fact]
-    public async Task DoNotInjectPoweredByHeaderIfDisabled()
+    public async Task DoNotInjectPoweredByHeaderIfDisabled_Default_Succeeds()
     {
         // Arrange
         string key = "X-Powered-By", value = "OrchardCore";

--- a/test/OrchardCore.Tests/Modules/Services/TimeZoneSelectListProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/Services/TimeZoneSelectListProviderTests.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Modules.Services.Tests;
 public class TimeZoneSelectListProviderTests
 {
     [Fact]
-    public async Task GetTimeZoneSelectList_MapsAndSortsTimeZones()
+    public async Task GetTimeZoneSelectList_MapsAndSortsTimeZones_Succeeds()
     {
         // Arrange
         var clock = new Mock<IClock>();

--- a/test/OrchardCore.Tests/Orchard.Queries/SqlLiquidOutputExpressionDetectorTests.cs
+++ b/test/OrchardCore.Tests/Orchard.Queries/SqlLiquidOutputExpressionDetectorTests.cs
@@ -9,7 +9,7 @@ public class SqlLiquidOutputExpressionDetectorTests
     [InlineData("select * from ContentItemIndex where ContentType = '{{ Request.Query.type }}'", true)]
     [InlineData("{% assign type = Request.Query.type %}select * from ContentItemIndex where ContentType = @type", false)]
     [InlineData("{% if Request.Query.type %}select * from ContentItemIndex where ContentType = @type{% endif %}", false)]
-    public void ShouldDetectLiquidOutputStatements(string query, bool expectedResult)
+    public void Detect_LiquidOutputStatements_Succeeds(string query, bool expectedResult)
     {
         var detector = new SqlLiquidOutputExpressionDetector(new FluidParser());
         var result = detector.ContainsOutputStatement(query);

--- a/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
@@ -25,7 +25,7 @@ public class SqlParserTests
     [InlineData("select Avg(a)", "SELECT Avg([a]);")]
     [InlineData("select Min(*)", "SELECT Min(*);")]
     [InlineData("select distinct a", "SELECT DISTINCT [a];")]
-    public void ShouldParseSelectClause(string sql, string expectedSql)
+    public void Parse_SelectClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -38,7 +38,7 @@ public class SqlParserTests
     [InlineData("select 1.0", "SELECT 1.0;")]
     [InlineData("select 1.11", "SELECT 1.11;")]
     [InlineData("select 1, 'a', true", "SELECT 1, N'a', [true];")]
-    public void ShouldParseColumnValues(string sql, string expectedSql)
+    public void Parse_ColumnValues_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -50,7 +50,7 @@ public class SqlParserTests
     [InlineData("SELECT a FROM t", "SELECT [a] FROM [tp_t];")]
     [InlineData("SELECT a FROM t as t1", "SELECT [a] FROM [tp_t] AS t1;")]
     [InlineData("SELECT a FROM t1, t2", "SELECT [a] FROM [tp_t1], [tp_t2];")]
-    public void ShouldParseFromClause(string sql, string expectedSql)
+    public void Parse_FromClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -62,7 +62,7 @@ public class SqlParserTests
     [InlineData("select a where b.b1", "SELECT [a] WHERE [tp_b].[b1];")]
     [InlineData("select a where b = c", "SELECT [a] WHERE [b] = [c];")]
     [InlineData("select a where b = c and d", "SELECT [a] WHERE [b] = [c] AND [d];")]
-    public void ShouldParseWhereClause(string sql, string expectedSql)
+    public void Parse_WhereClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -91,7 +91,7 @@ public class SqlParserTests
     [InlineData("select a where b not in (1,2,3)", "SELECT [a] WHERE [b] NOT IN (1, 2, 3);")]
     [InlineData("select a where b not in (select b)", "SELECT [a] WHERE [b] NOT IN (SELECT [b]);")]
     [InlineData("select a where b = (select Avg(c) from d)", "SELECT [a] WHERE [b] = (SELECT Avg([c]) FROM [tp_d]);")]
-    public void ShouldParseExpression(string sql, string expectedSql)
+    public void Parse_Expression_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -102,7 +102,7 @@ public class SqlParserTests
     [InlineData("select a where a = @b", "SELECT [a] WHERE [a] = @b;")]
     [InlineData("select a where a = @b limit @limit", "SELECT TOP (@limit) [a] WHERE [a] = @b;")]
     [InlineData("select a where a = @b limit @limit:10", "SELECT TOP (@limit) [a] WHERE [a] = @b;")]
-    public void ShouldParseParameters(string sql, string expectedSql)
+    public void Parse_Parameters_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -110,7 +110,7 @@ public class SqlParserTests
     }
 
     [Fact]
-    public void ShouldDefineDefaultParametersValue()
+    public void Define_DefaultParametersValue_Succeeds()
     {
         var parameters = new Dictionary<string, object>();
         var result = SqlParser.TryParse("select a where a = @b:10", _schema, _defaultDialect, _defaultTablePrefix, parameters, out _, out _);
@@ -127,7 +127,7 @@ public class SqlParserTests
     [InlineData("select a from b inner join c on b.b1 = c.c1 and b.b2 = @param", "SELECT [a] FROM [tp_b] INNER JOIN [tp_c] ON [tp_b].[b1] = [tp_c].[c1] AND [tp_b].[b2] = @param;")]
     [InlineData("select a from b inner join c on 1 = 1 and @param = 'foo'", "SELECT [a] FROM [tp_b] INNER JOIN [tp_c] ON 1 = 1 AND @param = N'foo';")]
     [InlineData("select a from b inner join c on 1 = @param left join d on d.a = @param left join e on e.a = 'foo'", "SELECT [a] FROM [tp_b] INNER JOIN [tp_c] ON 1 = @param LEFT JOIN [tp_d] ON [tp_d].[a] = @param LEFT JOIN [tp_e] ON [tp_e].[a] = N'foo';")]
-    public void ShouldParseJoinClause(string sql, string expectedSql)
+    public void Parse_JoinClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -141,7 +141,7 @@ public class SqlParserTests
     [InlineData("select a from b as b1 order by b1.c", "SELECT [a] FROM [tp_b] AS b1 ORDER BY b1.[c];")]
     [InlineData("select a order by b asc", "SELECT [a] ORDER BY [b] ASC;")]
     [InlineData("select a order by b desc", "SELECT [a] ORDER BY [b] DESC;")]
-    public void ShouldParseOrderByClause(string sql, string expectedSql)
+    public void Parse_OrderByClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -152,7 +152,7 @@ public class SqlParserTests
     [InlineData("select a limit 100", "SELECT TOP (100) [a];")]
     [InlineData("select a limit 100 offset 10", "SELECT [a] OFFSET 10 ROWS FETCH NEXT 100 ROWS ONLY;")]
     [InlineData("select a offset 10", "SELECT [a] OFFSET 10 ROWS;")]
-    public void ShouldParseLimitOffsetClause(string sql, string expectedSql)
+    public void Parse_LimitOffsetClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -165,7 +165,7 @@ public class SqlParserTests
     [InlineData("select count(a) group by b.c", "SELECT count([a]) GROUP BY [tp_b].[c];")]
     [InlineData("select count(a) from b as b1 group by b1.c", "SELECT count([a]) FROM [tp_b] AS b1 GROUP BY b1.[c];")]
     [InlineData("select Month(a) as m group by Month(a)", "SELECT Month([a]) AS m GROUP BY Month([a]);")]
-    public void ShouldParseGroupByClause(string sql, string expectedSql)
+    public void Parse_GroupByClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -174,7 +174,7 @@ public class SqlParserTests
 
     [Theory]
     [InlineData("SELECT COUNT(CustomerID) GROUP BY Country HAVING COUNT(CustomerID) > 5", "SELECT COUNT([CustomerID]) GROUP BY [Country] HAVING COUNT([CustomerID]) > 5;")]
-    public void ShouldParseHavingClause(string sql, string expectedSql)
+    public void Parse_HavingClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -188,7 +188,7 @@ public class SqlParserTests
     [InlineData("-- this is a comment\n SELECT a; -- this is another comment\n SELECT b;", "SELECT [a]; SELECT [b];")]
     [InlineData("SELECT /* comment */ a;", "SELECT [a];")]
     [InlineData("/* comment \n comment */SELECT /* comment \n comment */ a /* comment \n comment */;/* comment \n comment */", "SELECT [a];")]
-    public void ShouldParseComments(string sql, string expectedSql)
+    public void Parse_Comments_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -204,7 +204,7 @@ public class SqlParserTests
     [InlineData("select COUNT(1) over (order by a asc, b desc, c desc) from d", "SELECT COUNT(1) OVER (ORDER BY [a] ASC, [b] DESC, [c] DESC) FROM [tp_d];")]
     [InlineData("select COUNT(1) over (partition by a order by b) from c", "SELECT COUNT(1) OVER (PARTITION BY [a] ORDER BY [b]) FROM [tp_c];")]
     [InlineData("select COUNT(1) over () a, MAX(b) over () c from d", "SELECT COUNT(1) OVER () AS a, MAX([b]) OVER () AS c FROM [tp_d];")]
-    public void ShouldParseWindowFunction(string sql, string expectedSql)
+    public void Parse_WindowFunction_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -215,7 +215,7 @@ public class SqlParserTests
     [InlineData("select a from b union select c from d", "SELECT [a] FROM [tp_b] UNION SELECT [c] FROM [tp_d];")]
     [InlineData("select a from b union all select c from d", "SELECT [a] FROM [tp_b] UNION ALL SELECT [c] FROM [tp_d];")]
     [InlineData("select a from b union all select c from d union select e from f", "SELECT [a] FROM [tp_b] UNION ALL SELECT [c] FROM [tp_d] UNION SELECT [e] FROM [tp_f];")]
-    public void ShouldParseUnionClause(string sql, string expectedSql)
+    public void Parse_UnionClause_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -230,7 +230,7 @@ public class SqlParserTests
     [InlineData("with test(test) as (select a as test from t) select test from test", "WITH test(test) AS (SELECT [a] AS test FROM [tp_t]) SELECT [test] FROM [test];")]
     [InlineData("with cte as (select t.a from SomeTable t where t.b = 1) select * from cte", "WITH cte AS (SELECT t.[a] FROM [tp_SomeTable] AS t WHERE t.[b] = 1) SELECT * FROM [cte];")]
     [InlineData("with cte as (select ci.DocumentId, ROW_NUMBER() over (order by ci.CreatedUtc desc) as RowNum from ContentItemIndex ci where ci.ContentType = 'BlogPost') select DocumentId from cte where RowNum <= 6", "WITH cte AS (SELECT ci.[DocumentId], ROW_NUMBER() OVER (ORDER BY ci.[CreatedUtc] DESC) AS RowNum FROM [tp_ContentItemIndex] AS ci WHERE ci.[ContentType] = N'BlogPost') SELECT [DocumentId] FROM [cte] WHERE [RowNum] <= 6;")]
-    public void ShouldParseCte(string sql, string expectedSql)
+    public void Parse_Cte_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -245,7 +245,7 @@ public class SqlParserTests
     [InlineData("select b.a from (select a from t where [a] = 1 union all select a from t where [a] = 2) as b", "SELECT b.[a] FROM (SELECT [a] FROM [tp_t] WHERE [a] = 1 UNION ALL SELECT [a] FROM [tp_t] WHERE [a] = 2) AS b;")]
     [InlineData("select d.b, g.b from (select a as b from c) as d, (select e as b from f) as g", "SELECT d.[b], g.[b] FROM (SELECT [a] AS b FROM [tp_c]) AS d, (SELECT [e] AS b FROM [tp_f]) AS g;")]
     [InlineData("select * from (select d as e from (select c as d from (select b as c from (select a as b from t) as l4) as l3) as l2) as l1", "SELECT * FROM (SELECT [d] AS e FROM (SELECT [c] AS d FROM (SELECT [b] AS c FROM (SELECT [a] AS b FROM [tp_t]) AS l4) AS l3) AS l2) AS l1;")]
-    public void ShouldParseSubquery(string sql, string expectedSql)
+    public void Parse_Subquery_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
         Assert.True(result);
@@ -257,7 +257,7 @@ public class SqlParserTests
     [InlineData("select a order by random()", "SELECT [a] ORDER BY newid();")]
     [InlineData("select a order by RANDOM", "SELECT [a] ORDER BY [RANDOM];")]
     [InlineData("select a order by random", "SELECT [a] ORDER BY [random];")]
-    public void ShouldOrderByRandom(string sql, string expectedSql)
+    public void Order_ByRandom_Succeeds(string sql, string expectedSql)
     {
         // Arrange & Act
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out _);
@@ -270,7 +270,7 @@ public class SqlParserTests
     [Theory]
     [InlineData("select a order by b limit 10", "SELECT TOP (10) [a] ORDER BY [b];")]
     [InlineData("select a from b order by c desc limit 5", "SELECT TOP (5) [a] FROM [tp_b] ORDER BY [c] DESC;")]
-    public void ShouldParseOrderByWithLimit(string sql, string expectedSql)
+    public void Parse_OrderByWithLimit_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
 
@@ -283,7 +283,7 @@ public class SqlParserTests
     [InlineData("select a where b='foo' order by c limit 5", "SELECT TOP (5) [a] WHERE [b] = N'foo' ORDER BY [c];")]
     [InlineData("SELECT DocumentId FROM ContentItemIndex WHERE ContentType='BlogPost' ORDER BY CreatedUtc DESC", "SELECT [DocumentId] FROM [tp_ContentItemIndex] WHERE [ContentType] = N'BlogPost' ORDER BY [CreatedUtc] DESC;")]
     [InlineData("SELECT DocumentId FROM ContentItemIndex WHERE ContentType='BlogPost' ORDER BY CreatedUtc DESC LIMIT 3", "SELECT TOP (3) [DocumentId] FROM [tp_ContentItemIndex] WHERE [ContentType] = N'BlogPost' ORDER BY [CreatedUtc] DESC;")]
-    public void ShouldParseWhereWithOrderBy(string sql, string expectedSql)
+    public void Parse_WhereWithOrderBy_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
 
@@ -299,7 +299,7 @@ public class SqlParserTests
     [InlineData("SELECT * FROM ContentItemIndex WHERE CreatedUtc > now()", "SELECT * FROM [tp_ContentItemIndex] WHERE [CreatedUtc] > getUtcDate();")]
     [InlineData("select now() as CurrentTime", "SELECT getUtcDate() AS CurrentTime;")]
     [InlineData("select count(*), now()", "SELECT count(*), getUtcDate();")]
-    public void ShouldParseParameterlessFunctions(string sql, string expectedSql)
+    public void Parse_ParameterlessFunctions_Succeeds(string sql, string expectedSql)
     {
         var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
 

--- a/test/OrchardCore.Tests/OrchardCore.Environment.Cache/CacheScopeManagerTests.cs
+++ b/test/OrchardCore.Tests/OrchardCore.Environment.Cache/CacheScopeManagerTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Environment.Cache;
 public class CacheScopeManagerTests
 {
     [Fact]
-    public void ScopesCanBeEnteredAndExited()
+    public void ScopesCanBeEnteredAndExited_Default_Succeeds()
     {
         var scopeA = new CacheContext("a");
         var scopeB = new CacheContext("b");
@@ -30,7 +30,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ContextsAreBubbledUp1()
+    public void ContextsAreBubbledUp1_Default_Succeeds()
     {
         var scopeA = new CacheContext("a");
         var scopeB = new CacheContext("b").AddContext("1", "2");
@@ -51,7 +51,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ContextsAreBubbledUp2()
+    public void ContextsAreBubbledUp2_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").AddContext("1", "2");
         var scopeB = new CacheContext("b");
@@ -71,7 +71,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ContextsAreBubbledUp3()
+    public void ContextsAreBubbledUp3_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").AddContext("3", "4");
         var scopeB = new CacheContext("b").AddContext("1", "2");
@@ -94,7 +94,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void TagsAreBubbledUp1()
+    public void TagsAreBubbledUp1_Default_Succeeds()
     {
         var scopeA = new CacheContext("a");
         var scopeB = new CacheContext("b").AddTag("1", "2");
@@ -115,7 +115,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void TagsAreBubbledUp2()
+    public void TagsAreBubbledUp2_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").AddTag("1", "2");
         var scopeB = new CacheContext("b");
@@ -135,7 +135,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void TagsAreBubbledUp3()
+    public void TagsAreBubbledUp3_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").AddTag("3", "4");
         var scopeB = new CacheContext("b").AddTag("1", "2");
@@ -158,7 +158,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpiryOnIsBubbledUp1()
+    public void ExpiryOnIsBubbledUp1_Default_Succeeds()
     {
         var scopeA = new CacheContext("a");
         var scopeB = new CacheContext("b").WithExpiryOn(new DateTime(2018, 10, 26));
@@ -176,7 +176,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpiryOnIsBubbledUp2()
+    public void ExpiryOnIsBubbledUp2_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").WithExpiryOn(new DateTime(2018, 10, 26));
         var scopeB = new CacheContext("b");
@@ -194,7 +194,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpiryOnIsBubbledUp3()
+    public void ExpiryOnIsBubbledUp3_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").WithExpiryOn(new DateTime(2020, 10, 26));
         var scopeB = new CacheContext("b").WithExpiryOn(new DateTime(2018, 10, 26));
@@ -212,7 +212,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpiryAfterIsBubbledUp1()
+    public void ExpiryAfterIsBubbledUp1_Default_Succeeds()
     {
         var scopeA = new CacheContext("a");
         var scopeB = new CacheContext("b").WithExpiryAfter(new TimeSpan(3, 30, 26));
@@ -230,7 +230,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpiryAfterIsBubbledUp2()
+    public void ExpiryAfterIsBubbledUp2_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").WithExpiryAfter(new TimeSpan(3, 30, 26));
         var scopeB = new CacheContext("b");
@@ -248,7 +248,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpiryAfterIsBubbledUp3()
+    public void ExpiryAfterIsBubbledUp3_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").WithExpiryAfter(new TimeSpan(5, 30, 26));
         var scopeB = new CacheContext("b").WithExpiryAfter(new TimeSpan(3, 30, 26));
@@ -266,7 +266,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpirySlidingIsBubbledUp1()
+    public void ExpirySlidingIsBubbledUp1_Default_Succeeds()
     {
         var scopeA = new CacheContext("a");
         var scopeB = new CacheContext("b").WithExpirySliding(new TimeSpan(3, 30, 26));
@@ -284,7 +284,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpirySlidingIsBubbledUp2()
+    public void ExpirySlidingIsBubbledUp2_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").WithExpirySliding(new TimeSpan(3, 30, 26));
         var scopeB = new CacheContext("b");
@@ -302,7 +302,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ExpirySlidingIsBubbledUp3()
+    public void ExpirySlidingIsBubbledUp3_Default_Succeeds()
     {
         var scopeA = new CacheContext("a").WithExpirySliding(new TimeSpan(5, 30, 26));
         var scopeB = new CacheContext("b").WithExpirySliding(new TimeSpan(3, 30, 26));
@@ -320,7 +320,7 @@ public class CacheScopeManagerTests
     }
 
     [Fact]
-    public void ComplexNesting()
+    public void ComplexNesting_Default_Succeeds()
     {
         var scopeA = new CacheContext("a")
             .AddContext("c1")

--- a/test/OrchardCore.Tests/Recipes/RecipeExecutorTests.cs
+++ b/test/OrchardCore.Tests/Recipes/RecipeExecutorTests.cs
@@ -20,7 +20,7 @@ public class RecipeExecutorTests
     [InlineData("recipe3", "js: valiables('now')")]
     [InlineData("recipe4", "[locale en]This text contains a colon ':' symbol[/locale][locale fr]Ce texte contient un deux-points ':'[/locale]")]
     [InlineData("recipe5", "[sc text='some : text'/]")]
-    public async Task ShouldTrimValidScriptExpression(string recipeName, string expected)
+    public async Task Trim_ValidScriptExpression_Succeeds(string recipeName, string expected)
     {
         await (await CreateShellContext().CreateScopeAsync()).UsingAsync(async scope =>
         {
@@ -57,7 +57,7 @@ public class RecipeExecutorTests
     }
 
     [Fact]
-    public async Task ContentDefinitionStep_WhenPartNameIsMissing_RecipeExecutionException()
+    public async Task ContentDefinitionStep_PartNameIsMissingRecipeExecutionException_Succeeds()
     {
         using var context = new BlogContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/ResourceManagement/ResourceDefinitionTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/ResourceDefinitionTests.cs
@@ -18,7 +18,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetScriptResourceWithUrl(string applicationPath)
+    public void GetScriptResourceWithUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineScript("foo")
             .SetUrl("~/foo.js", "~/foo.debug.js")
@@ -33,7 +33,7 @@ public class ResourceDefinitionTests
 
     [Theory]
     [InlineData("/base")]
-    public void GetScriptResourceWithBasePath(string basePath)
+    public void GetScriptResourceWithBasePath_Default_Succeeds(string basePath)
     {
         var resourceDefinition = _resourceManifest.DefineScript("foo")
             .SetUrl("~/foo.js", "~/foo.debug.js")
@@ -50,7 +50,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetScriptResourceWithDebugUrl(string applicationPath)
+    public void GetScriptResourceWithDebugUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineScript("foo")
             .SetUrl("~/foo.js", "~/foo.debug.js")
@@ -67,7 +67,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetScriptResourceWithCdnUrl(string applicationPath)
+    public void GetScriptResourceWithCdnUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineScript("foo")
             .SetUrl("~/foo.js", "~/foo.debug.js")
@@ -84,7 +84,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetScriptResourceWithDebugCdnUrl(string applicationPath)
+    public void GetScriptResourceWithDebugCdnUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineScript("foo")
             .SetUrl("~/foo.js", "~/foo.debug.js")
@@ -106,7 +106,7 @@ public class ResourceDefinitionTests
     [InlineData("/tenant", "http://external.com/foo.js", "http://external.com/foo.js")]
     [InlineData("", "https://external.com/foo.js", "https://external.com/foo.js")]
     [InlineData("/tenant", "https://external.com/foo.js", "https://external.com/foo.js")]
-    public void GetLocalScriptResourceWithCdnBaseUrl(string applicationPath, string url, string expected)
+    public void GetLocalScriptResourceWithCdnBaseUrl_Default_Succeeds(string applicationPath, string url, string expected)
     {
         var resourceDefinition = _resourceManifest.DefineScript("foo")
             .SetUrl(url, url);
@@ -122,7 +122,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetScriptResourceWithInlineContent(string applicationPath)
+    public void GetScriptResourceWithInlineContent_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineScript("foo")
             .SetInnerContent("console.log('foo');");
@@ -139,7 +139,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetStyleResourceWithUrl(string applicationPath)
+    public void GetStyleResourceWithUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineStyle("foo")
             .SetUrl("~/foo.css", "~/foo.debug.css")
@@ -158,7 +158,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetStyleResourceWithDebugUrl(string applicationPath)
+    public void GetStyleResourceWithDebugUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineStyle("foo")
             .SetUrl("~/foo.css", "~/foo.debug.css")
@@ -177,7 +177,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetStyleResourceWithCdnUrl(string applicationPath)
+    public void GetStyleResourceWithCdnUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineStyle("foo")
             .SetUrl("~/foo.css", "~/foo.debug.css")
@@ -201,7 +201,7 @@ public class ResourceDefinitionTests
     [InlineData("/tenant", "http://external.com/foo.css", "http://external.com/foo.css")]
     [InlineData("", "https://external.com/foo.css", "https://external.com/foo.css")]
     [InlineData("/tenant", "https://external.com/foo.css", "https://external.com/foo.css")]
-    public void GetLocalStyleResourceWithCdnBaseUrl(string applicationPath, string url, string expected)
+    public void GetLocalStyleResourceWithCdnBaseUrl_Default_Succeeds(string applicationPath, string url, string expected)
     {
         var resourceDefinition = _resourceManifest.DefineStyle("foo")
             .SetUrl(url, url);
@@ -219,7 +219,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetStyleResourceWithDebugCdnUrl(string applicationPath)
+    public void GetStyleResourceWithDebugCdnUrl_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineStyle("foo")
             .SetUrl("~/foo.css", "~/foo.debug.css")
@@ -238,7 +238,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetStyleResourceWithAttributes(string applicationPath)
+    public void GetStyleResourceWithAttributes_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineStyle("foo")
             .SetUrl("~/foo.css", "~/foo.debug.css")
@@ -259,7 +259,7 @@ public class ResourceDefinitionTests
     [InlineData("")]
     [InlineData("/tenant")]
     [InlineData("/virtualpath/tenant")]
-    public void GetStyleResourceWithInlineContent(string applicationPath)
+    public void GetStyleResourceWithInlineContent_Default_Succeeds(string applicationPath)
     {
         var resourceDefinition = _resourceManifest.DefineStyle("foo")
             .SetInnerContent("body { background-color: white; }");

--- a/test/OrchardCore.Tests/ResourceManagement/ResourceManagerTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/ResourceManagerTests.cs
@@ -19,7 +19,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void FindResourceFromManifestProviders()
+    public void FindResourceFromManifestProviders_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -45,7 +45,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void FindHighestVersionedResourceFromManifest()
+    public void FindHighestVersionedResourceFromManifest_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -77,7 +77,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisterResourceUrl()
+    public void RegisterResourceUrl_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -94,7 +94,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisteredResouceUrlIsRequired()
+    public void RegisteredResouceUrlIsRequired_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -113,7 +113,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisteredResouceNameIsRequired()
+    public void RegisteredResouceNameIsRequired_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -139,7 +139,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RequireDependencies()
+    public void RequireDependencies_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -202,7 +202,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RequireCircularDependenciesShouldThrowException()
+    public void RequireCircularDependencies_Default_ThrowsException()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -226,7 +226,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RequireCircularNestedDependencyShouldThrowException()
+    public void RequireCircularNestedDependency_Default_ThrowsException()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -253,7 +253,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RequireByDependencyResourceThatDependsOnLastPositionedResourceShouldRegisterResourceLast()
+    public void RequireByDependencyResourceThatDependsOnLastPositionedResource_Default_RegisterResourceLast()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -287,7 +287,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RequireFirstPositionedResourceThatDependsOnByDependencyResourceShouldRegisterDependencyFirst()
+    public void RequireFirstPositionedResourceThatDependsOnByDependencyResource_Default_RegisterDependencyFirst()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -321,7 +321,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RequireFirstPositionedResourceWithDependencyToResourcePositionedLastShouldThrowException()
+    public void RequireFirstPositionedResourceWithDependencyToResourcePositionedLast_Default_ThrowsException()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -349,7 +349,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RemoveRequiredResource()
+    public void RemoveRequiredResource_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -380,7 +380,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RemoveRequiredResourceDependency()
+    public void RemoveRequiredResourceDependency_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -414,7 +414,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisterHeadScript()
+    public void RegisterHeadScript_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -430,7 +430,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisterFootScript()
+    public void RegisterFootScript_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -446,7 +446,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisterStyle()
+    public void RegisterStyle_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -462,7 +462,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisterLink()
+    public void RegisterLink_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -483,7 +483,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public void RegisterMeta()
+    public void RegisterMeta_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -500,7 +500,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task AppendMeta()
+    public async Task AppendMeta_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -528,7 +528,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderMeta()
+    public async Task RenderMeta_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -555,7 +555,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderHeadLink()
+    public async Task RenderHeadLink_Default_Succeeds()
     {
         var resourceManager = new ResourceManager(
             new OptionsWrapper<ResourceManagementOptions>(new ResourceManagementOptions()),
@@ -581,7 +581,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderStylesheet()
+    public async Task RenderStylesheet_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -638,7 +638,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderHeadScript()
+    public async Task RenderHeadScript_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -690,7 +690,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderFootScript()
+    public async Task RenderFootScript_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -742,7 +742,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderHeadAndFootScriptWithSameDependency()
+    public async Task RenderHeadAndFootScriptWithSameDependency_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -810,7 +810,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderLocalScript()
+    public async Task RenderLocalScript_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();
@@ -850,7 +850,7 @@ public class ResourceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task RenderLocalStyle()
+    public async Task RenderLocalStyle_Default_Succeeds()
     {
         var options = new ResourceManagementOptions();
         var manifest = new ResourceManifest();

--- a/test/OrchardCore.Tests/ResourceManagement/ScriptTagHelperTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/ScriptTagHelperTests.cs
@@ -20,7 +20,7 @@ public class ScriptTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousScriptWithSrcOnly_RegistersUrlWithDebugSrc()
+    public async Task AnonymousScriptWithSrcOnly_RegistersUrlWithDebugSrc_Succeeds()
     {
         // Arrange
         var resourceManager = CreateResourceManager();
@@ -48,7 +48,7 @@ public class ScriptTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousScriptWithSrcAndDependsOn_DefinesInInlineManifest()
+    public async Task AnonymousScriptWithSrcAndDependsOn_DefinesInInlineManifest_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -217,7 +217,7 @@ public class ScriptTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedScriptWithNameAndSrc_DefinesInInlineManifest()
+    public async Task NamedScriptWithNameAndSrc_DefinesInInlineManifest_Succeeds()
     {
         // Arrange
         var resourceManager = CreateResourceManager();
@@ -280,7 +280,7 @@ public class ScriptTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedScriptRequireOnly_RegistersResource()
+    public async Task NamedScriptRequireOnly_RegistersResource_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -312,7 +312,7 @@ public class ScriptTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedScriptRequireOnly_WithDependsOn_AddsDependencies()
+    public async Task NamedScriptRequireOnly_DependsOn_AddsDependencies()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -347,7 +347,7 @@ public class ScriptTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task DuplicateAnonymousScriptsWithDependencies_DeduplicateByName()
+    public async Task DuplicateAnonymousScriptsWithDependencies_DeduplicateByName_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();

--- a/test/OrchardCore.Tests/ResourceManagement/ScriptTagTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/ScriptTagTests.cs
@@ -22,7 +22,7 @@ public class ScriptTagTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousScriptWithSrcOnly_RegistersUrlWithDebugSrc()
+    public async Task AnonymousScriptWithSrcOnly_RegistersUrlWithDebugSrc_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -49,7 +49,7 @@ public class ScriptTagTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousScriptWithSrcAndDependsOn_DefinesInInlineManifest()
+    public async Task AnonymousScriptWithSrcAndDependsOn_DefinesInInlineManifest_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -188,7 +188,7 @@ public class ScriptTagTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedScriptRequireOnly_RegistersResource()
+    public async Task NamedScriptRequireOnly_RegistersResource_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -218,7 +218,7 @@ public class ScriptTagTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedScriptRequireOnly_WithDependsOn_AddsDependencies()
+    public async Task NamedScriptRequireOnly_DependsOn_AddsDependencies()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -253,7 +253,7 @@ public class ScriptTagTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedScriptWithNameAndSrc_DefinesInInlineManifest()
+    public async Task NamedScriptWithNameAndSrc_DefinesInInlineManifest_Succeeds()
     {
         // Arrange
         var resourceManager = CreateResourceManager();
@@ -350,7 +350,7 @@ public class ScriptTagTests : IDisposable
     }
 
     [Fact]
-    public async Task DuplicateAnonymousScriptsWithDependencies_DeduplicateByName()
+    public async Task DuplicateAnonymousScriptsWithDependencies_DeduplicateByName_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -406,7 +406,7 @@ public class ScriptTagTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousScriptWithCustomAttributes_SetsAttributes()
+    public async Task AnonymousScriptWithCustomAttributes_Default_SetsAttributes()
     {
         // Arrange
         var resourceManager = CreateResourceManager();

--- a/test/OrchardCore.Tests/ResourceManagement/StyleTagHelperTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/StyleTagHelperTests.cs
@@ -20,7 +20,7 @@ public class StyleTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousStyleWithSrcOnly_RegistersUrlWithDebugSrc()
+    public async Task AnonymousStyleWithSrcOnly_RegistersUrlWithDebugSrc_Succeeds()
     {
         // Arrange
         var resourceManager = CreateResourceManager();
@@ -48,7 +48,7 @@ public class StyleTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousStyleWithSrcAndDependsOn_DefinesInInlineManifest()
+    public async Task AnonymousStyleWithSrcAndDependsOn_DefinesInInlineManifest_Succeeds()
     {
         // Arrange — This is the primary test for the fix in PR #18909.
         var options = new ResourceManagementOptions();
@@ -164,7 +164,7 @@ public class StyleTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedStyleWithNameAndSrc_DefinesInInlineManifest()
+    public async Task NamedStyleWithNameAndSrc_DefinesInInlineManifest_Succeeds()
     {
         // Arrange
         var resourceManager = CreateResourceManager();
@@ -196,7 +196,7 @@ public class StyleTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedStyleRequireOnly_RegistersResource()
+    public async Task NamedStyleRequireOnly_RegistersResource_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -228,7 +228,7 @@ public class StyleTagHelperTests : IDisposable
     }
 
     [Fact]
-    public async Task DuplicateAnonymousStylesWithDependencies_DeduplicateByName()
+    public async Task DuplicateAnonymousStylesWithDependencies_DeduplicateByName_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();

--- a/test/OrchardCore.Tests/ResourceManagement/StyleTagTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/StyleTagTests.cs
@@ -23,7 +23,7 @@ public class StyleTagTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousStyleWithSrcOnly_RegistersUrlWithDebugSrc()
+    public async Task AnonymousStyleWithSrcOnly_RegistersUrlWithDebugSrc_Succeeds()
     {
         // Arrange
         var resourceManager = CreateResourceManager();
@@ -49,7 +49,7 @@ public class StyleTagTests : IDisposable
     }
 
     [Fact]
-    public async Task AnonymousStyleWithSrcAndDependsOn_DefinesInInlineManifest()
+    public async Task AnonymousStyleWithSrcAndDependsOn_DefinesInInlineManifest_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -182,7 +182,7 @@ public class StyleTagTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedStyleRequireOnly_RegistersResource()
+    public async Task NamedStyleRequireOnly_RegistersResource_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -212,7 +212,7 @@ public class StyleTagTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedStyleRequireOnly_WithDependsOn_AddsDependencies()
+    public async Task NamedStyleRequireOnly_DependsOn_AddsDependencies()
     {
         // Arrange
         var options = new ResourceManagementOptions();
@@ -247,7 +247,7 @@ public class StyleTagTests : IDisposable
     }
 
     [Fact]
-    public async Task NamedStyleWithNameAndSrc_DefinesInInlineManifest()
+    public async Task NamedStyleWithNameAndSrc_DefinesInInlineManifest_Succeeds()
     {
         // Arrange
         var resourceManager = CreateResourceManager();
@@ -346,7 +346,7 @@ public class StyleTagTests : IDisposable
     }
 
     [Fact]
-    public async Task DuplicateAnonymousStylesWithDependencies_DeduplicateByName()
+    public async Task DuplicateAnonymousStylesWithDependencies_DeduplicateByName_Succeeds()
     {
         // Arrange
         var options = new ResourceManagementOptions();

--- a/test/OrchardCore.Tests/Roles/DefaultSystemRoleProviderTests.cs
+++ b/test/OrchardCore.Tests/Roles/DefaultSystemRoleProviderTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Roles.Tests;
 public class DefaultSystemRoleProviderTests
 {
     [Fact]
-    public void GetSystemRoles_WhenCalledByDefault_ContainsAdministratorAuthenticatedAndAnonymousRoles()
+    public void GetSystemRoles_CalledByDefaultContainsAdministratorAuthenticatedAndAnonymousRoles_Succeeds()
     {
         // Arrange
         var shellSettings = new ShellSettings();
@@ -28,7 +28,7 @@ public class DefaultSystemRoleProviderTests
     }
 
     [Fact]
-    public void GetAdminRole_FromOptions_ReturnAdminRoleName()
+    public void GetAdminRole_FromOptions_ReturnsAdminRoleName()
     {
         // Arrange
         var shellSettings = new ShellSettings();
@@ -85,7 +85,7 @@ public class DefaultSystemRoleProviderTests
     [InlineData("TEST", false)]
     [InlineData("TesT", false)]
     [InlineData("test", false)]
-    public void IsSystemRole_IfTheRoleExists_ReturnsTrue(string roleName, bool expectedResult)
+    public void IsSystemRole_TheRoleExistsReturnsTrue_IsSystemRole(string roleName, bool expectedResult)
     {
         // Arrange
         var shellSettings = new ShellSettings();
@@ -113,7 +113,7 @@ public class DefaultSystemRoleProviderTests
     [InlineData("TEST", false)]
     [InlineData("TesT", false)]
     [InlineData("test", false)]
-    public void IsAdminRole_WhenCalled_ReturnsAdministrator(string roleName, bool expectedResult)
+    public void IsAdminRole_CalledReturnsAdministrator_IsAdminRole(string roleName, bool expectedResult)
     {
         // Arrange
         var shellSettings = new ShellSettings();

--- a/test/OrchardCore.Tests/Routing/AutorouteEntriesTests.cs
+++ b/test/OrchardCore.Tests/Routing/AutorouteEntriesTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Routing;
 public class AutorouteEntriesTests
 {
     [Fact]
-    public async Task ShouldGetContainedEntryByPath()
+    public async Task Get_ContainedEntryByPath_Succeeds()
     {
         // Setup
         var shellContext = CreateShellContext();
@@ -44,7 +44,7 @@ public class AutorouteEntriesTests
     }
 
     [Fact]
-    public async Task ShouldGetEntryByContainedContentItemId()
+    public async Task Get_EntryByContainedContentItemId_Succeeds()
     {
         // Setup
         var shellContext = CreateShellContext();
@@ -78,7 +78,7 @@ public class AutorouteEntriesTests
     }
 
     [Fact]
-    public async Task RemovesContainedEntriesWhenContainerRemoved()
+    public async Task RemovesContainedEntries_ContainerRemoved_Succeeds()
     {
         // Setup
         var shellContext = CreateShellContext();
@@ -113,7 +113,7 @@ public class AutorouteEntriesTests
     }
 
     [Fact]
-    public async Task RemovesContainedEntriesWhenDeleted()
+    public async Task RemovesContainedEntries_Deleted_Succeeds()
     {
         // Setup
         var shellContext = CreateShellContext();
@@ -155,7 +155,7 @@ public class AutorouteEntriesTests
     }
 
     [Fact]
-    public async Task RemovesOldContainedPaths()
+    public async Task RemovesOldContainedPaths_Default_Succeeds()
     {
         // Setup
         var shellContext = CreateShellContext();
@@ -196,7 +196,7 @@ public class AutorouteEntriesTests
     }
 
     [Fact]
-    public async Task RemovesOldPaths()
+    public async Task RemovesOldPaths_Default_Succeeds()
     {
         // Setup
         var shellContext = CreateShellContext();

--- a/test/OrchardCore.Tests/Scripting/ScriptFunctionsTest.cs
+++ b/test/OrchardCore.Tests/Scripting/ScriptFunctionsTest.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Scripting;
 public class ScriptFunctionsTest
 {
     [Fact]
-    public async Task TheScriptingManagerShouldEvaluateAsyncGlobalMethods()
+    public async Task TheScriptingManager_Default_EvaluateAsyncGlobalMethods()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();
@@ -40,7 +40,7 @@ public class ScriptFunctionsTest
     }
 
     [Fact]
-    public async Task TheScriptingEngineShouldBeAbleToHandleJsonObject()
+    public async Task TheScriptingEngine_Default_BeAbleToHandleJsonObject()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
+++ b/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
@@ -9,7 +9,7 @@ public class PermissionHandlerTests
     [Theory]
     [InlineData("Allowed", true)]
     [InlineData("NotAllowed", false)]
-    public async Task GrantsClaimsPermissions(string required, bool success)
+    public async Task GrantsClaimsPermissions_Default_Succeeds(string required, bool success)
     {
         // Arrange
         var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission(required), ["Allowed"], true);
@@ -23,7 +23,7 @@ public class PermissionHandlerTests
     }
 
     [Fact]
-    public async Task DoNotRevokeExistingGrants()
+    public async Task DoNotRevokeExistingGrants_Default_Succeeds()
     {
         // Arrange
         var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Required"), ["Other"], true);
@@ -39,7 +39,7 @@ public class PermissionHandlerTests
     }
 
     [Fact]
-    public async Task DoNotHandleNonAuthenticated()
+    public async Task DoNotHandleNonAuthenticated_Default_Succeeds()
     {
         // Arrange
         var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Allowed"), ["Allowed"]);
@@ -53,7 +53,7 @@ public class PermissionHandlerTests
     }
 
     [Fact]
-    public async Task GrantsInheritedPermissions()
+    public async Task GrantsInheritedPermissions_Default_Succeeds()
     {
         // Arrange
         var level2 = new Permission("Implicit2");
@@ -71,7 +71,7 @@ public class PermissionHandlerTests
     }
 
     [Fact]
-    public async Task IsCaseInsensitive()
+    public async Task IsCaseInsensitive_Default_Succeeds()
     {
         // Arrange
         var required = new Permission("required");

--- a/test/OrchardCore.Tests/Serializers/DefaultDocumentSerializerTests.cs
+++ b/test/OrchardCore.Tests/Serializers/DefaultDocumentSerializerTests.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Serializers;
 public class DefaultDocumentSerializerTests
 {
     [Fact]
-    public async Task ShouldSerializeAndDeserialize()
+    public async Task Serialize_Deserialize_Succeeds()
     {
         var settings = new SiteSettings
         {

--- a/test/OrchardCore.Tests/Serializers/JsonSerializerTests.cs
+++ b/test/OrchardCore.Tests/Serializers/JsonSerializerTests.cs
@@ -20,7 +20,7 @@ public class JsonSerializerTests
     }
 
     [Fact]
-    public void Deserialize_WhenCalled_ReturnValidUserLoginInfo()
+    public void Deserialize_CalledReturnValidUserLoginInfo_Succeeds()
     {
         var obj = JsonSerializer.Deserialize<UserLoginInfo>(_userLoginInfo, _options);
 
@@ -34,7 +34,7 @@ public class JsonSerializerTests
     [InlineData("{\"name\":\"One\",\"value\":\"1\",\"Weight\":\"1\"}", 1)]
     [InlineData("{\"name\":\"One\",\"value\":\"1\",\"Weight\":1}", 1)]
     [InlineData("{\"name\":\"One\",\"value\":\"1\",\"Weight\":2.75}", 2.75)]
-    public void Deserialize_WhenCalled_ReturnDoubleFromStringWithBaseOptions(string json, double expectedWeight)
+    public void Deserialize_CalledReturnDoubleFromStringWithBaseOptions_Succeeds(string json, double expectedWeight)
     {
         var item = JsonSerializer.Deserialize<CustomListValueOption>(json, JOptions.Base);
 
@@ -42,7 +42,7 @@ public class JsonSerializerTests
     }
 
     [Fact]
-    public void Serialize_WhenCalled_ReturnValidJson()
+    public void Serialize_CalledReturnValidJson_Succeeds()
     {
         var loginInfo = new UserLoginInfo("OpenIdConnect", "abc", "default");
         var json = JsonSerializer.Serialize(loginInfo, _options);
@@ -51,7 +51,7 @@ public class JsonSerializerTests
     }
 
     [Fact]
-    public async Task DefaultContentSerializer_SerializeAndDeserialize_UserWithUserLoginInfo()
+    public async Task DefaultContentSerializer_SerializeAndDeserialize_UsesrWithUserLoginInfo()
     {
         using var context = new SiteContext();
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Serializers/ResilientPolymorphicJsonConverterTests.cs
+++ b/test/OrchardCore.Tests/Serializers/ResilientPolymorphicJsonConverterTests.cs
@@ -32,7 +32,7 @@ public class ResilientPolymorphicJsonConverterTests
     }
 
     [Fact]
-    public void Deserialize_WithKnownDiscriminator_ReturnsCorrectDerivedType()
+    public void Deserialize_KnownDiscriminator_ReturnsCorrectDerivedType()
     {
         var options = CreateOptions(o =>
         {
@@ -52,7 +52,7 @@ public class ResilientPolymorphicJsonConverterTests
     }
 
     [Fact]
-    public void Deserialize_WithUnknownDiscriminator_WithoutFallback_ReturnsNull()
+    public void Deserialize_UnknownDiscriminatorWithoutFallback_ReturnsNull()
     {
         // No fallback registered — unrecognized discriminator returns null.
         var options = CreateOptions(RegisterDerivedType<ConcreteStepA, AbstractBaseStep>);
@@ -66,7 +66,7 @@ public class ResilientPolymorphicJsonConverterTests
     }
 
     [Fact]
-    public void Deserialize_WithUnknownDiscriminator_WithFallback_ReturnsFallbackType()
+    public void Deserialize_UnknownDiscriminatorWithFallback_ReturnsFallbackType()
     {
         var options = CreateOptions(o =>
         {
@@ -87,7 +87,7 @@ public class ResilientPolymorphicJsonConverterTests
     }
 
     [Fact]
-    public void Deserialize_WithMissingDiscriminator_WithFallback_ReturnsFallbackType()
+    public void Deserialize_MissingDiscriminatorWithFallback_ReturnsFallbackType()
     {
         var options = CreateOptions(o =>
         {
@@ -145,7 +145,7 @@ public class ResilientPolymorphicJsonConverterTests
     }
 
     [Fact]
-    public void Serialize_WithKnownDerivedType_WritesDiscriminator()
+    public void Serialize_KnownDerivedType_WritesDiscriminator()
     {
         var options = CreateOptions(o =>
         {

--- a/test/OrchardCore.Tests/Settings/ShapeRenderingOptionsConfigurationTests.cs
+++ b/test/OrchardCore.Tests/Settings/ShapeRenderingOptionsConfigurationTests.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Settings;
 public class ShapeRenderingOptionsConfigurationTests
 {
     [Fact]
-    public void ConfigureDisablesShapeDebugInformationByDefault()
+    public void ConfigureDisablesShapeDebugInformationByDefault_Default_Succeeds()
     {
         var site = new SiteSettings();
         var siteService = new Mock<ISiteService>();
@@ -26,7 +26,7 @@ public class ShapeRenderingOptionsConfigurationTests
     }
 
     [Fact]
-    public void ConfigureEnablesShapeDebugInformationWhenConfiguredInSiteSettings()
+    public void ConfigureEnablesShapeDebugInformation_ConfiguredInSiteSettings_Succeeds()
     {
         var site = new SiteSettings();
         site.Put(new DebugSettings

--- a/test/OrchardCore.Tests/Settings/SiteSettingsTests.cs
+++ b/test/OrchardCore.Tests/Settings/SiteSettingsTests.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Tests.Settings;
 public class SiteSettingsTests
 {
     [Fact]
-    public void TryGetReturnsCachedSettingsWithoutAllocatingNewInstances()
+    public void TryGetReturnsCachedSettingsWithoutAllocatingNewInstances_Default_Succeeds()
     {
         var site = new SiteSettings();
         site.Put(new TestSettings { Name = "alpha" });
@@ -19,7 +19,7 @@ public class SiteSettingsTests
     }
 
     [Fact]
-    public void TryGetReturnsNullWhenSettingsAreMissing()
+    public void TryGetReturnsNull_SettingsAreMissing_Succeeds()
     {
         var site = new SiteSettings();
 
@@ -28,7 +28,7 @@ public class SiteSettingsTests
     }
 
     [Fact]
-    public void RemoveDeletesStoredProperties()
+    public void RemoveDeletesStoredProperties_Default_Succeeds()
     {
         var site = new SiteSettings();
         site.Put(new TestSettings { Name = "alpha" });

--- a/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
+++ b/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Shell;
 public class CompositionStrategyTests
 {
     [Fact]
-    public async Task ComposeAsync_ReturnsBlueprintWithDependencies_WhenFeaturesPresent()
+    public async Task ComposeAsync_FeaturesPresent_ReturnsBlueprintWithDependencies()
     {
         // Arrange
         var featureId = "FeatureA";
@@ -49,7 +49,7 @@ public class CompositionStrategyTests
     }
 
     [Fact]
-    public async Task ComposeAsync_SkipsType_WhenRequiredFeatureMissing()
+    public async Task ComposeAsync_RequiredFeatureMissing_SkipsType()
     {
         // Arrange
         var featureId = "FeatureA";
@@ -84,7 +84,7 @@ public class CompositionStrategyTests
     }
 
     [Fact]
-    public async Task ComposeAsync_SkipsType_WhenNotAllRequiredFeaturesAreEnabled()
+    public async Task ComposeAsync_NotAllRequiredFeaturesAreEnabled_SkipsType()
     {
         // Arrange
         var featureId = "FeatureA";
@@ -120,7 +120,7 @@ public class CompositionStrategyTests
     }
 
     [Fact]
-    public async Task ComposeAsync_IncludedType_WhenAllRequiredFeaturesAreEnabled()
+    public async Task ComposeAsyncIncludedType_AllRequiredFeaturesAreEnabled_Succeeds()
     {
         // Arrange
         var featureAId = "FeatureA";
@@ -164,7 +164,7 @@ public class CompositionStrategyTests
     }
 
     [Fact]
-    public async Task ComposeAsync_LogsDebug_WhenLoggerEnabled()
+    public async Task ComposeAsyncLogsDebug_LoggerEnabled_Succeeds()
     {
         // Arrange
         var featureId = "FeatureA";
@@ -205,7 +205,7 @@ public class CompositionStrategyTests
     }
 
     [Fact]
-    public async Task ComposeAsync_SkipsType_WhenFeatureIsDefaultTenantOnly_AndTenantIsNotDefault()
+    public async Task ComposeAsync_FeatureIsDefaultTenantOnlyAndTenantIsNotDefault_SkipsType()
     {
         // Arrange - Bug #18244: DefaultTenantOnly feature types should be skipped on non-default tenants
         var featureId = "FeatureA";
@@ -241,7 +241,7 @@ public class CompositionStrategyTests
     }
 
     [Fact]
-    public async Task ComposeAsync_IncludesType_WhenFeatureIsDefaultTenantOnly_AndTenantIsDefault()
+    public async Task ComposeAsyncIncludesType_FeatureIsDefaultTenantOnlyAndTenantIsDefault_Succeeds()
     {
         // Arrange
         var featureId = "FeatureA";
@@ -278,7 +278,7 @@ public class CompositionStrategyTests
     }
 
     [Fact]
-    public async Task ComposeAsync_IncludesType_WhenFeatureIsNotDefaultTenantOnly_AndTenantIsNotDefault()
+    public async Task ComposeAsyncIncludesType_FeatureIsNotDefaultTenantOnlyAndTenantIsNotDefault_Succeeds()
     {
         // Arrange
         var featureId = "FeatureA";

--- a/test/OrchardCore.Tests/Shell/RunningShellTableTests.cs
+++ b/test/OrchardCore.Tests/Shell/RunningShellTableTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Shell;
 public class RunningShellTableTests
 {
     [Fact]
-    public void NoShellsGiveNoMatch()
+    public void NoShellsGiveNoMatch_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var match = table.Match(new HostString("localhost"), "/yadda");
@@ -13,7 +13,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void DefaultShellMatchesByDefault()
+    public void DefaultShellMatchesByDefault_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -23,7 +23,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void DefaultShellMatchesAllPortsByDefault()
+    public void DefaultShellMatchesAllPortsByDefault_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -33,7 +33,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void AnotherShellMatchesByHostHeader()
+    public void AnotherShellMatchesByHostHeader_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -45,7 +45,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void DefaultStillCatchesWhenOtherShellsMiss()
+    public void DefaultStillCatches_OtherShellsMiss_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -57,7 +57,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void DefaultWontFallbackIfItHasCriteria()
+    public void DefaultWontFallbackIfItHasCriteria_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings { RequestUrlHost = "www.example.com" }.AsDefaultShell();
@@ -69,7 +69,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void DefaultWillCatchRequestsIfItMatchesCriteria()
+    public void DefaultWillCatchRequestsIfItMatchesCriteria_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings { RequestUrlHost = "www.example.com" }.AsDefaultShell();
@@ -81,7 +81,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void NonDefaultCatchallWillFallbackIfNothingElseMatches()
+    public void NonDefaultCatchallWillFallbackIfNothingElseMatches_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings { RequestUrlHost = "www.example.com" }.AsDefaultShell();
@@ -93,7 +93,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void DefaultCatchallIsFallbackEvenWhenOthersAreUnqualified()
+    public void DefaultCatchallIsFallbackEven_OthersAreUnqualified_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -109,7 +109,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void PathAlsoCausesMatch()
+    public void PathAlsoCausesMatch_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -121,7 +121,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void PathAndHostMustBothMatch()
+    public void PathAndHost_Default_BothMatch()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings { RequestUrlHost = "www.example.com" }.AsDefaultShell();
@@ -153,7 +153,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void PathAndHostMustMatchOnFullUrl()
+    public void PathAndHost_Default_MatchOnFullUrl()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings { RequestUrlHost = "www.example.com" }.AsDefaultShell();
@@ -169,7 +169,7 @@ public class RunningShellTableTests
         Assert.Equal(settingsG, table.Match(new HostString("wiki.example.com"), "/barbaz"));
     }
     [Fact]
-    public void PathAloneWillMatch()
+    public void PathAloneWillMatch_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settingsA = new ShellSettings { Name = "Alpha", RequestUrlPrefix = "foo" };
@@ -180,7 +180,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void HostNameMatchesRightmostIfRequestIsLonger()
+    public void HostNameMatchesRightmostIfRequestIsLonger_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -194,7 +194,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void HostNameMatchesRightmostIfStar()
+    public void HostNameMatchesRightmostIfStar_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -208,7 +208,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void LongestMatchingHostHasPriority()
+    public void LongestMatchingHostHasPriority_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -227,7 +227,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void ShellNameUsedToDistinctThingsAsTheyAreAdded()
+    public void ShellNameUsedToDistinctThingsAsTheyAreAdded_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -244,7 +244,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void MultipleHostsOnShellAreAdded()
+    public void MultipleHostsOnShellAreAdded_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settingsAlpha = new ShellSettings { Name = "Alpha", RequestUrlHost = "a.example.com,b.example.com" };
@@ -260,7 +260,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void HostContainsSpaces()
+    public void HostContainsSpaces_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settingsAlpha = new ShellSettings { Name = "Alpha", RequestUrlHost = "   a.example.com,  b.example.com     " };
@@ -271,7 +271,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void PortAreIgnoredIfNotSetInSettings()
+    public void PortAreIgnoredIfNotSetInSettings_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -283,7 +283,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void ShouldNotFallBackToDefault()
+    public void Not_FallBackToDefault_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -296,7 +296,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void PortAreNotIgnoredIfSetInSettings()
+    public void PortAreNotIgnoredIfSetInSettings_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();
@@ -312,7 +312,7 @@ public class RunningShellTableTests
     }
 
     [Fact]
-    public void IPv6AddressesAreSupported()
+    public void IPv6AddressesAreSupported_Default_Succeeds()
     {
         var table = new RunningShellTable();
         var settings = new ShellSettings().AsDefaultShell();

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -45,7 +45,7 @@ public class ShellContainerFactoryTests
     }
 
     [Fact]
-    public async Task CanRegisterDefaultServiceWithFeatureInfo()
+    public async Task CanRegisterDefaultServiceWithFeatureInfo_Default_Succeeds()
     {
         var shellBlueprint = CreateBlueprint();
 
@@ -63,7 +63,7 @@ public class ShellContainerFactoryTests
     }
 
     [Fact]
-    public async Task CanReplaceDefaultServiceWithCustomService()
+    public async Task CanReplaceDefaultServiceWithCustomService_Default_Succeeds()
     {
         var shellBlueprint = CreateBlueprint();
 
@@ -83,7 +83,7 @@ public class ShellContainerFactoryTests
     }
 
     [Fact]
-    public async Task HostServiceLifeTimesShouldBePreserved()
+    public async Task HostServiceLifeTimes_Default_BePreserved()
     {
         var shellBlueprint = CreateBlueprint();
         var container = (await _shellContainerFactory
@@ -122,7 +122,7 @@ public class ShellContainerFactoryTests
     }
 
     [Fact]
-    public async Task WhenTwoHostSingletons_GetServices_Returns_HostAndShellServices()
+    public async Task Default_TwoHostSingletonsTwoHostSingletonsGetServicesReturnsHostAndShellServicesSucceeds_Succeeds()
     {
         var shellBlueprint = CreateBlueprint();
         AddStartup(shellBlueprint, typeof(ServicesOfTheSameTypeStartup));
@@ -138,7 +138,7 @@ public class ShellContainerFactoryTests
     }
 
     [Fact]
-    public async Task WhenHostSingletonAndScoped_GetServices_Returns_CorrectImplementations()
+    public async Task Default_HostSingletonAndScopedHostSingletonAndScopedGetServicesReturnsCorrectImplementationsSucceeds_Succeeds()
     {
         var shellBlueprint = CreateBlueprint();
 
@@ -155,7 +155,7 @@ public class ShellContainerFactoryTests
     }
 
     [Fact]
-    public async Task AssignsTypeToMultipleFeatures()
+    public async Task AssignsTypeToMultipleFeatures_Default_Succeeds()
     {
         var shellBlueprint = CreateBlueprint();
 
@@ -173,7 +173,7 @@ public class ShellContainerFactoryTests
     }
 
     [Fact]
-    public async Task RawStartupIsAssignedToCorrectFeature()
+    public async Task RawStartupIsAssignedToCorrectFeature_Default_Succeeds()
     {
         var shellBlueprint = CreateBlueprint();
 

--- a/test/OrchardCore.Tests/Tokens.Content/SlugServiceTests.cs
+++ b/test/OrchardCore.Tests/Tokens.Content/SlugServiceTests.cs
@@ -16,21 +16,21 @@ public class SlugServiceTests
     [InlineData("a - b", "a-b")]
     [InlineData("a  -  -      -  -   -   -b", "a-b")]
     [InlineData("a - b - c-- d", "a-b-c-d")]
-    public void ShouldStripContiguousDashes(string input, string expected)
+    public void Strip_ContiguousDashes_Succeeds(string input, string expected)
     {
         var slug = _slugService.Slugify(input);
         Assert.Equal(expected, slug);
     }
 
     [Fact]
-    public void ShouldChangePercentSymbolsToHyphans()
+    public void Change_PercentSymbolsToHyphans_Succeeds()
     {
         var slug = _slugService.Slugify("a%d");
         Assert.Equal("a-d", slug);
     }
 
     [Fact]
-    public void ShouldChangeDotSymbolsToHyphans()
+    public void Change_DotSymbolsToHyphans_Succeeds()
     {
         var slug = _slugService.Slugify("a,d");
         Assert.Equal("a-d", slug);
@@ -39,7 +39,7 @@ public class SlugServiceTests
     [Theory]
     [InlineData("Smith, John B.")]
     [InlineData("Smith, John B...")]
-    public void ShouldRemoveHyphansFromEnd(string input)
+    public void Remove_HyphansFromEnd_Succeeds(string input)
     {
         // Act
         var slug = _slugService.Slugify(input);
@@ -47,21 +47,21 @@ public class SlugServiceTests
     }
 
     [Fact]
-    public void ShouldMakeSureFunkycharactersAndHyphansOnlyReturnSingleHyphan()
+    public void Make_SureFunkycharactersAndHyphansOnlyReturnSingleHyphan_Succeeds()
     {
         var slug = _slugService.Slugify("«a»\"'-%-.d");
         Assert.Equal("a-d", slug);
     }
 
     [Fact]
-    public void ShouldConvertToLowercase()
+    public void Convert_ToLowercase_Succeeds()
     {
         var slug = _slugService.Slugify("ABCDE");
         Assert.Equal("abcde", slug);
     }
 
     [Fact]
-    public void ShouldRemoveDiacritics()
+    public void Remove_Diacritics_Succeeds()
     {
         var slug = _slugService.Slugify("àçéïôù");
         Assert.Equal("aceiou", slug);
@@ -73,14 +73,14 @@ public class SlugServiceTests
     [InlineData("调度模块允许后台任务调度", "调度模块允许后台任务调度")]
     [InlineData("فريق_الاورشارد", "فريق_الاورشارد")]
     [InlineData("不正なコンテナ", "不正なコンテナ")]
-    public void ShouldPreserveNonLatinCharacters(string input, string expected)
+    public void Preserve_NonLatinCharacters_Succeeds(string input, string expected)
     {
         var slug = _slugService.Slugify(input);
         Assert.Equal(expected, slug);
     }
 
     [Fact]
-    public void ShouldTransliterateWhenRequested()
+    public void Transliterate_Requested_Succeeds()
     {
         var slug = _slugService.SlugifyAndTransliterate("Æneid");
         Assert.Equal("aeneid", slug);

--- a/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
+++ b/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Tests.Workflows;
 public class WorkflowManagerTests
 {
     [Fact]
-    public async Task CanExecuteSimpleWorkflow()
+    public async Task CanExecuteSimpleWorkflow_Default_Succeeds()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -78,7 +78,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task SetOutputTaskShouldEvaluateLiquidExpression()
+    public async Task SetOutputTask_Default_EvaluateLiquidExpression()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -115,7 +115,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task SetPropertyTaskShouldEvaluateLiquidExpression()
+    public async Task SetPropertyTask_Default_EvaluateLiquidExpression()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -152,7 +152,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task IfElseTaskShouldEvaluateLiquidExpression()
+    public async Task Default_ElseTaskDefaultEvaluateLiquidExpression_Succeeds()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -187,7 +187,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task WhileLoopTaskShouldEvaluateLiquidExpression()
+    public async Task WhileLoopTask_Default_EvaluateLiquidExpression()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -222,7 +222,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task ForLoopTaskShouldEvaluateLiquidExpressions()
+    public async Task ForLoopTask_Default_EvaluateLiquidExpressions()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -259,7 +259,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task ForEachTaskShouldEvaluateLiquidExpression()
+    public async Task ForEachTask_Default_EvaluateLiquidExpression()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -293,7 +293,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task LiquidTaskShouldSetLastResult()
+    public async Task LiquidTask_Default_SetsLastResult()
     {
         var serviceProvider = CreateServiceProvider();
         var expressionEvaluator = new Mock<IWorkflowExpressionEvaluator>();
@@ -323,7 +323,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task LiquidWorkflowExpressionEvaluatorShouldPreserveCollectionValues()
+    public async Task LiquidWorkflowExpressionEvaluator_Default_PreservesCollectionValues()
     {
         using var serviceProvider = CreateLiquidWorkflowServiceProvider();
         var evaluator = CreateLiquidWorkflowExpressionEvaluator(serviceProvider);
@@ -347,7 +347,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task LiquidWorkflowExpressionEvaluatorShouldEvaluateBooleanComparison()
+    public async Task LiquidWorkflowExpressionEvaluator_Default_EvaluateBooleanComparison()
     {
         using var serviceProvider = CreateLiquidWorkflowServiceProvider();
         var evaluator = CreateLiquidWorkflowExpressionEvaluator(serviceProvider);
@@ -372,7 +372,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task WorkflowScriptEvaluatorShouldEvaluateAsyncScopedGlobalMethods()
+    public async Task WorkflowScriptEvaluator_Default_EvaluateAsyncScopedGlobalMethods()
     {
         var serviceProvider = CreateServiceProvider();
         var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
@@ -395,7 +395,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task TriggerEventAsync_ShouldAllowReexecutionAfterUnexpectedError()
+    public async Task TriggerEventAsync_Default_AllowsReexecutionAfterUnexpectedError()
     {
         const string nonExistentActivityId = "missing";
 
@@ -430,7 +430,7 @@ public class WorkflowManagerTests
     }
 
     [Fact]
-    public async Task TriggerEventAsync_ShouldAllowFaultHandlerToTriggerWorkflowAfterActivityError()
+    public async Task TriggerEventAsync_Default_AllowsFaultHandlerToTriggerWorkflowAfterActivityError()
     {
         var serviceProvider = CreateServiceProvider();
         var executionCount = 0;


### PR DESCRIPTION
This pull request standardizes unit and integration test method naming conventions across the codebase to improve clarity and consistency. The new convention uses the `{Action}_{Condition}_{ExpectedResult}` format for test method names, making test purposes more explicit. Documentation and numerous test files have been updated to reflect this approach.

**Test naming convention updates:**

* Updated test method naming guidelines in documentation files (`SKILL.md`, `references/testing.md`, `AGENTS.md`) to specify the `{Action}_{Condition}_{ExpectedResult}` format, replacing previous conventions. [[1]](diffhunk://#diff-fd0ed4c840568ffcbfbac550152b4f07b220772919d7df835d8059cc7bcb7285L33-R33) [[2]](diffhunk://#diff-309cc301b92a617c9d4d4efc912cd42d206f288eb3608a8342ed8c8ab5fdfc81L25-R25) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R321-R322)
* Provided concrete examples and updated sample test methods in documentation to illustrate the new naming standard. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L329-R331) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L344-R346) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L364-R366)

**Test method renaming in codebase:**

* Renamed test methods in unit test files (e.g., `InvokeExtensionsTests.cs`, `StringExtensionsTests.cs`, `.agents/skills/orchardcore-unit-test/SKILL.md`) to follow the new naming convention, improving readability and intent. [[1]](diffhunk://#diff-86879c581fa8ab7592e5d6f72351ebb9e498b363a826575b55b00a42a9055df7L13-R13) [[2]](diffhunk://#diff-86879c581fa8ab7592e5d6f72351ebb9e498b363a826575b55b00a42a9055df7L31-R31) [[3]](diffhunk://#diff-86879c581fa8ab7592e5d6f72351ebb9e498b363a826575b55b00a42a9055df7L55-R55) [[4]](diffhunk://#diff-4a5e3d3358826634ac7acacde1b12f016beb41643a1855850e3c69a06a64dd7bL12-R12) [[5]](diffhunk://#diff-4a5e3d3358826634ac7acacde1b12f016beb41643a1855850e3c69a06a64dd7bL24-R24) [[6]](diffhunk://#diff-4a5e3d3358826634ac7acacde1b12f016beb41643a1855850e3c69a06a64dd7bL34-R34) [[7]](diffhunk://#diff-fd0ed4c840568ffcbfbac550152b4f07b220772919d7df835d8059cc7bcb7285L43-R43) [[8]](diffhunk://#diff-fd0ed4c840568ffcbfbac550152b4f07b220772919d7df835d8059cc7bcb7285L86-R86)

* Renamed test methods in functional and integration test files for various modules and features (e.g., `AdminNavigationTests.cs`, `AgencyTests.cs`, `BlogTests.cs`, `ComingSoonTests.cs`, `HeadlessTests.cs`, `MigrationsTests.cs`, `SaasTests.cs`, `MediaImageTests.cs`, `MvcTests.cs`, `AWSS3ResizedImageCacheTests.cs`) to match the new convention. [[1]](diffhunk://#diff-6a198536c1b689785d6611d0bbac13ffc0e423d6faa12ecace41ad9d562533b8L16-R16) [[2]](diffhunk://#diff-6a198536c1b689785d6611d0bbac13ffc0e423d6faa12ecace41ad9d562533b8L41-R41) [[3]](diffhunk://#diff-6f079f0521caed85625daace56d7c2250e3d06dabc9e175c183e0c3ccd42e21fL11-R11) [[4]](diffhunk://#diff-6f079f0521caed85625daace56d7c2250e3d06dabc9e175c183e0c3ccd42e21fL20-R20) [[5]](diffhunk://#diff-b701e4ca0edc3d1682ca78198e6621a813da7780ec1d1d0c3b0c4d1954393749L11-R11) [[6]](diffhunk://#diff-b701e4ca0edc3d1682ca78198e6621a813da7780ec1d1d0c3b0c4d1954393749L20-R20) [[7]](diffhunk://#diff-1395b7fd4ad25f278807b3e38a38388f5485a2b080c1b1967da3e2dd31ba0fe3L11-R11) [[8]](diffhunk://#diff-1395b7fd4ad25f278807b3e38a38388f5485a2b080c1b1967da3e2dd31ba0fe3L21-R21) [[9]](diffhunk://#diff-46732caf41e787158bcfac0b8ec47f6011cb5e2f4a27d4a68ad07201ae6b7942L11-R11) [[10]](diffhunk://#diff-46732caf41e787158bcfac0b8ec47f6011cb5e2f4a27d4a68ad07201ae6b7942L20-R20) [[11]](diffhunk://#diff-737a1c4204c8066a1e250a1539bd08276b440913f3027a917456ea251c57feb5L11-R11) [[12]](diffhunk://#diff-737a1c4204c8066a1e250a1539bd08276b440913f3027a917456ea251c57feb5L20-R20) [[13]](diffhunk://#diff-903f351730977c0819185ca00c9774bc3a12062d3e6608b88bc0b306500f7be0L24-R24) [[14]](diffhunk://#diff-903f351730977c0819185ca00c9774bc3a12062d3e6608b88bc0b306500f7be0L33-R33) [[15]](diffhunk://#diff-903f351730977c0819185ca00c9774bc3a12062d3e6608b88bc0b306500f7be0L43-R43) [[16]](diffhunk://#diff-7c4c400b0d17025600a8d2688e86f602879672b28fbf7d742d0d02b52ad7dce4L16-R16) [[17]](diffhunk://#diff-7c4c400b0d17025600a8d2688e86f602879672b28fbf7d742d0d02b52ad7dce4L28-R28) [[18]](diffhunk://#diff-7c4c400b0d17025600a8d2688e86f602879672b28fbf7d742d0d02b52ad7dce4L76-R76) [[19]](diffhunk://#diff-3a0731f7a5585749871d9b2c6585649de2febea51f2e1f0784f3b2f5cbdfbff7L24-R24) [[20]](diffhunk://#diff-2de0e2091975d526c546fee1e027c4b2f6385cf0137aa41e057c6e791a049dd8L100-R100)

These changes collectively improve the maintainability and clarity of the test suite by making test purposes more explicit and consistent throughout the project.