### PR TITLE
Fix Elasticsearch query source throwing when projecting result documents

### DIFF
--- a/src/OrchardCore/OrchardCore.Elasticsearch.Core/Services/ElasticsearchQuerySource.cs
+++ b/src/OrchardCore/OrchardCore.Elasticsearch.Core/Services/ElasticsearchQuerySource.cs
@@ -113,8 +113,9 @@ public sealed class ElasticsearchQuerySource : IQuerySource
 
             foreach (var document in docs.TopDocs)
             {
-                results.Add(new JsonObject(document.Value.Select(x =>
-                    KeyValuePair.Create(x.Key, (JsonNode)JsonValue.Create(x.Value)))));
+                results.Add(new JsonObject(document.Value
+                    .Where(x => x.Value is not null)
+                    .Select(x => KeyValuePair.Create(x.Key, x.Value.DeepClone()))));
             }
 
             elasticQueryResults.Items = results;


### PR DESCRIPTION
Closes #17716

When an Elasticsearch query does not return content items, the query source projects each
result document into a new `JsonObject`. That projection calls `JsonValue.Create(x.Value)`
where `x.Value` is a `JsonNode`, which throws:

    ArgumentException: A JsonNode cannot be used as a value. (Parameter 'value')

This means any result document containing at least one non-null field fails, so the
non-content-item path is broken rather than merely null-unsafe. The original report
(#17716) described a `NullReferenceException` from `x.Value.ToString()` on OC 2.1.6; that
call was removed in #19074, which introduced the current behaviour.

Skipping null values alone is not sufficient. The wrap still throws on non-null nodes.
Reusing the node directly is also not possible, as it is already parented to the source
document (`InvalidOperationException: The node already has a parent`), so the values are
deep-cloned.

## Changes

- `ElasticsearchQuerySource`: filter out null-valued fields and copy the remaining values
  with `DeepClone()` instead of wrapping them in `JsonValue.Create`.

## Notes

- Null-valued fields are now omitted from the projected document, which matches the
  behaviour requested in #17716.
- `ElasticsearchQueryService` and the Elasticsearch `AdminController` do not use this
  pattern and are unaffected. `LuceneQuerySource` performs a comparable projection but
  converts values with `GetStringValue()`, so it does not throw; it does still emit null
  entries. Left out of scope here. Probably a separate issue can be opened, if wanted.
- No unit test added: the projection is only reachable through
  `ExecuteQueryAsync` → `ElasticsearchQueryService.SearchAsync` →
  `ElasticsearchIndexManager.SearchAsync`, which is sealed and requires a live
  `ElasticsearchClient`, so there is no seam to test against without refactoring
  production code.
- No changelog entry: `src/docs/releases/4.0.0.md` currently has no bug-fix section, and I
  did not want to invent one. Happy to add it wherever you prefer.