### PR TITLE
Fix ADLS Gen2 review findings

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,17 +48,16 @@ jobs:
         github.event.review.state == 'CHANGES_REQUESTED'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: ./.github/actions/setup-dotnet
     - name: Build
       run: |
         dotnet build -c Release ./test/OrchardCore.Tests.Integration/OrchardCore.Tests.Integration.csproj /p:NuGetAudit=false
     - name: Start Azurite
       run: |
-        docker run -d --name azurite -p 10000:10000 ghcr.io/skrypt/azurite-adls-gen2:latest azurite --blobHost 0.0.0.0 --skipApiVersionCheck --enableHierarchicalNamespace=true
+        docker run -d --name azurite -p 10000:10000 ghcr.io/skrypt/azurite-adls-gen2@sha256:39a3382dbf13aaa93d10515d4f3c6f994bb62f96c5b095d158d4ec367f2de7a4 azurite --blobHost 0.0.0.0 --skipApiVersionCheck --enableHierarchicalNamespace=true
     - name: Azure Blob Integration Tests
       env:
         AZURITE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
       run: |
         dotnet test --project ./test/OrchardCore.Tests.Integration/OrchardCore.Tests.Integration.csproj -c Release --no-build
-

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -101,7 +101,8 @@
     //  "BasePath": "some/base/path", // Optionally, set to a path to store media in a subdirectory inside your container. Templatable, refer to docs.
     //  "CreateContainer": true, // Activates an event to create the container if it does not already exist.
     //  "RemoveContainer": true, // Whether the 'Container' is deleted if the tenant is removed, false by default.
-    //  "RemoveFilesFromBasePath": true // Whether only the files under the given base path are deleted instead of the container if the tenant is removed, false by default.
+    //  "RemoveFilesFromBasePath": true, // Whether only the files under the given base path are deleted instead of the container if the tenant is removed, false by default.
+    //  "UseHierarchicalNamespace": true // Optional. Force Gen2/HNS behavior when account auto-detection is unavailable, such as with a container-scoped SAS token.
     //},
     // See http://127.0.0.1:8000/docs/reference/modules/Media.Azure/#configuration_1
     //"OrchardCore_Media_Azure_Image_Cache": {
@@ -139,7 +140,8 @@
     //  "ConnectionString": "", // Set to your Azure Storage account connection string.
     //  "ContainerName": "hostcontainer", // Set to the Azure Blob container name.
     //  "BasePath": "some/base/path", // Optionally, set to a subdirectory inside your container.
-    //  "MigrateFromFiles": true // Optionally, enable to migrate existing App_Data files to Blob automatically.
+    //  "MigrateFromFiles": true, // Optionally, enable to migrate existing App_Data files to Blob automatically.
+    //  "UseHierarchicalNamespace": true // Optional. Force Gen2/HNS behavior when account auto-detection is unavailable, such as with a container-scoped SAS token.
     //},
     // See https://docs.orchardcore.net/en/latest/reference/modules/Shells/#enable-database-shells-configuration to configure shell and tenant configuration in the database store.
     // Add '.AddDatabaseShellsConfiguration()' to your Host Startup AddOrchardCms() section.

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Services/MediaBlobContainerTenantEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Services/MediaBlobContainerTenantEvents.cs
@@ -43,13 +43,11 @@ public sealed class MediaBlobContainerTenantEvents : ModularTenantEvents
         }
         catch (Exception ex)
         {
-            // Don't let a failed capability probe (e.g. restricted SAS token, transient network
-            // error) take down the whole tenant. The store falls back to flat-namespace (Gen1)
-            // operations, which remain safe (if suboptimal) even against a Gen2 account.
+            // Don't let invalid HNS configuration take down the whole tenant. Namespace-sensitive
+            // operations will surface the configuration error when the media store is used.
             _logger.LogError(
                 ex,
-                "Unable to determine the Azure Media Storage account type (Gen1 flat namespace or Gen2 Hierarchical Namespace). " +
-                "Falling back to flat-namespace blob operations.");
+                "Unable to initialize the Azure Media Storage account type (Gen1 flat namespace or Gen2 Hierarchical Namespace).");
         }
 
         // Only create container if options are valid.

