### PR TITLE
Namespace the prepared script cache and stop caching per-user login scripts

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/ScriptExternalLoginEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/ScriptExternalLoginEventHandler.cs
@@ -10,6 +10,11 @@ namespace OrchardCore.Users.Handlers;
 
 public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
 {
+    // The scripts are prepared and cached by their source text, so the per-user state must be handed to
+    // the script through a global method rather than being serialized into the script itself. Otherwise
+    // every external login would add a distinct entry to the shared cache.
+    private const string ContextMethodName = "externalLoginContext";
+
     private readonly ILogger _logger;
     private readonly IScriptingManager _scriptingManager;
     private readonly ISiteService _siteService;
@@ -43,9 +48,9 @@ public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
                 externalClaims = claims,
             };
 
-            var script = $"js: function generateUsername(context) {{\n{registrationSettings.GenerateUsernameScript}\n}}\nvar context = {JConvert.SerializeObject(context, JOptions.CamelCase)};\ngenerateUsername(context);\nreturn context;";
+            var script = $"js: function generateUsername(context) {{\n{registrationSettings.GenerateUsernameScript}\n}}\nvar context = JSON.parse({ContextMethodName}());\ngenerateUsername(context);\nreturn context;";
 
-            dynamic evaluationResult = await _scriptingManager.EvaluateAsync(script, null, null, null);
+            dynamic evaluationResult = await _scriptingManager.EvaluateAsync(script, null, null, [CreateContextMethodProvider(context)]);
 
             if (evaluationResult is IDictionary<string, object> data && data.TryGetValue("userName", out var userNameObj))
             {
@@ -70,8 +75,8 @@ public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
             return;
         }
 
-        var script = $"js: function syncRoles(context) {{\n{loginSettings.SyncPropertiesScript}\n}}\nvar context={JConvert.SerializeObject(context, JOptions.CamelCase)};\nsyncRoles(context);\nreturn context;";
-        dynamic evaluationResult = await _scriptingManager.EvaluateAsync(script, null, null, null);
+        var script = $"js: function syncRoles(context) {{\n{loginSettings.SyncPropertiesScript}\n}}\nvar context = JSON.parse({ContextMethodName}());\nsyncRoles(context);\nreturn context;";
+        dynamic evaluationResult = await _scriptingManager.EvaluateAsync(script, null, null, [CreateContextMethodProvider(context)]);
         context.RolesToAdd.AddRange((evaluationResult.rolesToAdd as object[]).Select(i => i.ToString()));
         context.RolesToRemove.AddRange((evaluationResult.rolesToRemove as object[]).Select(i => i.ToString()));
 
@@ -103,5 +108,24 @@ public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
                 }
             }
         }
+    }
+
+    private static ContextMethodProvider CreateContextMethodProvider(object context)
+        => new(JConvert.SerializeObject(context, JOptions.CamelCase));
+
+    private sealed class ContextMethodProvider : IGlobalMethodProvider
+    {
+        private readonly GlobalMethod _globalMethod;
+
+        public ContextMethodProvider(string serializedContext)
+        {
+            _globalMethod = new GlobalMethod
+            {
+                Name = ContextMethodName,
+                Method = _ => (Func<string>)(() => serializedContext),
+            };
+        }
+
+        public IEnumerable<GlobalMethod> GetMethods() => [_globalMethod];
     }
 }

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
@@ -1,3 +1,4 @@
+using Acornima.Ast;
 using Jint;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
@@ -35,12 +36,7 @@ public sealed class JavaScriptEngine : IScriptingEngine
     {
         var jsScope = GetJavaScriptScope(scope);
 
-        var parsedAst = _memoryCache.GetOrCreate(
-            script,
-            static entry => Engine.PrepareScript((string)entry.Key),
-            ScriptCacheEntryOptions);
-
-        var result = jsScope.Engine.Evaluate(parsedAst).ToObject();
+        var result = jsScope.Engine.Evaluate(PrepareScript(script)).ToObject();
 
         return result;
     }
@@ -49,15 +45,16 @@ public sealed class JavaScriptEngine : IScriptingEngine
     {
         var jsScope = GetJavaScriptScope(scope);
 
-        var parsedAst = _memoryCache.GetOrCreate(
-            script,
-            static entry => Engine.PrepareScript((string)entry.Key),
-            ScriptCacheEntryOptions);
-
-        var result = await jsScope.Engine.EvaluateAsync(parsedAst, cancellationToken);
+        var result = await jsScope.Engine.EvaluateAsync(PrepareScript(script), cancellationToken);
 
         return result.ToObject();
     }
+
+    private Prepared<Script> PrepareScript(string script)
+        => _memoryCache.GetOrCreate(
+            new PreparedScriptCacheKey(script),
+            static entry => Engine.PrepareScript(((PreparedScriptCacheKey)entry.Key).Script),
+            ScriptCacheEntryOptions);
 
     private static JavaScriptScope GetJavaScriptScope(IScriptingScope scope)
     {
@@ -68,4 +65,11 @@ public sealed class JavaScriptEngine : IScriptingEngine
 
         return jsScope;
     }
