### PR TITLE
Fix stylesheet link in the decoupled Blazor CMS guide

### DIFF
--- a/src/docs/guides/create-blazor-cms/README.md
+++ b/src/docs/guides/create-blazor-cms/README.md
@@ -190,7 +190,7 @@ Now, your project explorer should look like the image below.
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <base href="/" />
                 <link rel="stylesheet" href="OrchardCore.Resources/Styles/bootstrap.min.css" />
-                <link rel="stylesheet" href="_content/BlazorCms.styles.css" />
+                <link rel="stylesheet" href="_content/BlazorCms/styles.css" />
                 <HeadOutlet />
             </head>
             

--- a/src/docs/guides/create-blazor-cms/README.md
+++ b/src/docs/guides/create-blazor-cms/README.md
@@ -190,7 +190,7 @@ Now, your project explorer should look like the image below.
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <base href="/" />
                 <link rel="stylesheet" href="OrchardCore.Resources/Styles/bootstrap.min.css" />
-                <link rel="stylesheet" href="_content/OCBlazor.styles.css" />
+                <link rel="stylesheet" href="@stylesheet" />
                 <HeadOutlet />
             </head>
             
@@ -199,6 +199,23 @@ Now, your project explorer should look like the image below.
                 <script src="_framework/blazor.web.js"></script>
             </body>
         </html>
+
+        @code {
+            private string stylesheet = "";
+
+            protected override void OnInitialized()
+            {
+                // Get the name of the host assembly, which is the one with the entry point,
+                // and use it to build the name of the blazor stylesheet.
+                var name = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .First(a => a.EntryPoint != null)
+                    .GetName()
+                    .Name;
+
+                stylesheet = $"{name}.styles.css";
+            }
+        }
     ```
 
 === "App.razor.css"

--- a/src/docs/guides/create-blazor-cms/README.md
+++ b/src/docs/guides/create-blazor-cms/README.md
@@ -190,7 +190,7 @@ Now, your project explorer should look like the image below.
                 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
                 <base href="/" />
                 <link rel="stylesheet" href="OrchardCore.Resources/Styles/bootstrap.min.css" />
-                <link rel="stylesheet" href="@stylesheet" />
+                <link rel="stylesheet" href="_content/BlazorCms.styles.css" />
                 <HeadOutlet />
             </head>
             
@@ -199,23 +199,6 @@ Now, your project explorer should look like the image below.
                 <script src="_framework/blazor.web.js"></script>
             </body>
         </html>
-
-        @code {
-            private string stylesheet = "";
-
-            protected override void OnInitialized()
-            {
-                // Get the name of the host assembly, which is the one with the entry point,
-                // and use it to build the name of the blazor stylesheet.
-                var name = AppDomain.CurrentDomain
-                    .GetAssemblies()
-                    .First(a => a.EntryPoint != null)
-                    .GetName()
-                    .Name;
-
-                stylesheet = $"{name}.styles.css";
-            }
-        }
     ```
 
 === "App.razor.css"


### PR DESCRIPTION
The `App.razor` sample in this guide hardcodes the scoped CSS bundle as `_content/OCBlazor.styles.css`, so following the guide leaves the stylesheet returning a 404. Blazor serves that bundle under the host application's assembly name rather than `OCBlazor`, so the sample now looks the name up from the entry assembly at runtime and works regardless of the project name. Follows the fix @Onman99 proposed in the issue.

Fixes #19114
