### PR TITLE
fix: query params being stripped from media urls

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/AssetUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/AssetUrlFilter.cs
@@ -16,7 +16,8 @@ public class AssetUrlFilter : ILiquidFilter
     public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
     {
         var url = input.ToStringValue();
-        var imageUrl = _mediaFileStore.MapPathToPublicUrl(url);
+        url = url.RemoveQueryString(out string queryString);
+        var imageUrl = _mediaFileStore.MapPathToPublicUrl(url) + queryString;
 
         return ValueTask.FromResult<FluidValue>(StringValue.Create(imageUrl ?? url));
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Liquid/MediaAnchorTag.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Liquid/MediaAnchorTag.cs
@@ -60,7 +60,8 @@ public class MediaAnchorTag : IAnchorTag
             return Completion.Normal;
         }
 
-        var resolvedUrl = mediaFileStore != null ? mediaFileStore.MapPathToPublicUrl(assetHref) : assetHref;
+        assetHref = assetHref.RemoveQueryString(out string queryString);
+        var resolvedUrl = mediaFileStore != null ? mediaFileStore.MapPathToPublicUrl(assetHref) + queryString : assetHref + queryString;
 
         if (appendVersion != null && fileVersionProvider != null)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -24,7 +24,8 @@ public static class MediaOrchardRazorHelperExtensions
             return assetPath;
         }
 
-        var resolvedAssetPath = mediaFileStore.MapPathToPublicUrl(assetPath);
+        assetPath = assetPath.RemoveQueryString(out string queryString);
+        var resolvedAssetPath = mediaFileStore.MapPathToPublicUrl(assetPath) + queryString;
 
         if (appendVersion)
         {
@@ -48,7 +49,8 @@ public static class MediaOrchardRazorHelperExtensions
             return Task.FromResult(assetPath);
         }
 
-        var resolvedAssetPath = mediaFileStore.MapPathToPublicUrl(assetPath);
+        assetPath = assetPath.RemoveQueryString(out string queryString);
+        var resolvedAssetPath = mediaFileStore.MapPathToPublicUrl(assetPath) + queryString;
 
         if (appendVersion)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/AnchorTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/AnchorTagHelper.cs
@@ -48,7 +48,8 @@ public class AnchorTagHelper : TagHelper
             return;
         }
 
-        var resolvedUrl = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(AssetHref) : AssetHref;
+        AssetHref = AssetHref.RemoveQueryString(out string queryString);
+        var resolvedUrl = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(AssetHref) + queryString : AssetHref + queryString;
 
         if (AppendVersion && _fileVersionProvider != null)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -53,7 +53,8 @@ public class ImageTagHelper : TagHelper
             return;
         }
 
-        var resolvedUrl = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(AssetSrc) : AssetSrc;
+        AssetSrc = AssetSrc.RemoveQueryString(out string queryString);
+        var resolvedUrl = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(AssetSrc) + queryString : AssetSrc + queryString;
 
         if (AppendVersion && _fileVersionProvider != null)
         {


### PR DESCRIPTION
by separating them from the call to MapPathToPublicUrl

Fixes #17985

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