+
+    /// <summary>
+    /// Namespaces the prepared script entries stored in the shared <see cref="IMemoryCache"/>. Using a
+    /// dedicated key type instead of the raw script text guarantees that a key registered by another
+    /// component cannot be read back as a prepared script.
+    /// </summary>
+    private readonly record struct PreparedScriptCacheKey(string Script);
 }

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -55,6 +55,13 @@ No breaking changes.
 
 ## Change Log
 
+### JavaScript Prepared Script Cache
+
+`JavaScriptEngine` caches the prepared (parsed) form of every script it evaluates in the shared `IMemoryCache`. Two problems were addressed:
+
+- The cache entries were keyed on the raw script text, so a key registered by any other component could be read back as a prepared script and throw an `InvalidCastException`. The entries are now namespaced with a dedicated key type.
+- `ScriptExternalLoginEventHandler` built its script by serializing the per-user context into the script source, which produced a unique script — and therefore a new cache entry holding a full syntax tree — for every external login. The context is now passed to the script through a scoped `externalLoginContext()` global method, so the cached script text only varies with the configured **Generate username** and **Sync properties** scripts.
+
 ### Multiple Content Types and Stereotypes in the Admin Contents List
 
 The `Contents` admin list action now supports filtering by multiple content type IDs or stereotypes while preserving the existing parameter names.

--- a/test/OrchardCore.Tests/Scripting/JavaScriptEngineTests.cs
+++ b/test/OrchardCore.Tests/Scripting/JavaScriptEngineTests.cs
@@ -1,0 +1,29 @@
+using OrchardCore.Scripting;
+using OrchardCore.Scripting.JavaScript;
+
+namespace OrchardCore.Tests.Scripting;
+
+public class JavaScriptEngineTests
+{
+    [Fact]
+    public void Evaluate_WhenTheScriptTextIsAlreadyUsedAsACacheKey_StillEvaluatesTheScript()
+    {
+        var services = new ServiceCollection()
+            .AddMemoryCache()
+            .AddScripting()
+            .AddJavaScriptEngine();
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        const string script = "return 1 + 1;";
+
+        // Another component of the application happens to use the same string as a cache key in the
+        // shared memory cache. Prepared scripts have to be namespaced so that they cannot collide.
+        serviceProvider.GetRequiredService<IMemoryCache>().Set(script, "an unrelated value");
+
+        var engine = serviceProvider.GetServices<IScriptingEngine>().First(engine => engine.Prefix == "js");
+        var scope = engine.CreateScope([], serviceProvider, null, null);
+
+        Assert.Equal(2, Convert.ToInt32(engine.Evaluate(scope, script)));
+    }
+}


### PR DESCRIPTION
`JavaScriptEngine` caches the prepared (parsed) form of every script it evaluates in the shared `IMemoryCache`, with a 30 minute sliding expiration. Two things are wrong with how that cache is used.

## The key is not namespaced

The entries are keyed on the raw script text:

```csharp
_memoryCache.GetOrCreate(
    script,
    static entry => Engine.PrepareScript((string)entry.Key),
    ScriptCacheEntryOptions);
```

`GetOrCreate<TItem>()` casts whatever it finds to `TItem`, so any other component that happens to use the same string as a cache key makes the evaluation throw. Added as a test, on `main`:

```
System.InvalidCastException : Unable to cast object of type 'System.String' to type 'Jint.Prepared`1[Acornima.Ast.Script]'.
   at Microsoft.Extensions.Caching.Memory.CacheExtensions.GetOrCreate[TItem](...)
   at OrchardCore.Scripting.JavaScript.JavaScriptEngine.Evaluate(IScriptingScope scope, String script)
```

The entries are now keyed with a dedicated private key type, so they cannot be confused with anyone else's.

## Every external login adds a cache entry

`ScriptExternalLoginEventHandler` builds its script by serializing the per-user context into the source:

```csharp
var script = $"js: function syncRoles(context) {{\n{loginSettings.SyncPropertiesScript}\n}}\nvar context={JConvert.SerializeObject(context, JOptions.CamelCase)};\nsyncRoles(context);\nreturn context;";
```

The serialized context contains the user, their claims and their roles, so every external login produces a script that has never been seen before, and therefore a new cache entry holding a full syntax tree, keyed on that user's own claims. The cache grows with the number of logins rather than with the number of configured scripts.

The context is now handed to the script by an `externalLoginContext()` global method scoped to the evaluation, and the script does `JSON.parse(externalLoginContext())`. The value the script receives is the same plain JavaScript object it received before, so the configured **Generate username** and **Sync properties** scripts are unaffected, and the script text now only varies with those settings. Not interpolating externally supplied claim values into script source is worth having on its own.

## Testing

`OrchardCore.Tests` in Release: 2438 passed, 1 skipped, 0 failed. `AccountControllerTests.ExternalLoginSignIn_Default_Succeeds`, which exercises `UpdateUserInternalAsync()` end to end with two different sync scripts, covers the second change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
