### PR TITLE
Update to Jint 4.15 and register the scripting globals lazily

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="GraphQL.DataLoader" Version="8.8.4" />
     <PackageVersion Include="GraphQL.MicrosoftDI" Version="8.8.4" />
     <PackageVersion Include="GraphQL.SystemTextJson" Version="8.8.4" />
-    <PackageVersion Include="Jint" Version="4.12.0" />
+    <PackageVersion Include="Jint" Version="4.15.3" />
     <PackageVersion Include="JsonPath.Net" Version="2.2.0" />
     <PackageVersion Include="HtmlSanitizer" Version="9.1.893-beta" />
     <PackageVersion Include="Microsoft.Extensions.Compliance.Redaction" Version="10.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Acornima" Version="1.6.2" />
     <PackageVersion Include="AnyAscii" Version="0.3.3" />
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="AWSSDK.S3" Version="4.0.100.3" />

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" />
+    <PackageReference Include="Acornima" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Html/OrchardCore.Html.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Html/OrchardCore.Html.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" />
+    <PackageReference Include="Acornima" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" />
+    <PackageReference Include="Acornima" />
     <PackageReference Include="Markdig" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
@@ -1,5 +1,7 @@
 using Acornima.Ast;
 using Jint;
+using Jint.Native;
+using Jint.Runtime.Descriptors;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
@@ -13,23 +15,42 @@ public sealed class JavaScriptEngine : IScriptingEngine
         .SetSlidingExpiration(TimeSpan.FromMinutes(30))
         ;
 
+    // The attributes Engine.SetValue(string, Delegate) gives a global, so that a lazily declared global is
+    // indistinguishable from an eagerly set one once it is materialized.
+    private const PropertyFlag GlobalPropertyFlags = PropertyFlag.NonEnumerable;
+
     private readonly IMemoryCache _memoryCache;
     private readonly JintOptions _jintOptions;
+    private readonly Dictionary<string, LazyGlobalMethod> _lazyGlobals;
 
-    public JavaScriptEngine(IMemoryCache memoryCache, IOptions<JintOptions> jintOptions)
+    public JavaScriptEngine(
+        IMemoryCache memoryCache,
+        IOptions<JintOptions> jintOptions,
+        IEnumerable<IGlobalMethodProvider> globalMethodProviders)
     {
         _memoryCache = memoryCache;
         _jintOptions = jintOptions.Value;
         _jintOptions.ExperimentalFeatures |= ExperimentalFeature.TaskInterop;
+        _lazyGlobals = RegisterLazyGlobals(_jintOptions, globalMethodProviders);
     }
 
     public string Prefix => "js";
 
+    /// <summary>
+    /// Creates a scope backed by a new engine.
+    /// </summary>
+    /// <remarks>
+    /// The globals of the registered <see cref="IGlobalMethodProvider"/> instances are installed on every
+    /// engine as lazy properties, whether or not <paramref name="methods"/> contains them. A lazy property
+    /// only builds its delegate when a script actually reads the name, so the ones a script does not use
+    /// cost nothing. Methods that are not registered by a provider, such as the ones a caller adds for a
+    /// single evaluation, are installed eagerly and take precedence over a registered global of the same name.
+    /// </remarks>
     public IScriptingScope CreateScope(IEnumerable<GlobalMethod> methods, IServiceProvider serviceProvider, IFileProvider fileProvider, string basePath)
     {
         var engine = new Engine(_jintOptions);
 
-        return new JavaScriptScope(engine, serviceProvider, methods);
+        return new JavaScriptScope(engine, serviceProvider, methods, _lazyGlobals);
     }
 
     public object Evaluate(IScriptingScope scope, string script)
@@ -72,4 +93,88 @@ public sealed class JavaScriptEngine : IScriptingEngine
     /// component cannot be read back as a prepared script.
     /// </summary>
     private readonly record struct PreparedScriptCacheKey(string Script);
