### PR TITLE
Add expiration to prepared script cache entries

### DIFF
--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
@@ -10,7 +10,7 @@ public sealed class JavaScriptEngine : IScriptingEngine
 {
     private static readonly MemoryCacheEntryOptions ScriptCacheEntryOptions = new MemoryCacheEntryOptions()
         .SetSlidingExpiration(TimeSpan.FromMinutes(30))
-        .SetAbsoluteExpiration(TimeSpan.FromHours(2));
+        ;
 
     private readonly IMemoryCache _memoryCache;
     private readonly JintOptions _jintOptions;

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
@@ -8,6 +8,10 @@ namespace OrchardCore.Scripting.JavaScript;
 
 public sealed class JavaScriptEngine : IScriptingEngine
 {
+    private static readonly MemoryCacheEntryOptions ScriptCacheEntryOptions = new MemoryCacheEntryOptions()
+        .SetSlidingExpiration(TimeSpan.FromMinutes(30))
+        .SetAbsoluteExpiration(TimeSpan.FromHours(2));
+
     private readonly IMemoryCache _memoryCache;
     private readonly JintOptions _jintOptions;
 
@@ -31,7 +35,10 @@ public sealed class JavaScriptEngine : IScriptingEngine
     {
         var jsScope = GetJavaScriptScope(scope);
 
-        var parsedAst = _memoryCache.GetOrCreate(script, static entry => Engine.PrepareScript((string)entry.Key));
+        var parsedAst = _memoryCache.GetOrCreate(
+            script,
+            static entry => Engine.PrepareScript((string)entry.Key),
+            ScriptCacheEntryOptions);
 
         var result = jsScope.Engine.Evaluate(parsedAst).ToObject();
 
@@ -42,7 +49,10 @@ public sealed class JavaScriptEngine : IScriptingEngine
     {
         var jsScope = GetJavaScriptScope(scope);
 
-        var parsedAst = _memoryCache.GetOrCreate(script, static entry => Engine.PrepareScript((string)entry.Key));
+        var parsedAst = _memoryCache.GetOrCreate(
+            script,
+            static entry => Engine.PrepareScript((string)entry.Key),
+            ScriptCacheEntryOptions);
 
         var result = await jsScope.Engine.EvaluateAsync(parsedAst, cancellationToken);
 


### PR DESCRIPTION
Adds sliding and absolute expiration to prepared script cache entries.

This helps prevent the cache from retaining unique prepared scripts indefinitely when script text varies over time.

The configured policy uses:

- 30-minute sliding expiration
- 2-hour absolute expiration

This keeps frequently used scripts cached while allowing unused entries to be evicted automatically, reducing long-term memory usage.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

Fixes #19539.
