### PR TITLE
Reorder tenants admin list pipeline to filter/sort/page before projec…

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
@@ -104,60 +104,61 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var allSettings = _shellHost.GetAllSettings().OrderBy(s => s.Name);
+        var allSettings = _shellHost.GetAllSettings();
         var dataProtector = _dataProtectorProvider.CreateProtector("Tokens").ToTimeLimitedDataProtector();
 
         var pager = new Pager(pagerParameters, _pagerOptions.GetPageSize());
 
-        var entries = allSettings.Select(settings =>
-           {
-               var entry = new ShellSettingsEntry
-               {
-                   Category = settings["Category"],
-                   Description = settings["Description"],
-                   Name = settings.Name,
-                   ShellSettings = settings,
-               };
-
-               if (settings.IsUninitialized() && !string.IsNullOrEmpty(settings["Secret"]))
-               {
-                   entry.Token = dataProtector.Protect(settings["Secret"], _clock.UtcNow.Add(new TimeSpan(24, 0, 0)));
-               }
-
-               return entry;
-           }).ToList();
+        var filteredSettings = allSettings;
 
         if (!string.IsNullOrWhiteSpace(options.Search))
         {
-            entries = entries.Where(t => t.Name.IndexOf(options.Search, StringComparison.OrdinalIgnoreCase) > -1 ||
-                (t.ShellSettings != null &&
-                 ((t.ShellSettings.RequestUrlHost != null && t.ShellSettings.RequestUrlHost.IndexOf(options.Search, StringComparison.OrdinalIgnoreCase) > -1) ||
-                 (t.ShellSettings.RequestUrlPrefix != null && t.ShellSettings.RequestUrlPrefix.IndexOf(options.Search, StringComparison.OrdinalIgnoreCase) > -1)))).ToList();
+            filteredSettings = filteredSettings.Where(settings =>
+                settings.Name.IndexOf(options.Search, StringComparison.OrdinalIgnoreCase) > -1 ||
+                (settings.RequestUrlHost != null && settings.RequestUrlHost.IndexOf(options.Search, StringComparison.OrdinalIgnoreCase) > -1) ||
+                (settings.RequestUrlPrefix != null && settings.RequestUrlPrefix.IndexOf(options.Search, StringComparison.OrdinalIgnoreCase) > -1));
         }
 
         if (!string.IsNullOrWhiteSpace(options.Category))
         {
-            entries = entries.Where(t => t.Category?.Equals(options.Category, StringComparison.OrdinalIgnoreCase) == true).ToList();
+            filteredSettings = filteredSettings.Where(settings => settings["Category"]?.Equals(options.Category, StringComparison.OrdinalIgnoreCase) == true);
         }
 
-        entries = options.Status switch
+        filteredSettings = options.Status switch
         {
-            TenantsState.Disabled => entries.Where(t => t.ShellSettings.IsDisabled()).ToList(),
-            TenantsState.Running => entries.Where(t => t.ShellSettings.IsRunning()).ToList(),
-            TenantsState.Uninitialized => entries.Where(t => t.ShellSettings.IsUninitialized()).ToList(),
-            _ => entries,
+            TenantsState.Disabled => filteredSettings.Where(settings => settings.IsDisabled()),
+            TenantsState.Running => filteredSettings.Where(settings => settings.IsRunning()),
+            TenantsState.Uninitialized => filteredSettings.Where(settings => settings.IsUninitialized()),
+            _ => filteredSettings,
         };
 
-        entries = options.OrderBy switch
+        var sortedSettings = (options.OrderBy switch
         {
-            TenantsOrder.Name => entries.OrderBy(t => t.Name).ToList(),
-            TenantsOrder.State => entries.OrderBy(t => t.ShellSettings?.State).ToList(),
-            _ => entries.OrderByDescending(t => t.Name).ToList(),
-        };
+            TenantsOrder.Name => filteredSettings.OrderBy(settings => settings.Name),
+            TenantsOrder.State => filteredSettings.OrderBy(settings => settings.State),
+            _ => filteredSettings.OrderByDescending(settings => settings.Name),
+        }).ToList();
 
