### PR TITLE
Fix widget type stringification to use content type names

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -12,7 +12,7 @@
 
 @{
     var widgetContentTypes = Model.ContainedContentTypeDefinitions;
-    var widgetTypesStringified = string.Join(";", widgetContentTypes);
+    var widgetTypesStringified = string.Join(";", widgetContentTypes.Select(x => x.Name));
     var widgetTemplatePlaceholderId = Html.Id("widgetTemplatePlaceholder");
     var htmlFieldPrefix = ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix;
     var parentContentType = Model.FlowPart.ContentItem.ContentType;


### PR DESCRIPTION
Updated FlowPart.Edit.cshtml to join widget content type names
instead of objects, ensuring correct semicolon-separated output.

Fixes #19524