### PR TITLE
Dispose Bootstrap tooltips when hiding dependency buttons

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -266,6 +266,12 @@
 
                 transitiveDependencies.classList.toggle('d-none');
                 button.classList.toggle('d-none');
+
+                const tooltip = bootstrap.Tooltip.getInstance(button);
+
+                if (tooltip) {
+                    tooltip.dispose();
+                }
             });
         });
     });


### PR DESCRIPTION
Prevents lingering tooltips by disposing any existing Bootstrap
tooltip instance on the button when toggling its visibility.
Ensures a cleaner UI when transitive dependencies are shown or hidden.