### PR TITLE
The order of execution for IMediaCreatingEventHandler. Lower values are executed first

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Middleware/MediaImageProcessingMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Middleware/MediaImageProcessingMiddleware.cs
@@ -85,7 +85,7 @@ internal sealed class MediaImageProcessingMiddleware : IMiddleware
         // If the format is not explicitly requested, default to the source file's format.
         if (string.IsNullOrEmpty(commands.Format))
         {
-            commands.Format = ExtensionToFormat(ext);
+            commands.Format = MediaResizingConstants.ExtensionToFormat(ext);
         }
 
         // The output format is fully determined here, so the cache file extension and content type
@@ -216,16 +216,7 @@ internal sealed class MediaImageProcessingMiddleware : IMiddleware
 
             await content.CopyToAsync(response.Body, context.RequestAborted);
         }
-    }
-
-    private static string ExtensionToFormat(string ext) => ext.TrimStart('.').ToLowerInvariant() switch
-    {
-        "jpeg" => "jpg",
-        "png"  => "png",
-        "gif"  => "gif",
-        "webp" => "webp",
-        _      => "jpg",
-    };
+    } 
 
     // Maps the validated, string-based request commands to the engine-agnostic, typed command set
     // consumed by IImageProcessingEngine. Parsing happens once here so engines never touch raw

--- a/src/OrchardCore.Modules/OrchardCore.Media/Middleware/MediaImageProcessingMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Middleware/MediaImageProcessingMiddleware.cs
@@ -216,7 +216,7 @@ internal sealed class MediaImageProcessingMiddleware : IMiddleware
 
             await content.CopyToAsync(response.Body, context.RequestAborted);
         }
-    } 
+    }
 
     // Maps the validated, string-based request commands to the engine-agnostic, typed command set
     // consumed by IImageProcessingEngine. Parsing happens once here so engines never touch raw

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
@@ -6,6 +6,10 @@ namespace OrchardCore.Media.Events;
 public interface IMediaCreatingEventHandler
 {
     /// <summary>
+    /// The order of execution for this event handler. Lower values are executed first.
+    /// </summary>
+    int Priority { get;}
+    /// <summary>
     /// Allows a stream to be mutated during creation of media.
     /// Any implementation must return a new stream,
     /// which should be disposed by the caller.

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
@@ -9,6 +9,7 @@ public interface IMediaCreatingEventHandler
     /// The order of execution for this event handler. Lower values are executed first.
     /// </summary>
     int Priority => 0;
+
     /// <summary>
     /// Allows a stream to be mutated during creation of media.
     /// Any implementation must return a new stream,

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
@@ -8,7 +8,7 @@ public interface IMediaCreatingEventHandler
     /// <summary>
     /// The order of execution for this event handler. Lower values are executed first.
     /// </summary>
-    int Priority => 0;
+    double Priority => 0;
 
     /// <summary>
     /// Allows a stream to be mutated during creation of media.

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaCreatingEventHandler.cs
@@ -8,7 +8,7 @@ public interface IMediaCreatingEventHandler
     /// <summary>
     /// The order of execution for this event handler. Lower values are executed first.
     /// </summary>
-    int Priority { get;}
+    int Priority => 0;
     /// <summary>
     /// Allows a stream to be mutated during creation of media.
     /// Any implementation must return a new stream,

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
@@ -76,5 +76,4 @@ public static class MediaResizingConstants
         "webp" => "webp",
         _ => "jpg",
     };
-
 }

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
@@ -19,7 +19,7 @@ public static class MediaResizingConstants
     /// <see cref="Format"/>. Unknown or unsupported names return <see cref="Format.Undefined"/>,
     /// which engines treat as the default JPEG output.
     /// </summary>
-    public static Format ParseFormat(string format) => format?.TrimStart('.').Trim().ToLowerInvariant() switch
+    public static Format ParseFormat(string format) => ExtensionToFormat(format) switch
     {
         "png" => Format.Png,
         "gif" => Format.Gif,

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
@@ -62,4 +62,19 @@ public static class MediaResizingConstants
         ".gif" => GifContentType,
         _ => JpegContentType,
     };
