### PR TITLE
Fix trailing slash issue when caching media files.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
@@ -59,7 +59,8 @@ public class MediaFileStoreResolverMiddleware
         }
 
         // subPath.Value returns an unescaped path value, subPath returns an escaped path value.
-        var subPathValue = subPath.Value;
+        // Trim the trailing slash so that a file isn't mistaken for a folder.
+        var subPathValue = subPath.Value.TrimEnd('/');
 
         var isFileCached = await _mediaFileStoreCache.IsCachedAsync(subPathValue);
         if (isFileCached)

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -44,7 +44,8 @@ public class DefaultMediaFileStoreCacheFileProvider : PhysicalFileProvider, IMed
     public async Task SetCacheAsync(Stream stream, IFileStoreEntry fileStoreEntry, CancellationToken cancellationToken)
     {
         // File store semantics may include a leading slash.
-        var cachePath = Path.Combine(Root, fileStoreEntry.Path.TrimStart('/'));
+        // Trailing slash would create an empty directory instead of a file.
+        var cachePath = Path.Combine(Root, fileStoreEntry.Path.TrimStart('/').TrimEnd('/'));
         var directory = Path.GetDirectoryName(cachePath);
 
         if (!Directory.Exists(directory))

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -45,7 +45,7 @@ public class DefaultMediaFileStoreCacheFileProvider : PhysicalFileProvider, IMed
     {
         // File store semantics may include a leading slash.
         // Trailing slash would create an empty directory instead of a file.
-        var cachePath = Path.Combine(Root, fileStoreEntry.Path.TrimStart('/').TrimEnd('/'));
+        var cachePath = Path.Combine(Root, fileStoreEntry.Path.Trim('/'));
         var directory = Path.GetDirectoryName(cachePath);
 
         if (!Directory.Exists(directory))


### PR DESCRIPTION
Trailing slash in the media file URL, eg. "/media/file1.jpg/" would cause creation of a folder "/ms-cache/file1.jpg/" instead of a file "/ms-cache/file1.jpg".