+
+    /// <summary>
+    /// Declares the globals of the registered method providers on the shared options, so that every engine
+    /// built from them gets its own lazy property per global instead of a delegate that has to be created,
+    /// reflected over and wrapped up front. The options replay the declarations for each engine, so a global
+    /// is materialized at most once per engine, on the first read of its name.
+    /// </summary>
+    private static Dictionary<string, LazyGlobalMethod> RegisterLazyGlobals(JintOptions options, IEnumerable<IGlobalMethodProvider> globalMethodProviders)
+    {
+        var candidates = new Dictionary<string, GlobalMethod>(StringComparer.Ordinal);
+        var ambiguous = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var method in globalMethodProviders.SelectMany(provider => provider.GetMethods()))
+        {
+            if (!candidates.TryAdd(method.Name, method))
+            {
+                // Several providers contribute a global with the same name. Which one wins depends on the
+                // order they are set in, so leave them all to the eager path where that order is observable.
+                ambiguous.Add(method.Name);
+            }
+        }
+
+        var lazyGlobals = new Dictionary<string, LazyGlobalMethod>(candidates.Count, StringComparer.Ordinal);
+
+        foreach (var (name, method) in candidates)
+        {
+            // A method named 'x' with an asynchronous variant and a method named 'xAsync' would both claim
+            // the 'xAsync' global; keep those on the eager path as well.
+            if (ambiguous.Contains(name) || (method.AsyncMethod != null && candidates.ContainsKey(name + "Async")))
+            {
+                continue;
+            }
+
+            var hasSyncGlobal = method.Method != null;
+            var hasAsyncGlobal = method.AsyncMethod != null;
+
+            if (hasSyncGlobal)
+            {
+                var factory = method.Method;
+                options.AddLazyGlobal(name, engine => CreateGlobal(engine, name, factory), GlobalPropertyFlags);
+            }
+
+            if (hasAsyncGlobal)
+            {
+                var asyncName = name + "Async";
+                var factory = method.AsyncMethod;
+                options.AddLazyGlobal(asyncName, engine => CreateGlobal(engine, asyncName, factory), GlobalPropertyFlags);
+            }
+
+            if (hasSyncGlobal || hasAsyncGlobal)
+            {
+                lazyGlobals[name] = new LazyGlobalMethod(method, hasSyncGlobal, hasAsyncGlobal);
+            }
+        }
+
+        return lazyGlobals;
+    }
+
+    private static JsValue CreateGlobal(Engine engine, string name, Func<IServiceProvider, Delegate> factory)
+    {
+        // The factory captures the services it is given, so the delegate has to be built with the services
+        // of the scope that owns this engine, and cannot be shared between engines.
+        if (!JavaScriptScope.TryGetServiceProvider(engine, out var serviceProvider))
+        {
+            // The lazy property stores whatever this returns and never runs again, so returning a value here
+            // would leave the global permanently undefined and fail as 'x is not a function' somewhere else.
+            // Reaching this means an engine was built from these options without a scope, which is a defect
+            // in the caller rather than a state a script should have to cope with.
+            throw new InvalidOperationException(
+                $"No scripting scope is associated with the engine reading the global '{name}'. Engines that expose the globals of the registered {nameof(IGlobalMethodProvider)} instances must be created through {nameof(IScriptingEngine)}.{nameof(CreateScope)}.");
+        }
+
+        // This is only equivalent to what Engine.SetValue(string, Delegate) installs while no IObjectConverter
+        // is registered on the options: FromObject consults the registered converters before it falls back to
+        // wrapping the delegate, so a converter handling Delegate would give a materialized global a different
+        // shape than an eagerly set one, in the same engine.
+        return JsValue.FromObject(engine, factory(serviceProvider));
+    }
+
+    /// <summary>
+    /// A <see cref="GlobalMethod"/> whose globals are declared on the engine options, and which of the two
+    /// globals it can contribute are covered by that declaration.
+    /// </summary>
+    internal readonly record struct LazyGlobalMethod(GlobalMethod Method, bool HasSyncGlobal, bool HasAsyncGlobal);
 }

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptScope.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptScope.cs
@@ -1,22 +1,52 @@
+using System.Runtime.CompilerServices;
 using Jint;
 
 namespace OrchardCore.Scripting.JavaScript;
 
 public class JavaScriptScope : IScriptingScope
 {
+    // A lazily registered global is only materialized when a script reads it, which happens long after
+    // the engine was built. The delegate it wraps is produced by a factory that takes the service
+    // provider of the evaluation it belongs to, so the engine has to be able to find its scope back.
+    // The table holds the engine weakly, so an entry disappears together with the engine that keys it.
+    private static readonly ConditionalWeakTable<Engine, IServiceProvider> _engineServiceProviders = new();
+
     public JavaScriptScope(Engine engine, IServiceProvider serviceProvider, IEnumerable<GlobalMethod> methods)
+        : this(engine, serviceProvider, methods, lazyGlobals: null)
+    {
+    }
+
+    internal JavaScriptScope(
+        Engine engine,
+        IServiceProvider serviceProvider,
+        IEnumerable<GlobalMethod> methods,
+        IReadOnlyDictionary<string, JavaScriptEngine.LazyGlobalMethod> lazyGlobals)
     {
         Engine = engine;
         ServiceProvider = serviceProvider;
-        
+
+        _engineServiceProviders.AddOrUpdate(engine, serviceProvider);
+
         foreach (var method in methods)
         {
-            if (method.Method != null)
+            // The globals of the registered method providers are already installed on the engine as lazy
+            // properties, so nothing has to be created for them here. Any other method, including one that
+            // shadows a registered name, is set eagerly and replaces the lazy property.
+            var lazyGlobal = default(JavaScriptEngine.LazyGlobalMethod);
+
+            if (lazyGlobals != null
+                && lazyGlobals.TryGetValue(method.Name, out var candidate)
+                && ReferenceEquals(candidate.Method, method))
+            {
+                lazyGlobal = candidate;
+            }
+
+            if (method.Method != null && !lazyGlobal.HasSyncGlobal)
             {
                 Engine.SetValue(method.Name, method.Method(ServiceProvider));
             }
-            
-            if (method.AsyncMethod != null)
+
+            if (method.AsyncMethod != null && !lazyGlobal.HasAsyncGlobal)
             {
                 Engine.SetValue(method.Name + "Async", method.AsyncMethod(ServiceProvider));
             }
@@ -26,4 +56,10 @@ public class JavaScriptScope : IScriptingScope
     public Engine Engine { get; }
 
     public IServiceProvider ServiceProvider { get; }
+
+    /// <summary>
+    /// Gets the services of the scope that owns the given engine.
+    /// </summary>
+    internal static bool TryGetServiceProvider(Engine engine, out IServiceProvider serviceProvider)
+        => _engineServiceProviders.TryGetValue(engine, out serviceProvider);
 }

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -55,7 +55,37 @@ The File scripting engine provides methods to read file contents.
 
 ## JavaScript `OrchardCore.Scripting.JavaScript`
 
-The JavaScript scripting module implements a `IScriptingEngine` that uses [Esprima.NET](https://github.com/sebastienros/esprima-dotnet) to evaluate scripts.
+The JavaScript scripting module implements an `IScriptingEngine` that uses [Jint](https://github.com/sebastienros/jint) to evaluate scripts.
+
+### Configuring the JavaScript engine
+
+The engine is configured through Jint's own options type, which is registered as `IOptions<Jint.Options>`:
+
+```csharp
+services.Configure<Jint.Options>(options =>
+{
+    options.MaxStatements(10_000);
+    options.TimeoutInterval(TimeSpan.FromSeconds(5));
+});
+```
+
+Three things are worth knowing about how that instance is used:
+
+- **One `Jint.Options` instance is shared by every engine of the tenant.** Configure only settings that make sense for the whole tenant, since the same options serve recipe execution, workflow scripts and layer rules alike. Use the constraint helpers shown above (`MaxStatements`, `TimeoutInterval`, `LimitMemory`, `CancellationToken`): each of them registers a *factory*, so every engine gets its own counter and its own deadline and the shared instance stays safe for concurrent requests. Registering a constraint *instance* — `options.Constraint(new MyConstraint())` — shares that instance, and with it its per-execution state, across every concurrently running engine of the tenant. Derive from `Jint.Constraint` and register it with the factory overload, `options.Constraint(() => new MyConstraint())`, instead.
+- **A limit spelled as a saturated or absent value registers nothing.** `MaxStatements(int.MaxValue)`, `LimitMemory(long.MaxValue)` and `TimeoutInterval(TimeSpan.MaxValue)` produce exactly the same engine as never calling the method, and additionally remove any limit of that kind set earlier. The same is true of `MaxStatements()` with no argument: its parameter defaults to `0`, and only a positive budget registers a constraint, so that call reads like it turns a statement limit on while leaving the statement count unlimited. Always pass the budget you mean, and omit the call rather than passing a maximum value.
+- **Do not register an `IObjectConverter` that handles `Delegate`.** Global methods are `Delegate` values, and converters are consulted before Jint's own delegate wrapping, so such a converter would change the shape of the globals that are created on demand while leaving the eagerly created ones alone.
+
+No execution constraints are configured by default, so a script such as `while (true) {}` runs until the process is recycled. Sites that let non-administrators author scripts should set at least one.
+
+### Global methods are created on demand
+
+The globals contributed by `IGlobalMethodProvider` implementations are declared on every engine but are not built until a script reads the name. A recipe expression such as `[js:uuid()]` therefore only pays for `uuid`, not for every registered global. This is not observable from script — the properties exist, they are non-enumerable, and the value a name resolves to is stable for the whole evaluation — but the `Func<IServiceProvider, Delegate>` you supply is invoked lazily, and not at all when the script does not use the method. Keep it free of side effects that the surrounding code depends on.
+
+Three kinds of method are created eagerly instead, so a factory backing one of them runs once per engine whether or not the script uses it:
+
+- Methods passed directly to `IScriptingEngine.CreateScope()` rather than registered through DI, such as a recipe's `variables()` or a workflow's `workflow()`. These also take precedence over a registered global of the same name.
+- A name contributed by more than one registered provider, because which provider wins depends on the order the methods are set in.
+- A method carrying an asynchronous variant whose `<name>Async` global is also claimed by a method literally named `<name>Async`.
 
 ### Methods
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -51,7 +51,22 @@ This feature integrates with the shared file upload security pipeline through `I
 
 ## Breaking Changes
 
-No breaking changes.
+### `JavaScriptEngine` Constructor
+
+`OrchardCore.Scripting.JavaScript.JavaScriptEngine` is public, and its constructor gained a third parameter, the registered `IGlobalMethodProvider` instances:
+
+```csharp
+public JavaScriptEngine(
+    IMemoryCache memoryCache,
+    IOptions<Jint.Options> jintOptions,
+    IEnumerable<IGlobalMethodProvider> globalMethodProviders)
+```
+
+Resolving `IScriptingEngine` from the service provider is unaffected. Code that constructs the type directly — in practice, test code — has to pass the providers, and may pass an empty sequence to get the previous behavior.
+
+### Globals Exposed by `IScriptingEngine.CreateScope()`
+
+Every engine created by `JavaScriptEngine` now exposes the globals of the registered `IGlobalMethodProvider` instances, whether or not those methods appear in the `methods` argument of `CreateScope()`. Both in-tree callers always pass all of them, so this is not observable in Orchard Core itself, but a caller that deliberately passed a restricted set to hide a global no longer gets that effect. Methods passed in `methods` still take precedence over a registered global of the same name.
 
 ## Change Log
 
@@ -65,6 +80,32 @@ No breaking changes.
 ### JavaScript Rule Condition Validation
 
 Saving a JavaScript rule condition that contains a syntax error no longer fails with an unhandled exception. `Engine.PrepareScript()` wraps parser failures in `Jint.ScriptPreparationException`, which is now caught by the condition editor and reported as the intended validation message.
+
+### JavaScript Engine Update
+
+The bundled JavaScript engine, Jint, was updated. Besides enabling the lazy globals described below, it changes two things that matter to sites configuring `IOptions<Jint.Options>`:
+
+- **The execution-constraint helpers are now safe on the shared options instance.** `MaxStatements()`, `TimeoutInterval()`, `LimitMemory()` and `CancellationToken()` register a factory rather than a constraint object, so each engine gets its own statement counter and its own deadline. One `Jint.Options` is shared by every engine of a tenant, so before this a configured constraint would have shared its per-execution state — and its resets — between concurrently running requests. Registering a constraint *instance* through `options.Constraint(constraint)` still shares it; use the `options.Constraint(() => new MyConstraint())` overload.
+- **Resolved CLR members are now cached across engines** rather than per engine. Since a new engine is built for nearly every evaluation, the reflection to resolve and compile access to a member of `HttpContext`, `ContentItem` or a workflow context used to be repeated for each one.
+
+See the [Scripting documentation](../reference/modules/Scripting/README.md#configuring-the-javascript-engine) for the current behavior.
+
+### Lazily Registered JavaScript Globals
+
+The globals contributed by `IGlobalMethodProvider` implementations are no longer created up front for every engine. `JavaScriptEngine` declares them on the shared Jint options with `Options.AddLazyGlobal()`, so each engine gets a lazy property per global and the delegate behind it is only built when a script reads the name. Because `DefaultScriptingManager` creates an engine per evaluation, a directive such as `[js:uuid()]` used to install every registered global — around forty on a typical site — in order to call one of them.
+
+Points worth knowing:
+
+- The properties themselves are installed as before, so `in`, `hasOwnProperty()` and `Object.getOwnPropertyNames()` still see every global. They remain non-enumerable, so `Object.keys(globalThis)` does not list them, exactly as with `Engine.SetValue()`.
+- The value is cached by the engine after the first read, so the identity of a global is stable for the whole evaluation.
+- Deleting a global before ever reading it means its delegate is never built. Assigning to it or redefining it does build it once and then discards the result. The end state is correct in every case; only the laziness is lost.
+- Every engine created by `JavaScriptEngine` exposes the globals of the registered method providers, whether or not they appear in the `methods` argument of `IScriptingEngine.CreateScope()`. Methods that are not registered by a provider — the ones a caller adds for a single evaluation, such as a recipe's `variables()` or a workflow's `workflow()` — are still installed eagerly, and take precedence over a registered global of the same name.
+
+`JavaScriptEngine` now takes the registered `IGlobalMethodProvider` instances as a constructor parameter; code that resolves `IScriptingEngine` from the service provider is unaffected.
+
+### Direct Acornima Dependency
+
+`OrchardCore.ContentFields`, `OrchardCore.Html` and `OrchardCore.Markdown` use `Acornima.Parser` to validate editor settings and reached it transitively through Jint. They now reference Acornima directly and no longer reference Jint.
 
 ### Multiple Content Types and Stereotypes in the Admin Contents List
 

--- a/test/OrchardCore.Tests/Scripting/JavaScriptScopeTests.cs
+++ b/test/OrchardCore.Tests/Scripting/JavaScriptScopeTests.cs
@@ -1,0 +1,142 @@
+using OrchardCore.Scripting;
+using OrchardCore.Scripting.JavaScript;
+
+namespace OrchardCore.Tests.Scripting;
+
+public class JavaScriptScopeTests
+{
+    [Fact]
+    public void RegisteredGlobals_AreNotBuiltWhenTheScriptDoesNotUseThem()
+    {
+        var (engine, methods, serviceProvider, provider) = CreateEngine();
+
+        var scope = engine.CreateScope(methods, serviceProvider, null, null);
+
+        Assert.Equal(0, provider.BuildCount);
+        Assert.Equal(1, Convert.ToInt32(engine.Evaluate(scope, "return 1;")));
+        Assert.Equal(0, provider.BuildCount);
+    }
+
+    [Fact]
+    public void RegisteredGlobals_AreBuiltOncePerEngine()
+    {
+        var (engine, methods, serviceProvider, provider) = CreateEngine();
+
+        var scope = engine.CreateScope(methods, serviceProvider, null, null);
+
+        Assert.Equal("counted", engine.Evaluate(scope, "return counted();"));
+        Assert.Equal(1, provider.BuildCount);
+
+        // The materialized value is kept by the engine, so the identity of the global is stable.
+        Assert.True((bool)engine.Evaluate(scope, "var first = counted; var second = counted; return first === second;"));
+        Assert.Equal(1, provider.BuildCount);
+
+        // A second scope gets its own engine, and therefore its own delegate built from its own services.
+        var otherScope = engine.CreateScope(methods, serviceProvider, null, null);
+
+        Assert.Equal("counted", engine.Evaluate(otherScope, "return counted();"));
+        Assert.Equal(2, provider.BuildCount);
+    }
+
+    [Fact]
+    public void RegisteredGlobals_AreNotEnumerable()
+    {
+        var (engine, methods, serviceProvider, _) = CreateEngine();
+
+        var scope = engine.CreateScope(methods, serviceProvider, null, null);
+
+        Assert.True((bool)engine.Evaluate(scope, "return Object.keys(globalThis).indexOf('counted') === -1;"));
+        Assert.True((bool)engine.Evaluate(scope, "return 'counted' in globalThis;"));
+    }
+
+    [Fact]
+    public void RegisteredGlobals_AreNotBuiltWhenTheScriptDeletesThemFirst()
+    {
+        var (engine, methods, serviceProvider, provider) = CreateEngine();
+
+        var scope = engine.CreateScope(methods, serviceProvider, null, null);
+
+        Assert.Equal("undefined", engine.Evaluate(scope, "delete globalThis.counted; return typeof counted;"));
+        Assert.Equal(0, provider.BuildCount);
+    }
+
+    [Fact]
+    public void ScopedMethods_TakePrecedenceOverRegisteredGlobalsOfTheSameName()
+    {
+        var (engine, methods, serviceProvider, provider) = CreateEngine();
+
+        var scopedMethod = new GlobalMethod
+        {
+            Name = "counted",
+            Method = _ => (Func<string>)(() => "scoped"),
+        };
+
+        var scope = engine.CreateScope(methods.Concat([scopedMethod]), serviceProvider, null, null);
+
+        Assert.Equal("scoped", engine.Evaluate(scope, "return counted();"));
+        Assert.Equal(0, provider.BuildCount);
+    }
+
+    [Fact]
+    public async Task AsynchronousGlobals_AreBuiltOnlyWhenUsed()
+    {
+        var (engine, methods, serviceProvider, provider) = CreateEngine();
+
+        var scope = engine.CreateScope(methods, serviceProvider, null, null);
+
+        Assert.Equal("counted async", await engine.EvaluateAsync(scope, "return countedAsync();", TestContext.Current.CancellationToken));
+        Assert.Equal(1, provider.AsyncBuildCount);
+
+        // The synchronous variant of the same method was not touched.
+        Assert.Equal(0, provider.BuildCount);
+    }
+
+    private static (IScriptingEngine Engine, IEnumerable<GlobalMethod> Methods, IServiceProvider ServiceProvider, CountingMethodProvider Provider) CreateEngine()
+    {
+        var provider = new CountingMethodProvider();
+
+        var serviceProvider = new ServiceCollection()
+            .AddMemoryCache()
+            .AddScripting()
+            .AddJavaScriptEngine()
+            .AddSingleton<IGlobalMethodProvider>(provider)
+            .BuildServiceProvider();
+
+        var scriptingManager = serviceProvider.GetRequiredService<IScriptingManager>();
+        var engine = scriptingManager.GetScriptingEngine("js");
+        var methods = scriptingManager.GlobalMethodProviders.SelectMany(p => p.GetMethods()).ToArray();
+
+        return (engine, methods, serviceProvider, provider);
+    }
+
+    private sealed class CountingMethodProvider : IGlobalMethodProvider
+    {
+        private readonly GlobalMethod _globalMethod;
+
+        public CountingMethodProvider()
+        {
+            _globalMethod = new GlobalMethod
+            {
+                Name = "counted",
+                Method = _ =>
+                {
+                    BuildCount++;
+
+                    return (Func<string>)(() => "counted");
+                },
+                AsyncMethod = _ =>
+                {
+                    AsyncBuildCount++;
+
+                    return (Func<Task<string>>)(() => Task.FromResult("counted async"));
+                },
+            };
+        }
+
+        public int BuildCount { get; private set; }
+
+        public int AsyncBuildCount { get; private set; }
+
+        public IEnumerable<GlobalMethod> GetMethods() => [_globalMethod];
+    }
+}

--- a/test/OrchardCore.Tests/Scripting/JintHostContractVerification.cs
+++ b/test/OrchardCore.Tests/Scripting/JintHostContractVerification.cs
@@ -1,0 +1,32 @@
+using System.Runtime.CompilerServices;
+
+namespace OrchardCore.Tests.Scripting;
+
+/// <summary>
+/// Turns on Jint's host-contract verifiers for the whole test run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The verifiers catch an object projected into script answering one of Jint's extension points in a way
+/// that contradicts another — a key that exists but is invisible to <c>Object.keys</c>, a read that resolves
+/// on the prototype for a property the object actually owns. The engine trusts those hooks on its fast paths
+/// rather than re-checking them, so a violation is otherwise silent rather than loud.
+/// </para>
+/// <para>
+/// Orchard Core defines no Jint types of its own today, so this currently has little to check. It is here as
+/// a tripwire: the moment a module projects a custom object into script — or a change to the wrap handler
+/// starts returning one — the contract is verified by the existing test run instead of by whatever
+/// misbehaves in production.
+/// </para>
+/// <para>
+/// The switch has to be set before the first use of any Jint type, because Jint reads it once at type
+/// initialization, hence the module initializer. It is deliberately confined to this test assembly: the
+/// verifiers redo work the paths they check exist to avoid, so this must not be set in a hosting app.
+/// </para>
+/// </remarks>
+internal static class JintHostContractVerification
+{
+    [ModuleInitializer]
+    internal static void Enable()
+        => AppContext.SetSwitch("Jint.EnableHostContractVerification", true);
+}

--- a/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
+++ b/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
@@ -511,9 +511,9 @@ public class WorkflowManagerTests
     private static JavaScriptWorkflowScriptEvaluator CreateWorkflowScriptEvaluator(IServiceProvider serviceProvider)
     {
         var memoryCache = new MemoryCache(new MemoryCacheOptions());
-        var javaScriptEngine = new JavaScriptEngine(memoryCache, Options.Create(new Jint.Options()));
-        var workflowContextHandlers = new Resolver<IEnumerable<IWorkflowExecutionContextHandler>>(serviceProvider);
         var globalMethodProviders = Array.Empty<IGlobalMethodProvider>();
+        var javaScriptEngine = new JavaScriptEngine(memoryCache, Options.Create(new Jint.Options()), globalMethodProviders);
+        var workflowContextHandlers = new Resolver<IEnumerable<IWorkflowExecutionContextHandler>>(serviceProvider);
         var scriptingManager = new DefaultScriptingManager(new[] { javaScriptEngine }, globalMethodProviders);
 
         return new JavaScriptWorkflowScriptEvaluator(


### PR DESCRIPTION
## The problem

`JavaScriptScope`'s constructor installs every registered `GlobalMethod` on the engine:

```csharp
foreach (var method in methods)
{
    if (method.Method != null)
    {
        Engine.SetValue(method.Name, method.Method(ServiceProvider));
    }

    if (method.AsyncMethod != null)
    {
        Engine.SetValue(method.Name + "Async", method.AsyncMethod(ServiceProvider));
    }
}
```

Each iteration invokes the method's delegate factory and then wraps the resulting delegate in a Jint function object, which reflects over the delegate's `Invoke` signature. With the full module set that is 40 globals from the 11 DI-registered providers — 30 synchronous and 10 `…Async`. `DefaultScriptingManager` creates an engine per evaluation, so a directive as small as `[js:uuid()]` pays for all forty in order to call one.

That shape is the common case rather than the corner case: across the 22 recipe files in this repository there are 208 `[js:…]` expressions, and all but a handful are a single call to a single global.

## The change

Jint 4.15.0 adds `Options.AddLazyGlobal(name, Func<Engine, JsValue> valueFactory, PropertyFlag flags)`. It installs the property immediately but leaves its value unresolved; the factory runs on the first read of the name. Registrations live on the `Options` instance and are replayed for each engine built from it, so a single shared `Options` gives every engine its own property and its own single factory invocation.

`JavaScriptEngine` now takes the registered `IGlobalMethodProvider` instances and declares their globals on the shared options once, with `PropertyFlag.NonEnumerable` so that a materialized global is indistinguishable from one set by `Engine.SetValue(string, Delegate)`. That flag is not the default — `AddLazyGlobal` otherwise matches `SetValue(string, JsValue)`, which is enumerable — and passing it is what keeps `Object.keys(globalThis)` looking the same. `JavaScriptScope` skips a method whose globals are covered by that declaration and keeps installing everything else exactly as before.

`GlobalMethod` exposes `Func<IServiceProvider, Delegate>`, and those factories capture the services they are handed, so a delegate cannot be shared between engines and nothing can be cached on it. The lazy factory receives the engine, so the engine is mapped back to the services of its scope through a `ConditionalWeakTable<Engine, IServiceProvider>` owned by `JavaScriptScope`; the engine is the weak key, so entries go away with the engines that key them.

Cases that stay on the eager path, so that nothing observable changes:

- A method passed to `CreateScope()` that is not the instance a provider registered. This covers the per-evaluation providers — a recipe's `parameters()` and `variables()`, a workflow's `workflow()` — and preserves shadowing: a scoped method with the same name as a registered global still wins, because it is set after the engine was built and replaces the lazy property.
- A name claimed by more than one registered provider, where which one wins depends on the order they are set in.
- A method with an asynchronous variant whose `xAsync` global is also claimed by a method literally named `xAsync`.

## Measured impact

BenchmarkDotNet, default job, `[MemoryDiagnoser]`, one evaluation per operation — a fresh engine plus the full 44-global surface, as `DefaultScriptingManager` does it. **Before** is this PR's merge base (`bee407c6f0`, Jint 4.12, eager registration); **after** is the PR tip (Jint 4.15.1, lazy). Both sides ran serially on an idle machine from identical harness source.

| Script | Before | After | Time | Allocated |
|---|---|---|---|---|
| calls **1** registered global | 4.671 µs / 24.14 KB | 3.947 µs / 17.07 KB | **−15.5 %** | **−29.3 %** |
| calls **10** | 7.566 µs / 28.75 KB | 7.123 µs / 26.56 KB | **−5.9 %** | **−7.6 %** |
| calls **all 30** | 16.707 µs / 47.42 KB | 15.010 µs / 56.21 KB | **−10.2 %** | **+18.5 %** |

Errors were ~1 % of the mean on every row. The pin has since moved on twice, to 4.15.2 and then 4.15.3, and the table is not re-measured for either. None of 4.15.2's seven fixes reaches this scenario. Two of them do touch property-read code: the builtin-shape fast-miss is gated on the receiver's side dictionary being empty, which the global object stops satisfying the moment the first host global is installed, and the accessor fix concerns *inherited accessors*, while these globals are data properties. Where the fast-miss could apply at all it only removes work, so if it moves anything here it moves the "after" column favourably — the published numbers are the conservative direction.

**Read the third row as the honest one.** When a script reads every global, laziness defers nothing, so the lazy descriptors are pure overhead on top of building all 30 delegates anyway — and allocation goes *up* 18.5 %. That is the designed-in worst case, predicted in the harness before the numbers existed, and it is the price of the first row. Time still improves there because the version bump separately cut the cost of *calling* a host delegate, which is what that row is dominated by.

**And read the first row honestly too.** A 15 % improvement is real but far smaller than "registration is 85–95 % of a short evaluation" would imply. The whole evaluation is 4.7 µs here, so registration cannot be most of it. Two reasons the mechanism recovers less than the framing suggests: the 40 lazy descriptors still have to be *installed* per engine — what laziness removes is the delegate wrapping, not the property — and these synthetic delegates have trivial signatures, so the reflection being skipped is at its cheapest. The allocation drop on the first row, −29 %, is the cleaner signal of what is no longer being built.

What is removed per evaluation is 40 delegate-factory invocations plus 40 `Engine.SetValue(string, Delegate)` calls, each of which reflects over the delegate's `Invoke` signature and allocates a wrapper and a descriptor. What replaces it is 40 lazy descriptors, plus one factory invocation for each global the script actually reads. Engine construction itself is unchanged and was already cheap; parsing was already avoided by the prepared-script cache.

Two caveats on the numbers themselves:

- **The delta is the bump and the laziness together.** Before is Jint 4.12 and after is 4.15.1, because that is what merging this PR actually gives you. It is not a measurement of lazy registration in isolation, and the third row shows the version bump carrying a row where laziness loses.
- **The providers are synthetic.** The count (40 registered, split 30/10 across 11 providers to match the real distribution, plus the 4 recipe-style per-evaluation ones), and each global being a real `Delegate` through the real registration path, are faithful. The delegate bodies are not — so these rows measure the cost of *getting globals onto an engine*, not what the real globals do once called.

Two honest limits on the change itself:

- It covers the 40 globals from DI-registered providers only. A recipe expression still eagerly installs 4 more (`parameters`, `configuration`, `variables`, `variablesAsync`) and a workflow script ~11, because those providers are constructed per evaluation and passed through `CreateScope()` rather than registered. **And those are the ones the shipped recipes actually call** — `variables('…')`, `parameters('…')` and `configuration('…')` dominate the 208 expressions, while `uuid()` and friends are the lazily-covered minority. So the canonical recipe expression goes from building 44 globals to building 4, not to building 1; reaching the last 4 no longer needs `ReferencedGlobals`: 4.15.3's `Engine.Advanced.AddLazyGlobal` installs a lazy global on an already-built engine, which is exactly the shape of a scoped method, so the eager path could go away entirely. See the follow-ups — it is a change to when a caller's factory runs, so it is not something to fold in here.
- `DefaultScriptingManager` still enumerates every provider's `GetMethods()` on every evaluation, and `JavaScriptScope` still walks that sequence. That is now the remaining per-evaluation cost in this path, and it is a much smaller one.

## Jint feature audit

Everything new in 4.15.0 was considered against this integration, not just the feature the branch was written for.

| Feature | Verdict |
| --- | --- |
| `Options.AddLazyGlobal` | **Adopted** — the change above. Verified against the shipped signature; `PropertyFlag.NonEnumerable` reproduces the attributes of `SetValue(string, Delegate)` exactly, and `JsValue.FromObject(engine, delegate)` reaches the same `DelegateWrapper`. That last equivalence has a precondition: `FromObject` consults registered `IObjectConverter`s first, so it holds only while none handles `Delegate`. Nothing registers a converter today; the precondition is now stated at the call site and on the docs page that teaches `Configure<Jint.Options>`. |
| Per-engine constraint instances | **Adopted as documentation.** The helpers now register a factory, which is what makes a constraint safe to configure on the single `Jint.Options` shared by every engine of a tenant. Before this, a `MaxStatements` or `TimeoutInterval` set through `IOptions<Jint.Options>` would have shared its counter and deadline — and its resets — across concurrent requests. Documented on the Scripting page along with the sentinel traps, since no constraints are configured anywhere today and the page previously said nothing about the extension point. |
| Cross-engine CLR member cache | **Adopted implicitly** — no code needed. Resolved and compiled member accessors now live on the shared `TypeResolver` instead of per engine, which is worth something here precisely because nearly every evaluation builds a new engine. Applies to `httpContext()`, `workflow()` and content-item traversal. |
| `CaptureGlobalSnapshot` / `RestoreGlobalSnapshot` | **Skipped on semantics, not on reachability.** It is implementable entirely inside `OrchardCore.Scripting.JavaScript` — `Evaluate`/`EvaluateAsync` already hold the concrete `JavaScriptScope` — so no new abstraction member and no change to `OrchardCore.Rules` is needed. What stops it here is that it changes behaviour: restoring between evaluations stops one rule's globals leaking into the next, and restore discards queued jobs and drops pre-restore promises, which interacts with `ExperimentalFeature.TaskInterop` being on. Worth its own PR — see the follow-ups. |
| `Prepared<T>.ReferencedGlobals` | **Skipped, and worth more than this PR's change on the recipe path.** It is the way to reach the eagerly installed per-evaluation providers, which as noted above are exactly the globals shipped recipes call. The barrier is that `IScriptingEngine.CreateScope()` has no script parameter — only `Evaluate()` does — so using it means moving installation out of the public `JavaScriptScope` constructor, which installs today, and deferring factories that callers may expect to have run. A separate change, not a smaller one. |
| Typed `AddObjectConverter` | **Skipped** — nothing in `src/` registers an `IObjectConverter`. The `SetWrapObjectHandler` in `ServiceCollectionExtensions` is a different extension point; a `Delegate` never reaches it, because Jint's delegate lane runs before the wrap-handler lane. |
| `EnumConversionMode.String` | **Skipped** — behaviour change with no requester. Enums reach script only as members of wrapped CLR objects, and exposing them as names instead of numbers would silently change existing scripts. |
| `NullPropagatingReferenceResolver` | **Skipped.** Jint documents it as a host-owned deviation from ECMAScript: `a.b.c` on a nullish `a.b` yields a value instead of throwing. No shipped or documented script uses optional chaining or traverses a chain whose links can be absent — recipe expressions are flat calls and string concatenation — so this would buy nothing and would change what every tenant's scripts do on error. |
| `JsObject.CreateFromEntries` / `JsObjectLayout` | **Skipped.** The globals return either scalars (`string`/`bool`, 30 of the 40) or deliberately open CLR graphs (`HttpContext`, `WorkflowExecutionContext`, `ContentItem`) whose members cannot be enumerated up front. These build a snapshot, whereas `ObjectWrapper` stays live over the CLR object and script writes reach it — so swapping would change semantics, not just cost. |
| JSON span / `IBufferWriter<byte>` overloads | **Skipped** — the overloads are on Jint's own `JsonParser`/`JsonSerializer`, both of which are engine-bound. A `GlobalMethod` factory has no `Engine`, so it cannot construct an engine-affine `JsValue` to hand back. (It *can* return one — `DelegateWrapper` passes a `JsValue` return through unchanged — so the barrier is construction, not the contract. `CreateGlobal` now holds the engine, so an engine-aware `GlobalMethod` variant is no longer structurally blocked, but that is a public API change of its own. `externalLoginContext()` serializing with `System.Text.Json` for the script to `JSON.parse` is a real double conversion, but removing it is a Users-module change.) |
| `ArrayLikeObject` | **Skipped, with a real seam noted.** `SetWrapObjectHandler` already intercepts `JsonDynamicArray`/`JsonArray` and returns an `ObjectInstance`, which is exactly where one would go, and content-item traversal is the path that would benefit. Not taken here because `Array.isArray` stays `false` by design, so it is a semantics change for any script reading a content field as an array. |
| `JsObjectShape` | **Skipped** — this one is *not* a subclassing API; it is the cheap way to give a host prototype its members once per process. It has no application yet because nothing here defines a host prototype, but it would be the tool if the wrap handler ever grew one. |
| `ProbeOwnProperty`, `TryGetOwnPropertyValue`, `PropertyAccessSemantics` | **Skipped** — these are for hosts that subclass `ObjectInstance` and project their own property model. This integration defines no Jint types. |

The pin moved to 4.15.1, then 4.15.2, then 4.15.3 while this was open; each was audited the same way. 4.15.1's five changes:

| 4.15.1 feature | Verdict |
| --- | --- |
| `Engine.Advanced.GetInteropConversionDiagnostics()` | **Skipped here, but it names a real question elsewhere.** It counts CLR arrays crossing into script, to audit whether `ArrayConversionMode.LiveView` (the default since 4.14) is handing script a writable view. Asserting it over `JavaScriptScopeTests` would prove nothing — those tests use a two-method test double, not the real global surface. The place it would pay is the wrap handler's `StringValues` branch, which calls `stringValues.ToArray()`, so a multi-valued `queryString('x')` does cross a freshly allocated `string[]`. Harmless as written (nothing else holds that temporary), but it is the one array crossing in the integration, and this is the tool for pinning it. That is an HTTP-module audit, not a lazy-globals change. |
| `GetPropertyAccessSemantics()` | **Skipped** — it reports the semantics the engine derived for a *host type*. There are none here, so there is nothing to observe. |
| `PropertyFlag.NonWritable` / `OnlyConfigurable` | **Skipped** — the two newly named combinations are not the one this PR builds. The globals use `NonEnumerable`, which already had a name and is what `SetValue(string, Delegate)` installs. |
| `JsObjectLayout` lazy slots | **Skipped** — it defers expensive members of a shaped object, which requires a `JsObjectLayout`. This integration builds none, for the reasons in the row above. |
| Documented contracts (no code) | **No claim here needed changing, and one is now backed by Jint's own docs.** `JsonSerializer` is documented as bound to its constructing engine, which is exactly why the JSON-overload row skips: a `GlobalMethod` factory has no engine. The new `GetOwnProperties` note — that script-visible enumeration goes through `GetOwnPropertyKeys` + `ProbeOwnProperty` and never `GetOwnProperties` — concerns hosts overriding those; nothing here does, and the non-enumerability of the lazy globals is asserted empirically by test rather than assumed from a mechanism. |

4.15.3's surface:

| 4.15.3 feature | Verdict |
| --- | --- |
| Host-contract verification in Release (`Jint.EnableHostContractVerification`) | **Adopted**, as a module initializer in `OrchardCore.Tests`. Jint trusts the extension points a projected object implements rather than re-checking them on its fast paths, so an object answering two of them inconsistently fails silently — a key that exists but no enumeration lists, a read that resolves on the prototype for a property the object owns. 4.15.3 makes those verifiers reachable from the shipped package instead of only from a source build. Honest scope: Orchard Core defines no Jint types, so today it has little to check. It is a tripwire for the moment a module projects one, or the wrap handler starts returning one, and it is confined to the test assembly because the verifiers redo work the checked paths exist to avoid. |
| `Engine.Advanced.AddLazyGlobal` (post-construction) | **Declined here, and it retires the follow-up it replaces.** It does *not* move this PR's residual — the per-engine lazy descriptor still has to be installed either way; what laziness defers is the delegate wrapping, and that is already deferred for the registered globals. What it does reach is the eager path this PR left behind: the per-evaluation methods handed to `CreateScope()`. That is a change to *when a caller's `Func<IServiceProvider, Delegate>` runs*, on a public constructor, so it wants its own review rather than being folded into a PR that is already under one. |
| `PropertyDescriptor.CreateLazy` | **Declined** — it is for hosts that build descriptors themselves. This integration builds none; the two lazy paths it uses are the two `AddLazyGlobal` overloads. |
| `Engine.Advanced.WithRestoredGlobals` | **Declined, but noted for the follow-up.** This PR contains no snapshot usage — the `JavascriptConditionEvaluator` adoption was deferred on a semantics decision, not a missing API. When that happens, this helper is the shape it wants: it scopes the restore so an evaluation that throws still cannot leave its globals behind, which was the third prerequisite recorded below. |
| `HasSharedShape` | **Declined** — a predicate for whether `JsObject.Create` / `JsObjectShape` actually produced the shared representation. Neither is used here, so there is nothing to assert about. |
| `AddImmutableCrossing` | **Declined** — it memoizes reads of a wrapped object the host promises never changes. Every object this integration wraps is mutable by design (`JsonObject` content, `ContentItem`, `HttpContext`), and the one temporary that is effectively frozen — the `string[]` from the wrap handler's `StringValues` branch — could only be declared by registering `string[]` wholesale, which would cover every other array crossing too. |

## Behaviour to be aware of

- The properties are installed up front, so `in`, `hasOwnProperty()` and `Object.getOwnPropertyNames()` see every global without materializing anything. They stay non-enumerable, so `Object.keys(globalThis)` does not list them, as before. There are tests for both.
- The value is cached by the engine after the first read, so the identity of a global is stable for the whole evaluation.
- `delete globalThis.x` before ever reading `x` removes the property and the factory never runs. Assigning to it or redefining it *does* run the factory once and then discard the result, because `[[Set]]` on the global object goes through `[[DefineOwnProperty]]`, which reads the current value before replacing it. The end state is correct in every case; only the laziness is lost for that sequence.
- A registered `Func<IServiceProvider, Delegate>` is now invoked lazily, and not at all when the script does not use the method. In-tree factories only close over services, but this is documented on the Scripting page since it is part of the provider contract.
- **Every engine created by `JavaScriptEngine` exposes the globals of the registered providers, whether or not they appear in the `methods` argument of `CreateScope()`.** Both in-tree callers always pass all of them, so this is not observable in the product, but it widens what `CreateScope(methods, ...)` means for a third-party caller that passes a deliberately restricted set. Now recorded under Breaking Changes, together with the added `JavaScriptEngine` constructor parameter — the release notes previously said there were none, which was wrong on both counts.

### Why the engine is mapped back to its services instead of building options per scope

Jint documents building an `Options` per scope, with the factories closing over that scope, as the supported way to give lazy globals access to scoped state. That would work here — `IOptionsFactory<Jint.Options>.Create()` produces a fresh instance with every registered `Configure<Jint.Options>` applied, so the extension point would be preserved — but it would re-run all 40 `AddLazyGlobal` registrations, and allocate the options and their configuration list, once per evaluation. Since an evaluation is exactly the unit this PR is trying to make cheaper, that trades most of the win back for no observable difference. The `ConditionalWeakTable` keeps registration a one-time, per-tenant cost.

## Also here

`OrchardCore.ContentFields`, `OrchardCore.Html` and `OrchardCore.Markdown` reference Jint but contain no Jint symbol — their editor settings drivers use `Acornima.Parser` and only reached Acornima transitively through Jint. They now reference Acornima directly. Separate commit; say the word and I will drop it from this PR.

The Scripting reference page also said the engine evaluates scripts with Esprima.NET, which is a parser rather than an evaluator and is not what Jint uses any more. Corrected in the docs commit.

## Follow-ups recorded, not fixed here

Written down so they are not lost. None is reachable with today's providers and call sites.

- **The `xAsync` collision guard is asymmetric.** It excludes the method carrying the `AsyncMethod` but not a method literally named `xAsync`, so with `x` first in provider order the `xAsync` global would resolve to `x.AsyncMethod` where the old eager loop's last write gave `xAsync.Method`. Order-dependent, and unreachable today — no registered global name ends in `Async`. The clean fix is to collect *claimed global names* (`name` and `name + "Async"`) in the first pass and treat any name claimed twice as ambiguous, which collapses the special case into the existing path; I left it out rather than restructure the guard in a PR that is not about it.
- **Engine reuse now carries a hazard it did not before.** A materialized lazy global caches a `DelegateWrapper` bound to the `IServiceProvider` the table held *at materialization time*, so reusing an engine across scopes would serve the first scope's services from every already-materialized global. `RestoreGlobalSnapshot` does return a global that was unmaterialized at capture to that state — but only if the snapshot is captured before anything materializes, and the table entry has to be re-pointed on each reuse. Both are prerequisites for the snapshot follow-up above. Jint 4.15.1's docs add the third: restore in a `finally`, since an evaluation that throws still declared its globals and restoring only on success hands them to the next caller — and 4.15.3's `Engine.Advanced.WithRestoredGlobals(snapshot, action)` is that shape as a single call, so the follow-up no longer has to get the `finally` right by hand.
- **`Object.getOwnPropertyNames(globalThis)` order rides `Dictionary` enumeration order.** The second pass iterates a `Dictionary`, and the install order is script-observable. It matches insertion (provider) order on the current BCL, so the enumeration is unchanged from the eager loop, but that is an implementation detail rather than a contract. If the order should be pinned, drive the second pass from an ordered list built in the first.
- **One locked `ConditionalWeakTable` write per evaluation**, on a static table shared by every tenant in the process. Reads are lock-free and the write is trivial against the ~40 `DelegateWrapper` constructions removed, so it is strongly net positive — named only because this is a performance change and it is the one new serialization point it introduces. Related: `AddOrUpdate` means a second `JavaScriptScope` built over the same `Engine` rebinds the mapping while already-materialized globals keep the first scope's services.

## What I deliberately did not do

**Reusing a scope across evaluations.** `JavascriptConditionEvaluator` already caches one scope per request, and extending that pattern is the obvious next step. Two of the three remaining call sites still look unsafe:

- `JavaScriptWorkflowScriptEvaluator` rebuilds its method providers for every evaluation — `IWorkflowExecutionContextHandler.EvaluatingScriptAsync()` contributes providers bound to that evaluation's `WorkflowExecutionScriptContext` — so a cached scope would keep serving the first evaluation's `workflow()` and `signalUrl()`.
- `ScriptExternalLoginEventHandler` evaluates at most twice per login, each time with its own per-user context.

`RecipeExecutor` is the one where I have to correct myself. I argued previously that a scope per step was blocked because the expressions in a step would share one global lexical environment, so a second `[js: let x = … ]` would fail with a redeclaration error where it succeeds today. **Jint 4.15.0's `RestoreGlobalSnapshot` clears exactly that** — top-level `let`/`const`/`class` declarations, which nothing else could — alongside global properties, prototype and extensibility, while deliberately keeping the engine's warm-up caches. So the blocker I named is gone, and this repository does ship a recipe expression with a top-level `const` (`comingsoon.recipe.json`), which is what would have broken.

I am still not doing it here: it changes recipe and rule semantics in ways worth reviewing on their own, it has the materialization-ordering prerequisite listed above, and it is a bigger change than the one this PR is about.

**Execution constraints.** Still none configured, so an admin-authored `while (true) {}` occupies a request thread until the process is restarted. What has changed is that configuring one is now *safe* on the shared options instance, which it was not before 4.15.0 — so this is now a policy decision about defaults rather than a correctness problem, and the Scripting page documents how to make it. Choosing the defaults is still its own PR: the options instance is shared by recipe execution, workflow scripts and layer rules alike, and a timeout that suits a layer rule would abort recipe steps that work today.

## Testing

Gated with CI's own flags — `dotnet build -c Release -p:TreatWarningsAsErrors=true -p:RunAnalyzers=true -p:NuGetAudit=false`, then `dotnet test --project ./test/OrchardCore.Tests/OrchardCore.Tests.csproj -c Release --no-build` — against Jint 4.15.3 from nuget.org: **0 warnings, and 2448 tests, 2447 passed, 1 skipped, 0 failed.**

New `JavaScriptScopeTests` cover laziness, per-engine caching and identity, non-enumerability, `delete` before first read, scoped shadowing, and the asynchronous variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uV6H9cTntzsoKiaJRBn4f