+
+    /// <summary>
+    /// Maps a cached resized-image file extension (including the leading dot) to its format.
+    /// </summary>
+    /// <param name="ext"></param>
+    /// <returns></returns>
+    public static string ExtensionToFormat(string ext) => ext.TrimStart('.').ToLowerInvariant() switch
+    {
+        "jpeg" => "jpg",
+        "png" => "png",
+        "gif" => "gif",
+        "webp" => "webp",
+        _ => "jpg",
+    };
+
 }

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
@@ -19,7 +19,7 @@ public static class MediaResizingConstants
     /// <see cref="Format"/>. Unknown or unsupported names return <see cref="Format.Undefined"/>,
     /// which engines treat as the default JPEG output.
     /// </summary>
-    public static Format ParseFormat(string format) => format?.TrimStart('.').ToLowerInvariant() switch
+    public static Format ParseFormat(string format) => format?.TrimStart('.').Trim().ToLowerInvariant() switch
     {
         "png" => Format.Png,
         "gif" => Format.Gif,
@@ -68,7 +68,7 @@ public static class MediaResizingConstants
     /// </summary>
     /// <param name="ext"></param>
     /// <returns></returns>
-    public static string ExtensionToFormat(string ext) => ext?.TrimStart('.').ToLowerInvariant() switch
+    public static string ExtensionToFormat(string ext) => ext?.TrimStart('.').Trim().ToLowerInvariant() switch
     {
         "jpeg" => "jpg",
         "png" => "png",

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Processing/MediaResizingConstants.cs
@@ -19,7 +19,7 @@ public static class MediaResizingConstants
     /// <see cref="Format"/>. Unknown or unsupported names return <see cref="Format.Undefined"/>,
     /// which engines treat as the default JPEG output.
     /// </summary>
-    public static Format ParseFormat(string format) => format?.ToLowerInvariant() switch
+    public static Format ParseFormat(string format) => format?.TrimStart('.').ToLowerInvariant() switch
     {
         "png" => Format.Png,
         "gif" => Format.Gif,
@@ -68,7 +68,7 @@ public static class MediaResizingConstants
     /// </summary>
     /// <param name="ext"></param>
     /// <returns></returns>
-    public static string ExtensionToFormat(string ext) => ext.TrimStart('.').ToLowerInvariant() switch
+    public static string ExtensionToFormat(string ext) => ext?.TrimStart('.').ToLowerInvariant() switch
     {
         "jpeg" => "jpg",
         "png" => "png",

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
@@ -172,7 +172,7 @@ public class DefaultMediaFileStore : IMediaFileStore
                     Path = path,
                 };
 
-                foreach (var mediaCreatingEventHandler in _mediaCreatingEventHandlers)
+                foreach (var mediaCreatingEventHandler in _mediaCreatingEventHandlers.OrderBy(x => x.Priority))
                 {
                     var creatingStream = outputStream;
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
@@ -77,6 +77,7 @@ public class MediaEventTests
 public class TestMediaEventHandler : IMediaCreatingEventHandler
 {
     public int Priority => 0;
+
     public async Task<Stream> MediaCreatingAsync(MediaCreatingContext context, Stream inputStream)
     {
         var outStream = MemoryStreamFactory.GetStream();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
@@ -76,6 +76,7 @@ public class MediaEventTests
 
 public class TestMediaEventHandler : IMediaCreatingEventHandler
 {
+    public int Priority => 0;
     public async Task<Stream> MediaCreatingAsync(MediaCreatingContext context, Stream inputStream)
     {
         var outStream = MemoryStreamFactory.GetStream();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
@@ -76,7 +76,7 @@ public class MediaEventTests
 
 public class TestMediaEventHandler : IMediaCreatingEventHandler
 {
-    public int Priority => 0;
+    public double Priority => 0;
 
     public async Task<Stream> MediaCreatingAsync(MediaCreatingContext context, Stream inputStream)
     {


### PR DESCRIPTION
Fix #19482 
