### PR TITLE
Docs: Recipe commands

### DIFF
--- a/src/docs/reference/modules/Recipes/README.md
+++ b/src/docs/reference/modules/Recipes/README.md
@@ -426,7 +426,7 @@ As `executionid` use a custom identifier to distinguish these recipe executions 
 
 ### `command`
 
-Runs one or more of the built-in commands, the same commands that are available on the command line. This is useful during setup or import, for example to create a user.
+Runs one or more of the built-in commands. This is useful during setup or import, for example to create a user.
 
 ```json
 {
@@ -437,7 +437,7 @@ Runs one or more of the built-in commands, the same commands that are available 
 }
 ```
 
-Each entry in `Commands` is a single command line, written exactly as you would type it on the command line: the command name followed by any `/Switch:value` arguments.
+Each entry in `Commands` is a single command: the command name followed by any `/Switch:value` arguments.
 
 The command most useful in recipes is `createUser`, which provisions a user during setup or import. See the [Users documentation](../Users/README.md#commands) for its switches.
 

--- a/src/docs/reference/modules/Recipes/README.md
+++ b/src/docs/reference/modules/Recipes/README.md
@@ -424,6 +424,27 @@ As `executionid` use a custom identifier to distinguish these recipe executions 
 
 ---
 
+### `command`
+
+Runs one or more of the built-in commands, the same commands that are available on the command line. This is useful during setup or import, for example to create a user.
+
+```json
+{
+  "name": "command",
+  "Commands": [
+    "createUser /UserName:admin /Password:Password1! /Email:admin@example.com /Roles:Administrator"
+  ]
+}
+```
+
+Each entry in `Commands` is a single command line, written exactly as you would type it on the command line: the command name followed by any `/Switch:value` arguments.
+
+The command most useful in recipes is `createUser`, which provisions a user during setup or import. See the [Users documentation](../Users/README.md#commands) for its switches.
+
+Other commands, such as `help commands` (lists every available command) and `recipes harvest` (lists the available recipes), write their result to the log and are meant for interactive or diagnostic use rather than for imports. Run `help commands` to see the full list of commands registered by the enabled features.
+
+---
+
 ## Recipe Migrations
 
 **Recipe migrations** allow you to perform updates using Orchard Core recipe files. These migrations are especially useful for updating metadata such as content types, workflows, settings, or any other component that can be updated via a recipe.

--- a/src/docs/reference/modules/Users/README.md
+++ b/src/docs/reference/modules/Users/README.md
@@ -233,6 +233,33 @@ User module settings can be configured using the `Settings` recipe step:
 }
 ```
 
+## Commands
+
+The Users module registers the `createUser` command, which you can run from the command line or from a recipe's [`command` step](../Recipes/README.md#command).
+
+```text
+createUser /UserName:<username> /Password:<password> /Email:<email> /PhoneNumber:<phonenumber> /Roles:{rolename,rolename,...}
+```
+
+| Switch        | Description                                                                        |
+|---------------|-----------------------------------------------------------------------------------|
+| `UserName`    | The username of the new user.                                                     |
+| `Password`    | The password of the new user. It has to satisfy the configured password rules.    |
+| `Email`       | The email address of the new user. It's created as confirmed.                     |
+| `PhoneNumber` | The phone number of the new user. Optional.                                       |
+| `Roles`       | A comma-separated list of the roles to assign to the user. Optional.              |
+
+For example, to create an administrator during setup from a recipe:
+
+```json
+{
+  "name": "command",
+  "Commands": [
+    "createUser /UserName:admin /Password:Password1! /Email:admin@example.com /Roles:Administrator"
+  ]
+}
+```
+
 ## Videos
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/78m04Inmilw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/docs/reference/modules/Users/README.md
+++ b/src/docs/reference/modules/Users/README.md
@@ -235,7 +235,7 @@ User module settings can be configured using the `Settings` recipe step:
 
 ## Commands
 
-The Users module registers the `createUser` command, which you can run from the command line or from a recipe's [`command` step](../Recipes/README.md#command).
+The Users module registers the `createUser` command, which you can run from a recipe's [`command` step](../Recipes/README.md#command).
 
 ```text
 createUser /UserName:<username> /Password:<password> /Email:<email> /PhoneNumber:<phonenumber> /Roles:{rolename,rolename,...}
@@ -245,7 +245,7 @@ createUser /UserName:<username> /Password:<password> /Email:<email> /PhoneNumber
 |---------------|-----------------------------------------------------------------------------------|
 | `UserName`    | The username of the new user.                                                     |
 | `Password`    | The password of the new user. It has to satisfy the configured password rules.    |
-| `Email`       | The email address of the new user. It's created as confirmed.                     |
+| `Email`       | The email address of the new user, which is marked as confirmed on creation.      |
 | `PhoneNumber` | The phone number of the new user. Optional.                                       |
 | `Roles`       | A comma-separated list of the roles to assign to the user. Optional.              |
 


### PR DESCRIPTION
Fixes #19477

Documents the `command` recipe step and the built-in `createUser` command. Adds a `command` step section to the Recipes reference, and a Commands section to the Users reference listing the `createUser` switches.