--- a/src/OrchardCore/OrchardCore.FileStorage.Abstractions/IFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.Abstractions/IFileStore.cs
@@ -42,46 +42,6 @@ public interface IFileStore
     IAsyncEnumerable<IFileStoreEntry> GetDirectoryContentAsync(string path = null, bool includeSubDirectories = false);
 
     /// <summary>
-    /// Enumerates only the files (not directories) in a given directory within the file store.
-    /// </summary>
-    /// <param name="path">The path of the directory to enumerate, or <c>null</c> to enumerate the root of the file store.</param>
-    /// <returns>The list of files in the given directory.</returns>
-    /// <remarks>
-    /// Default implementation filters <see cref="GetDirectoryContentAsync"/>. Implementations
-    /// may override this to avoid enumerating directories for better performance.
-    /// </remarks>
-    async IAsyncEnumerable<IFileStoreEntry> GetFilesAsync(string path = null)
-    {
-        await foreach (var entry in GetDirectoryContentAsync(path))
-        {
-            if (!entry.IsDirectory)
-            {
-                yield return entry;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Enumerates only the subdirectories in a given directory within the file store.
-    /// </summary>
-    /// <param name="path">The path of the directory to enumerate, or <c>null</c> to enumerate the root of the file store.</param>
-    /// <returns>The list of subdirectories in the given directory.</returns>
-    /// <remarks>
-    /// Default implementation filters <see cref="GetDirectoryContentAsync"/>. Implementations
-    /// may override this to avoid enumerating files for better performance.
-    /// </remarks>
-    async IAsyncEnumerable<IFileStoreEntry> GetDirectoriesAsync(string path = null)
-    {
-        await foreach (var entry in GetDirectoryContentAsync(path))
-        {
-            if (entry.IsDirectory)
-            {
-                yield return entry;
-            }
-        }
-    }
-
-    /// <summary>
     /// Creates a directory in the file store if it doesn't already exist.
     /// </summary>
     /// <param name="path">The path of the directory to be created.</param>

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -48,13 +48,14 @@ public class BlobFileStore : IFileStore
     private readonly ILogger _logger;
     private readonly bool? _useHierarchicalNamespaceOverride;
     private readonly SemaphoreSlim _capabilitiesLock = new(1, 1);
+    private bool _capabilitiesInitialized;
     private bool? _hnsEnabled;
 
     private readonly string _basePrefix;
 
     /// <summary>
     /// Whether the storage account has Hierarchical Namespace (ADLS Gen2) enabled, as determined by
-    /// <see cref="EnsureCapabilitiesAsync"/>. <c>null</c> until that method has run, or if it could
+    /// <see cref="EnsureCapabilitiesAsync"/>. <c>null</c> until detection has run, or if it could
     /// not determine the account type (in which case flat-namespace operations are used as a safe fallback).
     /// </summary>
     public bool? IsHierarchicalNamespaceEnabled => _hnsEnabled;
@@ -84,11 +85,11 @@ public class BlobFileStore : IFileStore
 
     /// <summary>
     /// Probes the storage account to determine whether Hierarchical Namespace (HNS) is enabled.
-    /// Must be called once at startup.
+    /// Namespace-sensitive operations call this automatically.
     /// </summary>
     public async Task EnsureCapabilitiesAsync()
     {
-        if (_hnsEnabled.HasValue)
+        if (_capabilitiesInitialized)
         {
             return;
         }
@@ -96,7 +97,7 @@ public class BlobFileStore : IFileStore
         await _capabilitiesLock.WaitAsync();
         try
         {
-            if (_hnsEnabled.HasValue)
+            if (_capabilitiesInitialized)
             {
                 return;
             }
@@ -149,11 +150,14 @@ public class BlobFileStore : IFileStore
             }
             catch (Exception ex)
             {
-                throw new FileStoreException(
+                _logger?.LogWarning(
+                    ex,
                     "Unable to determine the Azure Blob Storage account type (Gen1 flat namespace or Gen2 Hierarchical Namespace). " +
-                    "This is required to select the correct storage operations. " +
-                    "If you are using a container-scoped SAS token, set 'UseHierarchicalNamespace' explicitly in your configuration.", ex);
+                    "Falling back to flat-namespace operations. If you are using a container-scoped SAS token with a Gen2 account, " +
+                    "set 'UseHierarchicalNamespace' to 'true' explicitly in your configuration.");
             }
+
+            _capabilitiesInitialized = true;
         }
         finally
         {
@@ -184,6 +188,8 @@ public class BlobFileStore : IFileStore
 
     public async Task<IFileStoreEntry> GetDirectoryInfoAsync(string path)
     {
+        await EnsureCapabilitiesAsync();
+
         if (_hnsEnabled == true)
         {
             try
@@ -256,6 +262,8 @@ public class BlobFileStore : IFileStore
 
     private async IAsyncEnumerable<IFileStoreEntry> GetDirectoryContentByHierarchyAsync(string path = null)
     {
+        await EnsureCapabilitiesAsync();
+
         path = this.NormalizePath(path);
 
         var prefix = this.Combine(_basePrefix, path);
@@ -268,12 +276,7 @@ public class BlobFileStore : IFileStore
             if (blob.IsPrefix)
             {
                 var folderPath = blob.Prefix;
-                if (!string.IsNullOrEmpty(_basePrefix))
-                {
-                    folderPath = folderPath[(_basePrefix.Length - 1)..];
-                }
-
-                folderPath = folderPath.Trim('/');
+                folderPath = RemoveBasePrefix(folderPath);
 
                 if (blob.Blob is not null && blob.Blob.Properties is not null)
                 {
@@ -319,6 +322,8 @@ public class BlobFileStore : IFileStore
 
     private async IAsyncEnumerable<IFileStoreEntry> GetDirectoryContentFlatAsync(string path = null)
     {
+        await EnsureCapabilitiesAsync();
+
         path = this.NormalizePath(path);
 
         var prefix = this.Combine(_basePrefix, path);
@@ -334,11 +339,7 @@ public class BlobFileStore : IFileStore
                 if (blob.Metadata.TryGetValue("hdi_isfolder", out var value) &&
                     value.Equals("true", StringComparison.OrdinalIgnoreCase))
                 {
-                    var directoryName = name;
-                    if (!string.IsNullOrEmpty(_basePrefix))
-                    {
-                        directoryName = directoryName[(_basePrefix.Length - 1)..];
-                    }
+                    var directoryName = RemoveBasePrefix(name);
 
                     if (blob.Properties is not null)
                     {
@@ -361,10 +362,7 @@ public class BlobFileStore : IFileStore
                     continue;
                 }
 
-                if (!string.IsNullOrEmpty(_basePrefix))
-                {
-                    name = name[(_basePrefix.Length - 1)..];
-                }
+                name = RemoveBasePrefix(name);
 
                 yield return new BlobFile(name, blob.Properties.ContentLength, blob.Properties.LastModified);
             }
@@ -386,10 +384,7 @@ public class BlobFileStore : IFileStore
             var directory = Path.GetDirectoryName(name);
 
             // Strip base folder from directory name.
-            if (!string.IsNullOrEmpty(_basePrefix))
-            {
-                directory = directory[(_basePrefix.Length - 1)..];
-            }
+            directory = RemoveBasePrefix(directory);
 
             // Do not include root folder, or current path, or multiple folders in folder listing.
             if (!string.IsNullOrEmpty(directory) &&
@@ -404,27 +399,20 @@ public class BlobFileStore : IFileStore
             // Ignore directory marker files.
             if (!name.EndsWith(DirectoryMarkerFileName))
             {
-                if (!string.IsNullOrEmpty(_basePrefix))
-                {
-                    name = name[(_basePrefix.Length - 1)..];
-                }
-                yield return new BlobFile(name.Trim('/'), blob.Properties.ContentLength, blob.Properties.LastModified);
+                yield return new BlobFile(RemoveBasePrefix(name), blob.Properties.ContentLength, blob.Properties.LastModified);
             }
         }
     }
 
     public async Task<bool> TryCreateDirectoryAsync(string path)
     {
+        await EnsureCapabilitiesAsync();
+
         if (_hnsEnabled == true)
         {
             try
             {
-                var prefix = this.Combine(_basePrefix, path);
-                var directoryClient = _dataLakeFileSystemClient.GetDirectoryClient(prefix);
-                var response = await directoryClient.CreateIfNotExistsAsync();
-
-                // CreateIfNotExistsAsync returns null if it already existed.
-                return response is not null;
+                return await TryCreateDataLakeDirectoryAsync(path);
             }
             catch (Exception ex)
             {
@@ -478,6 +466,8 @@ public class BlobFileStore : IFileStore
 
     public async Task<bool> TryDeleteDirectoryAsync(string path)
     {
+        await EnsureCapabilitiesAsync();
+
         if (_hnsEnabled == true)
         {
             try
@@ -545,6 +535,8 @@ public class BlobFileStore : IFileStore
 
     public async Task MoveFileAsync(string oldPath, string newPath)
     {
+        await EnsureCapabilitiesAsync();
+
         if (_hnsEnabled == true)
         {
             try
@@ -721,6 +713,41 @@ public class BlobFileStore : IFileStore
         using var stream = new MemoryStream(MarkerFileContent);
 
         await placeholderBlob.UploadAsync(stream);
+    }
+
+    private async Task<bool> TryCreateDataLakeDirectoryAsync(string path)
+    {
+        var fullPath = this.Combine(_basePrefix, path);
+        var segments = fullPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var currentPath = string.Empty;
+        var targetCreated = false;
+
+        for (var i = 0; i < segments.Length; i++)
+        {
+            currentPath = this.Combine(currentPath, segments[i]);
+            var response = await _dataLakeFileSystemClient
+                .GetDirectoryClient(currentPath)
+                .CreateIfNotExistsAsync();
+
+            if (i == segments.Length - 1)
+            {
+                // CreateIfNotExistsAsync returns null if the target already existed.
+                targetCreated = response is not null;
+            }
+        }
+
+        return targetCreated;
+    }
+
+    private string RemoveBasePrefix(string path)
+    {
+        if (!string.IsNullOrEmpty(_basePrefix) &&
+            path.StartsWith(_basePrefix, StringComparison.Ordinal))
+        {
+            path = path[_basePrefix.Length..];
+        }
+
+        return path?.Trim('/');
     }
 
     /// <summary>

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobStorageOptions.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobStorageOptions.cs
@@ -19,14 +19,14 @@ public abstract class BlobStorageOptions
 
     /// <summary>
     /// Overrides auto-detection of Hierarchical Namespace (HNS / ADLS Gen2) support.
-    /// Leave <c>null</c> (default) to auto-detect via <c>GetAccountInfo</c> at startup.
-    /// Set to <c>true</c> or <c>false</c> to skip detection and force the behavior explicitly.
+    /// Leave <c>null</c> (default) to auto-detect via <c>GetAccountInfo</c>.
+    /// Set to <c>true</c> or <c>false</c> to select the behavior explicitly if detection fails.
     /// </summary>
     /// <remarks>
     /// Auto-detection requires storage account-level permissions. If you are using a
-    /// container-scoped SAS token, detection will fail and startup will be blocked.
-    /// In that case, set this to <c>true</c> for a Gen2 (HNS-enabled) account, or
-    /// <c>false</c> for a Gen1 (flat namespace) account.
+    /// container-scoped SAS token, detection can fail and the store will use flat-namespace
+    /// operations. In that case, set this to <c>true</c> for a Gen2 (HNS-enabled) account
+    /// to use native Data Lake operations, or <c>false</c> for a Gen1 account.
     /// </remarks>
     public bool? UseHierarchicalNamespace { get; set; }
 

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/Events/IMediaEventHandler.cs
@@ -13,7 +13,5 @@ public interface IMediaEventHandler
     Task MediaMovedAsync(MediaMoveContext context) => Task.CompletedTask;
     Task MediaCreatingDirectoryAsync(MediaCreatingContext context) => Task.CompletedTask;
     Task MediaCreatedDirectoryAsync(MediaCreatedContext context) => Task.CompletedTask;
-    Task MediaCreatedFileAsync(MediaCreatedContext context) => Task.CompletedTask;
-    Task MediaCopiedFileAsync(MediaMoveContext context) => Task.CompletedTask;
     Task MediaPermittedStorageAsync(MediaPermittedStorageContext context) => Task.CompletedTask;
 }

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
@@ -56,16 +56,6 @@ public class DefaultMediaFileStore : IMediaFileStore
         return _fileStore.GetDirectoryContentAsync(path, includeSubDirectories);
     }
 
-    public virtual IAsyncEnumerable<IFileStoreEntry> GetFilesAsync(string path = null)
-    {
-        return _fileStore.GetFilesAsync(path);
-    }
-
-    public virtual IAsyncEnumerable<IFileStoreEntry> GetDirectoriesAsync(string path = null)
-    {
-        return _fileStore.GetDirectoriesAsync(path);
-    }
-
     public virtual async Task<bool> TryCreateDirectoryAsync(string path)
     {
         var creatingContext = new MediaCreatingContext
@@ -155,8 +145,6 @@ public class DefaultMediaFileStore : IMediaFileStore
         }
 
         await _fileStore.CopyFileAsync(srcPath, dstPath);
-
-        await _mediaEventHandlers.InvokeAsync((handler, ctx) => handler.MediaCopiedFileAsync(ctx), new MediaMoveContext { OldPath = srcPath, NewPath = dstPath }, _logger);
     }
 
     public virtual Task<Stream> GetFileStreamAsync(string path)
@@ -275,10 +263,6 @@ public class DefaultMediaFileStore : IMediaFileStore
     {
         await ValidateAvailableStorageAsync(stream.Length);
 
-        var result = await _fileStore.CreateFileFromStreamAsync(path, stream, overwrite);
-
-        await _mediaEventHandlers.InvokeAsync((handler, ctx) => handler.MediaCreatedFileAsync(ctx), new MediaCreatedContext { Path = result }, _logger);
-
-        return result;
+        return await _fileStore.CreateFileFromStreamAsync(path, stream, overwrite);
     }
 }

--- a/src/docs/reference/modules/Media.Azure/README.md
+++ b/src/docs/reference/modules/Media.Azure/README.md
@@ -32,8 +32,8 @@ The following configuration values are used by default and can be customized:
       // Whether the 'Container' is deleted if the tenant is removed, false by default.
       "RemoveContainer": true,
       // Overrides auto-detection of Hierarchical Namespace (HNS / ADLS Gen2) support. Leave unset to
-      // auto-detect at startup. Set to 'true' or 'false' to skip detection and force the behavior
-      // explicitly, which is required when connecting with a container-scoped SAS token.
+      // auto-detect. Set explicitly when account-level detection is unavailable, such as when
+      // connecting with a container-scoped SAS token.
       "UseHierarchicalNamespace": true
     }
   }
@@ -54,17 +54,17 @@ If these are not present in `appSettings.json`, it will not enable the feature, 
 Azure Media Storage supports Azure Storage accounts with Hierarchical Namespace (HNS), also known as
 Azure Data Lake Storage Gen2, in addition to standard flat-namespace (Gen1) accounts.
 
-On startup, the store probes the storage account to auto-detect whether HNS is enabled. When it is,
+The store probes the storage account to auto-detect whether HNS is enabled. When it is,
 directory creation, directory deletion, and file moves use native Data Lake Storage APIs, which provide
 atomic moves and real (non-virtual) directories. On flat-namespace (Gen1) accounts, directories continue
 to be emulated with a marker file, matching the existing behavior.
 
 Auto-detection requires storage account-level permissions and will fail if you connect with a
 container-scoped SAS token. In that case, set `UseHierarchicalNamespace` explicitly to `true` for a
-Gen2 account or `false` for a Gen1 account to skip detection.
+Gen2 account or `false` for a Gen1 account so the configured behavior is used when detection fails.
 
-Data Lake Storage traffic is served over the same blob endpoint as regular blob operations, so no
-separate DFS endpoint configuration is required.
+The Data Lake SDK derives the account's DFS endpoint from the configured connection string, so no
+separate DFS endpoint setting is required.
 
 ### Templating Configuration
 

--- a/src/docs/reference/modules/Shells/README.md
+++ b/src/docs/reference/modules/Shells/README.md
@@ -45,7 +45,8 @@ The Azure Shells Configuration is configured via the `appsettings.json` section 
       "ConnectionString": "", // Set to your Azure Storage account connection string.
       "ContainerName": "hostcontainer", // Set to the Azure Blob container name.
       "BasePath": "some/base/path", // Optionally, set to a subdirectory inside your container.
-      "MigrateFromFiles": true // Optionally, enable to migrate existing App_Data files to Blob automatically.
+      "MigrateFromFiles": true, // Optionally, enable to migrate existing App_Data files to Blob automatically.
+      "UseHierarchicalNamespace": true // Optional. Force Gen2/HNS behavior when account auto-detection is unavailable.
     }
   }
 }
@@ -70,6 +71,8 @@ namespace OrchardCore.Cms.Web
 !!! note
     The container must be created before using the Azure Shells Configuration provider.
     Make sure this container is secure and access to keys is limited.
+    Hierarchical Namespace is detected automatically. Set `UseHierarchicalNamespace` explicitly when
+    account-level detection is unavailable, such as when connecting with a container-scoped SAS token.
 
 ## Database Shells Configuration Provider
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -20,12 +20,12 @@ Static assets are excluded from the tenant rate limiter because the middleware i
 
 ### Azure Blob Storage Gen2 (ADLS Hierarchical Namespace) Support
 
-`BlobFileStore` (used by Azure Media Storage and the Azure Media Image Cache) now supports Azure Storage accounts with Hierarchical Namespace (HNS / ADLS Gen2) enabled, in addition to standard flat-namespace (Gen1) accounts.
+`BlobFileStore` (used by Azure Media Storage and Azure Shells Configuration) now supports Azure Storage accounts with Hierarchical Namespace (HNS / ADLS Gen2) enabled, in addition to standard flat-namespace (Gen1) accounts.
 
-- On startup, the store probes the account via `GetAccountInfo` to auto-detect whether HNS is enabled.
+- Before a namespace-sensitive operation, the store probes the account via `GetAccountInfo` to auto-detect whether HNS is enabled. Azure Media Storage also performs this probe during tenant activation.
 - When HNS is detected, directory creation/deletion and file moves use native Azure Data Lake Storage APIs, giving atomic moves and real (non-virtual) directories instead of the marker-file emulation used on Gen1 accounts.
-- A new `UseHierarchicalNamespace` setting on the Azure Media Storage configuration (`OrchardCore_Media_Azure`) lets you skip auto-detection and force Gen1 or Gen2 behavior explicitly. This is required when connecting with a container-scoped SAS token, since account-level detection is not possible in that case. This override is not yet exposed for the Azure Media Image Cache (`OrchardCore_Media_Azure_Image_Cache`), which relies on auto-detection only.
-- Data Lake Storage traffic is served over the same blob endpoint, so no separate DFS endpoint configuration is needed.
+- A new `UseHierarchicalNamespace` setting on the Azure Media Storage configuration (`OrchardCore_Media_Azure`) lets you force Gen1 or Gen2 behavior when account-level detection is unavailable, such as when connecting with a container-scoped SAS token.
+- The Data Lake SDK derives the account's DFS endpoint from the configured connection string, so no separate DFS endpoint setting is needed.
 
 See the [Azure Media documentation](../reference/modules/Media.Azure/README.md) for configuration details.
 

--- a/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreGen2Tests.cs
+++ b/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreGen2Tests.cs
@@ -11,6 +11,8 @@ namespace OrchardCore.Tests.Integration.AzureBlob;
 /// </summary>
 public sealed class BlobFileStoreGen2Tests : BlobFileStoreTestsBase
 {
+    protected override string BasePath => "gen2/base";
+
     protected override async Task CreateContainerAsync(string connectionString, string containerName)
         => await new DataLakeServiceClient(connectionString)
             .GetFileSystemClient(containerName)
@@ -23,7 +25,7 @@ public sealed class BlobFileStoreGen2Tests : BlobFileStoreTestsBase
 
         // Gen2 creates real directory objects via the DataLake API — no marker blob.
         var blobs = new List<string>();
-        await foreach (var blob in ContainerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, "gen2-dir/", CancellationToken.None))
+        await foreach (var blob in ContainerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, $"{BasePath}/gen2-dir/", CancellationToken.None))
         {
             blobs.Add(blob.Name);
         }
@@ -39,6 +41,7 @@ public sealed class BlobFileStoreGen2Tests : BlobFileStoreTestsBase
         Assert.NotNull(await GetDirectoryInfoAsync("a/b/c"));
         Assert.NotNull(await GetDirectoryInfoAsync("a/b"));
         Assert.NotNull(await GetDirectoryInfoAsync("a"));
+        Assert.True(Store.IsHierarchicalNamespaceEnabled);
     }
 
     [AzuriteFact]
@@ -59,6 +62,7 @@ public sealed class BlobFileStoreGen2Tests : BlobFileStoreTestsBase
         Assert.Contains(entries, e => e.IsDirectory && e.Name == "subdir");
         Assert.Contains(entries, e => !e.IsDirectory && e.Name == "file.txt");
         Assert.Contains(entries, e => !e.IsDirectory && e.Name == "nested.txt");
+        Assert.DoesNotContain(entries, e => e.Path.StartsWith('/'));
     }
 
     [AzuriteFact]

--- a/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreTestsBase.cs
+++ b/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreTestsBase.cs
@@ -24,6 +24,8 @@ public abstract class BlobFileStoreTestsBase : IAsyncLifetime
     /// </summary>
     protected virtual bool? UseHierarchicalNamespaceOverride => null;
 
+    protected virtual string BasePath => "";
+
     /// <summary>
     /// Creates the test container. Gen1 uses the Blob SDK (flat namespace).
     /// Gen2 subclasses override to use the DataLake SDK, which stamps the container as an HNS filesystem.
@@ -37,6 +39,8 @@ public abstract class BlobFileStoreTestsBase : IAsyncLifetime
 
     protected BlobContainerClient ContainerClient => _containerClient;
 
+    protected BlobFileStore Store => _store;
+
     public async ValueTask InitializeAsync()
     {
         var connectionString = System.Environment.GetEnvironmentVariable(ConnectionStringEnvVar);
@@ -46,7 +50,7 @@ public abstract class BlobFileStoreTestsBase : IAsyncLifetime
         {
             ConnectionString = connectionString,
             ContainerName = _containerName,
-            BasePath = "",
+            BasePath = BasePath,
             UseHierarchicalNamespace = UseHierarchicalNamespaceOverride,
         };
 
@@ -57,7 +61,6 @@ public abstract class BlobFileStoreTestsBase : IAsyncLifetime
         var contentTypeProvider = new FileExtensionContentTypeProvider();
 
         _store = new BlobFileStore(options, clock, contentTypeProvider);
-        await _store.EnsureCapabilitiesAsync();
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
Addresses the high-confidence findings from the self-review of #19014.

- removes unused public enumeration and media-event APIs that had no optimized implementations or consumers
- makes HNS detection automatic for every namespace-sensitive `BlobFileStore` operation
- creates missing parent directories for native ADLS directory creation and fixes `BasePath` path leakage
- expands Gen2 integration coverage for lazy detection and non-empty base paths
- aligns Media and Azure Shells configuration samples and documentation with the implemented behavior
- pins the custom Azurite image and aligns the checkout action version

`dotnet build test/OrchardCore.Tests.Integration/OrchardCore.Tests.Integration.csproj -c Release /p:NuGetAudit=false` passes with no warnings. The Azurite-backed tests could not be run locally because Docker was unavailable.