### PR TITLE
Hide List Items button on Display action

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
@@ -9,6 +9,7 @@
 @inject IAuthorizationService AuthorizationService
 @inject IDataLocalizer D
 @{
+    var actionName = ViewContext.RouteData.Values["action"]?.ToString();
     var authorizedContentTypeDefinitions = new List<ContentTypeDefinition>();
     foreach (var contentTypeDefinition in Model.ContainedContentTypeDefinitions)
     {
@@ -24,7 +25,7 @@
     <div class="card-body">
         <div class="d-flex justify-content-end">
 
-            @if (await AuthorizationService.AuthorizeContentTypeDefinitionsAsync(User, CommonPermissions.ViewContent, Model.ContainedContentTypeDefinitions, ContentManager))
+            @if (await AuthorizationService.AuthorizeContentTypeDefinitionsAsync(User, CommonPermissions.ViewContent, Model.ContainedContentTypeDefinitions, ContentManager) && actionName != "Display")
             {
                 <a class="btn btn-secondary me-1" asp-action="Display" asp-controller="Admin" asp-route-contentItemId="@Model.Container.ContentItemId">@T["List Items"]</a>
             }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
@@ -25,7 +25,7 @@
     <div class="card-body">
         <div class="d-flex justify-content-end">
 
-            @if (await AuthorizationService.AuthorizeContentTypeDefinitionsAsync(User, CommonPermissions.ViewContent, Model.ContainedContentTypeDefinitions, ContentManager) && actionName != "Display")
+            @if (actionName != "Display" && await AuthorizationService.AuthorizeContentTypeDefinitionsAsync(User, CommonPermissions.ViewContent, Model.ContainedContentTypeDefinitions, ContentManager))
             {
                 <a class="btn btn-secondary me-1" asp-action="Display" asp-controller="Admin" asp-route-contentItemId="@Model.Container.ContentItemId">@T["List Items"]</a>
             }


### PR DESCRIPTION
The `List Items` doesn't make sense to show up on the `Display` action, because once the user clicks, it returns to the same action