-        var results = entries
+        var results = sortedSettings
             .Skip(pager.GetStartIndex())
-            .Take(pager.PageSize).ToList();
+            .Take(pager.PageSize)
+            .Select(settings =>
+            {
+                var entry = new ShellSettingsEntry
+                {
+                    Category = settings["Category"],
+                    Description = settings["Description"],
+                    Name = settings.Name,
+                    ShellSettings = settings,
+                };
+
+                if (settings.IsUninitialized() && !string.IsNullOrEmpty(settings["Secret"]))
+                {
+                    entry.Token = dataProtector.Protect(settings["Secret"], _clock.UtcNow.Add(new TimeSpan(24, 0, 0)));
+                }
+
+                return entry;
+            }).ToList();
 
         // Maintain previous route data when generating page links
         var routeData = new RouteData();
@@ -174,7 +175,7 @@ public sealed class AdminController : Controller
             routeData.Values.TryAdd("Options.Search", options.Search);
         }
 
-        var pagerShape = await _shapeFactory.PagerAsync(pager, entries.Count, routeData);
+        var pagerShape = await _shapeFactory.PagerAsync(pager, sortedSettings.Count, routeData);
 
         var model = new AdminIndexViewModel
         {
@@ -185,6 +186,7 @@ public sealed class AdminController : Controller
 
         // We populate the SelectLists
         model.Options.TenantsCategories = allSettings
+            .OrderBy(settings => settings.Name)
             .GroupBy(settings => settings["Category"])
             .Where(group => !string.IsNullOrEmpty(group.Key))
             .Select(group => new SelectListItem(group.Key, group.Key, string.Equals(options.Category, group.Key, StringComparison.OrdinalIgnoreCase)))

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/AdminControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/AdminControllerTests.cs
@@ -1,0 +1,134 @@
+using OrchardCore.Data;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.Implementation;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Removing;
+using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using OrchardCore.Recipes.Services;
+using OrchardCore.Tenants;
+using OrchardCore.Tenants.Controllers;
+using OrchardCore.Tenants.Services;
+using OrchardCore.Tenants.ViewModels;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Tenants;
+
+public class AdminControllerTests
+{
+    [Fact]
+    public async Task Index_FilteredAndSortedSettings_ArePagedAfterFilteringAndSorting()
+    {
+        var settings = new[]
+        {
+            CreateSettings("zeta", "Zeta description", running: true),
+            CreateSettings("alpha", "Alpha description", running: false),
+            CreateSettings("gamma", "Gamma description", running: true),
+            CreateSettings("beta", "Beta description", running: true),
+        };
+        var controller = CreateController(settings);
+
+        var result = await controller.Index(
+            new TenantIndexOptions
+            {
+                Status = TenantsState.Running,
+                OrderBy = TenantsOrder.Name,
+            },
+            new PagerParameters
+            {
+                Page = 2,
+                PageSize = 2,
+            });
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<AdminIndexViewModel>(viewResult.Model);
+        var entry = Assert.Single(model.ShellSettingsEntries);
+        Assert.Equal("zeta", entry.Name);
+        Assert.Equal("Zeta description", entry.Description);
+
+        var pager = Assert.IsAssignableFrom<IShape>((object)model.Pager);
+        Assert.Equal(3, pager.Properties["TotalItemCount"]);
+    }
+
+    private static ShellSettings CreateSettings(string name, string description, bool running)
+    {
+        var settings = new ShellSettings
+        {
+            Name = name,
+            ["Description"] = description,
+        };
+
+        return running ? settings.AsRunning() : settings.AsDisabled();
+    }
+
+    private static AdminController CreateController(IEnumerable<ShellSettings> settings)
+    {
+        var shellHost = new Mock<IShellHost>();
+        shellHost
+            .Setup(x => x.GetAllSettings())
+            .Returns(settings);
+
+        return new AdminController(
+            shellHost.Object,
+            Mock.Of<IShellSettingsManager>(),
+            Mock.Of<IShellRemovalManager>(),
+            CreateAuthorizationService().Object,
+            new ShellSettings { Name = ShellSettings.DefaultShellName }.AsRunning(),
+            Mock.Of<IFeatureProfilesService>(),
+            [],
+            new EphemeralDataProtectionProvider(),
+            Mock.Of<IClock>(),
+            Mock.Of<INotifier>(),
+            Mock.Of<ITenantValidator>(),
+            [],
+            Options.Create(new PagerOptions { PageSize = 2 }),
+            Options.Create(new TenantsOptions()),
+            null,
+            NullLogger<AdminController>.Instance,
+            new TestShapeFactory(),
+            Mock.Of<IStringLocalizer<AdminController>>(),
+            Mock.Of<IHtmlLocalizer<AdminController>>())
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    private static Mock<IAuthorizationService> CreateAuthorizationService()
+    {
+        var authorizationService = new Mock<IAuthorizationService>();
+        authorizationService
+            .Setup(x => x.AuthorizeAsync(
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<object>(),
+                It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
+            .ReturnsAsync(AuthorizationResult.Success());
+
+        return authorizationService;
+    }
+
+    private sealed class TestShapeFactory : IShapeFactory
+    {
+        public dynamic New => this;
+
+        public async ValueTask<IShape> CreateAsync(
+            string shapeType,
+            Func<ValueTask<IShape>> shapeFactory,
+            Action<ShapeCreatingContext> creating,
+            Action<ShapeCreatedContext> created)
+        {
+            var shape = await shapeFactory();
+
+            created?.Invoke(new ShapeCreatedContext
+            {
+                Shape = shape,
+                ShapeFactory = this,
+                ShapeType = shapeType,
+            });
+
+            return shape;
+        }
+    }
+}


### PR DESCRIPTION
Closes #19556

On instances with large numbers of tenants (thousands), the Tenants admin list page was slow to load because `AdminController.Index` built a full `ShellSettingsEntry`, including reads of Category, Description, and dataProtector.Protect for the Secret token for every single tenant before filtering, sorting, and paging down to the page actually shown. Since `Category`, `Description`, and `Secret` are backed by each tenant's lazily-loaded configuration, this forced a full config build for every tenant on every page load, even though only ~10 rows are ever rendered.

This PR reorders the pipeline so filtering, sorting, and paging happen first, using only the cheap fields already available from `tenants.json` (`Name`, `RequestUrlHost`, `RequestUrlPrefix`,` State`), and defers the expensive per-tenant projection (and token protection) to only the rows on the current page.

Changes

- Reordered `AdminController.Index`: filter (search/category/status) → sort → page → project into ShellSettingsEntry, instead of project → filter → sort → page.
- Search and status filtering now operate directly on `ShellSettings`' cheap `_settings`-backed properties instead of the fully-projected entry list.
- Category filtering reads `settings["Category"]` only when a category filter is actually applied, keeping the default (no filter) case fully cheap.
- `dataProtector.Protect` for the Secret token is now called only for the paged rows shown, not for every uninitialized tenant with a Secret.
- Removed the redundant `allSettings.OrderBy(s => s.Name)` that was immediately re-sorted later in the method.
- Added a targeted `.OrderBy(settings => settings.Name)` scoped to the Category dropdown's `GroupBy`, to preserve its original alphabetical ordering after removing the blanket sort above.
- Pager count now derived from the full filtered+sorted set (`sortedSettings.Count`) rather than the old post-projection `entries.Count`.

Notes

- Category dropdown caching (avoiding a full-tenant config scan to populate the dropdown itself) and the underlying `ShellSettingsManager` semaphore/async warmup improvements discussed in the issue are intentionally out of scope for this PR, since both are more structural/framework-level changes. Happy to follow up separately if useful.
- This is a pure reordering of existing logic; search/category/status filter semantics and sort/paging behavior are unchanged; only the order and cost of operations changed.


