### PR TITLE
Add tenant async options validation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptionsConfiguration.cs
@@ -10,7 +10,7 @@ using OrchardCore.Liquid.Abstractions;
 
 namespace OrchardCore.DataProtection.Azure;
 
-internal sealed class BlobOptionsConfiguration : IConfigureOptions<BlobOptions>
+internal sealed class BlobOptionsConfiguration : IConfigureOptions<BlobOptions>, IAsyncValidateOptions<BlobOptions>
 {
     private readonly FluidParser _fluidParser;
     private readonly IShellConfiguration _configuration;
@@ -63,27 +63,37 @@ internal sealed class BlobOptionsConfiguration : IConfigureOptions<BlobOptions>
             throw;
         }
 
-        if (options.CreateContainer)
+    }
+
+    public async Task<ValidateOptionsResult> ValidateAsync(string? name, BlobOptions options, CancellationToken cancellationToken = default)
+    {
+        if (!options.CreateContainer)
         {
-            try
+            return ValidateOptionsResult.Success;
+        }
+
+        try
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                if (_logger.IsEnabled(LogLevel.Debug))
-                {
-                    _logger.LogDebug("Testing data protection container {ContainerName} existence", options.ContainerName);
-                }
-                var blobContainer = new BlobContainerClient(options.ConnectionString, options.ContainerName);
-                var response = blobContainer.CreateIfNotExistsAsync(PublicAccessType.None).GetAwaiter().GetResult();
-                if (_logger.IsEnabled(LogLevel.Debug))
-                {
-                    _logger.LogDebug("Data protection container {ContainerName} created.", options.ContainerName);
-                }
+                _logger.LogDebug("Testing data protection container {ContainerName} existence", options.ContainerName);
             }
-            catch (Exception e)
+
+            var blobContainer = new BlobContainerClient(options.ConnectionString, options.ContainerName);
+            await blobContainer.CreateIfNotExistsAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogCritical(e, "Unable to connect to Azure Storage to configure data protection storage. Ensure that an application setting containing a valid Azure Storage connection string is available at `Modules:OrchardCore.DataProtection.Azure:ConnectionString`.");
-                throw;
+                _logger.LogDebug("Data protection container {ContainerName} created.", options.ContainerName);
             }
         }
+        catch (Exception e)
+        {
+            _logger.LogCritical(e, "Unable to connect to Azure Storage to configure data protection storage. Ensure that an application setting containing a valid Azure Storage connection string is available at `Modules:OrchardCore.DataProtection.Azure:ConnectionString`.");
+            throw;
+        }
+
+        return ValidateOptionsResult.Success;
     }
 
     private void ConfigureBlobName(BlobOptions options)

--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/Startup.cs
@@ -58,7 +58,10 @@ public sealed class Startup : StartupBase
                         options.BlobName);
                 });
 
-            services.AddSingleton<IConfigureOptions<BlobOptions>, BlobOptionsConfiguration>();
+            services.AddSingleton<BlobOptionsConfiguration>();
+            services.AddSingleton<IConfigureOptions<BlobOptions>>(sp => sp.GetRequiredService<BlobOptionsConfiguration>());
+            services.AddSingleton<IAsyncValidateOptions<BlobOptions>>(sp => sp.GetRequiredService<BlobOptionsConfiguration>());
+            services.AddOptions<BlobOptions>().ValidateOnStart();
 
             services.AddScoped<IModularTenantEvents, BlobModularTenantEvents>();
         }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Modules;
@@ -337,6 +339,15 @@ public sealed class ShellScope : IServiceScope, IAsyncDisposable
                 foreach (var tenantEvent in tenantEvents)
                 {
                     await tenantEvent.ActivatingAsync();
+                }
+
+                scope.ServiceProvider.GetService<IStartupValidator>()?.Validate();
+
+                var asyncStartupValidator = scope.ServiceProvider.GetService<IAsyncStartupValidator>();
+                if (asyncStartupValidator is not null)
+                {
+                    var applicationLifetime = scope.ServiceProvider.GetService<IHostApplicationLifetime>();
+                    await asyncStartupValidator.ValidateAsync(applicationLifetime?.ApplicationStopping ?? CancellationToken.None);
                 }
 
                 foreach (var tenantEvent in tenantEvents.Reverse())

--- a/src/docs/reference/modules/DataProtection.Azure/README.md
+++ b/src/docs/reference/modules/DataProtection.Azure/README.md
@@ -38,7 +38,7 @@ By default this will use a single container to store all Data Protection Keys ba
 dataprotection/Sites/tenant_name/DataProtectionKeys.xml
 ```
 
-During `Startup` if `CreateContainer` is set to `true`, Data Protection will check if the container exists and create it if it doesn't. Set `CreateContainer` to `false` to disable this check if your container already exists.
+During tenant activation, if `CreateContainer` is set to `true`, Data Protection will asynchronously check if the container exists and create it if it doesn't. A failure prevents the tenant from activating. Set `CreateContainer` to `false` to disable this check if your container already exists.
 
 ## Advanced Configuration with Liquid Templating
 

--- a/src/docs/reference/modules/Shells/README.md
+++ b/src/docs/reference/modules/Shells/README.md
@@ -156,3 +156,30 @@ namespace OrchardCore.Cms.Web
     }
 }
 ```
+
+## Tenant startup options validation
+
+Tenant service containers run the standard `Microsoft.Extensions.Options` startup validation
+contracts when the tenant is activated. Register options and call `ValidateOnStart()` from a
+tenant feature's `ConfigureServices` method as usual:
+
+```csharp
+services.AddOptions<StorageOptions>()
+    .BindConfiguration("Storage")
+    .Validate(options => !string.IsNullOrWhiteSpace(options.ConnectionString),
+        "A storage connection string is required.")
+    .Validate<IStorageClient>((options, storageClient, cancellationToken) =>
+        storageClient.CanConnectAsync(options.ConnectionString, cancellationToken),
+        "The storage service is unavailable.")
+    .ValidateOnStart();
+```
+
+During activation, Orchard Core runs `IStartupValidator` after tenant
+`ActivatingAsync()` events and then runs `IAsyncStartupValidator` before
+`ActivatedAsync()` events. A validation failure prevents the tenant from becoming activated and
+is propagated to the caller. Async validation receives the host application stopping token when
+one is available.
+
+Validation runs once for each tenant shell instance. It runs again when a tenant shell is rebuilt
+or reloaded. It does not validate subsequent mutable tenant-setting saves or
+`IOptionsMonitor<T>` reloads; validate those changes where they are saved or handled.

--- a/test/OrchardCore.Tests/Modules/OrchardCore.DataProtection.Azure/StartupTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.DataProtection.Azure/StartupTests.cs
@@ -1,0 +1,41 @@
+using Fluid;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OrchardCore.DataProtection.Azure;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Configuration;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.DataProtection.Azure;
+
+public class StartupTests
+{
+    [Fact]
+    public async Task ConfigureServices_CreateContainerDisabled_RunsAsyncStartupValidationWithoutAzureAccess()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["OrchardCore_DataProtection_Azure:ConnectionString"] = "UseDevelopmentStorage=true",
+                ["OrchardCore_DataProtection_Azure:CreateContainer"] = "false",
+            })
+            .Build();
+        var shellConfiguration = new ShellConfiguration(configuration);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IShellConfiguration>(shellConfiguration);
+        services.AddSingleton(new ShellSettings { Name = "Default" });
+        services.AddSingleton(new FluidParser());
+        services.AddOptions<ShellOptions>();
+
+        var startup = new Startup(shellConfiguration, NullLogger<Startup>.Instance);
+        startup.ConfigureServices(services);
+
+        await using var serviceProvider = services.BuildServiceProvider();
+        await serviceProvider.GetRequiredService<IAsyncStartupValidator>().ValidateAsync(TestContext.Current.CancellationToken);
+
+        var options = serviceProvider.GetRequiredService<IOptions<BlobOptions>>().Value;
+        Assert.False(options.CreateContainer);
+    }
+}

--- a/test/OrchardCore.Tests/Shell/ShellScopeTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellScopeTests.cs
@@ -1,5 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Scope;
+using OrchardCore.Locking;
+using OrchardCore.Locking.Distributed;
+using OrchardCore.Modules;
 using OrchardCore.Tests.Apis.Context;
 
 namespace OrchardCore.Tests.Shell;
@@ -53,5 +61,256 @@ public class ShellScopeTests
         cts.Cancel();
 
         await t1;
+    }
+
+    [Fact]
+    public async Task ActivateShell_StartupValidators_ExecuteBetweenTenantEvents()
+    {
+        var executionOrder = new List<string>();
+        await using var shellContext = CreateShellContext(services =>
+        {
+            services.AddSingleton<IModularTenantEvents>(new RecordingTenantEvents(executionOrder));
+            services.AddOptions<TestOptions>()
+                .Configure(options => options.IsValid = true)
+                .Validate(options =>
+                {
+                    executionOrder.Add("Sync validation");
+                    return options.IsValid;
+                })
+                .Validate((options, cancellationToken) =>
+                {
+                    executionOrder.Add("Async validation");
+                    return Task.FromResult(options.IsValid);
+                })
+                .ValidateOnStart();
+        });
+
+        await ActivateAsync(shellContext);
+
+        Assert.True(shellContext.IsActivated);
+        Assert.Equal(
+            ["Activating", "Sync validation", "Async validation", "Activated"],
+            executionOrder);
+    }
+
+    [Fact]
+    public async Task ActivateShell_SyncStartupValidationFails_DoesNotActivateAndCanRetry()
+    {
+        var validator = new MutableStartupValidator { ShouldFail = true };
+        await using var shellContext = CreateShellContext(services =>
+        {
+            services.AddSingleton<IStartupValidator>(validator);
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => ActivateAsync(shellContext));
+
+        Assert.False(shellContext.IsActivated);
+        Assert.Equal(1, validator.CallCount);
+
+        validator.ShouldFail = false;
+        await ActivateAsync(shellContext);
+
+        Assert.True(shellContext.IsActivated);
+        Assert.Equal(2, validator.CallCount);
+    }
+
+    [Fact]
+    public async Task ActivateShell_AsyncStartupValidationFails_DoesNotActivate()
+    {
+        var validator = new RecordingAsyncStartupValidator(_ => throw new OptionsValidationException(
+            Options.DefaultName,
+            typeof(TestOptions),
+            ["Async validation failed."]));
+        await using var shellContext = CreateShellContext(services =>
+        {
+            services.AddSingleton<IAsyncStartupValidator>(validator);
+        });
+
+        await Assert.ThrowsAsync<OptionsValidationException>(() => ActivateAsync(shellContext));
+
+        Assert.False(shellContext.IsActivated);
+        Assert.Equal(1, validator.CallCount);
+    }
+
+    [Fact]
+    public async Task ActivateShell_AsyncStartupValidation_UsesApplicationStoppingToken()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        var validator = new RecordingAsyncStartupValidator(cancellationToken =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        });
+        await using var shellContext = CreateShellContext(services =>
+        {
+            services.AddSingleton<IHostApplicationLifetime>(new TestHostApplicationLifetime(cancellationTokenSource.Token));
+            services.AddSingleton<IAsyncStartupValidator>(validator);
+        });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ActivateAsync(shellContext));
+
+        Assert.False(shellContext.IsActivated);
+        Assert.Equal(cancellationTokenSource.Token, validator.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ActivateShell_ActivatedShell_DoesNotRunStartupValidatorsAgain()
+    {
+        var syncValidator = new MutableStartupValidator();
+        var validatorStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeValidator = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var asyncValidator = new RecordingAsyncStartupValidator(_ =>
+        {
+            validatorStarted.TrySetResult();
+            return completeValidator.Task;
+        });
+        await using var shellContext = CreateShellContext(services =>
+        {
+            services.AddSingleton<IStartupValidator>(syncValidator);
+            services.AddSingleton<IAsyncStartupValidator>(asyncValidator);
+        });
+
+        var firstActivation = ActivateAsync(shellContext);
+        await validatorStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        var secondActivation = ActivateAsync(shellContext);
+        completeValidator.SetResult();
+        await Task.WhenAll(firstActivation, secondActivation);
+
+        Assert.Equal(1, syncValidator.CallCount);
+        Assert.Equal(1, asyncValidator.CallCount);
+    }
+
+    [Fact]
+    public async Task ActivateShell_RebuiltShell_RunsStartupValidatorsAgain()
+    {
+        var syncValidator = new MutableStartupValidator();
+        var asyncValidator = new RecordingAsyncStartupValidator(_ => Task.CompletedTask);
+
+        await using (var firstShellContext = CreateShellContext(services =>
+        {
+            services.AddSingleton<IStartupValidator>(syncValidator);
+            services.AddSingleton<IAsyncStartupValidator>(asyncValidator);
+        }))
+        {
+            await ActivateAsync(firstShellContext);
+        }
+
+        await using (var rebuiltShellContext = CreateShellContext(services =>
+        {
+            services.AddSingleton<IStartupValidator>(syncValidator);
+            services.AddSingleton<IAsyncStartupValidator>(asyncValidator);
+        }))
+        {
+            await ActivateAsync(rebuiltShellContext);
+        }
+
+        Assert.Equal(2, syncValidator.CallCount);
+        Assert.Equal(2, asyncValidator.CallCount);
+    }
+
+    private static async Task ActivateAsync(ShellContext shellContext)
+    {
+        var scope = await shellContext.CreateScopeAsync();
+        await scope.UsingAsync(_ => Task.CompletedTask);
+    }
+
+    private static ShellContext CreateShellContext(Action<IServiceCollection> configureServices)
+    {
+        var services = new ServiceCollection();
+        var localLock = new LocalLock(NullLogger<LocalLock>.Instance);
+        services.AddSingleton<ILocalLock>(localLock);
+        services.AddSingleton<IDistributedLock>(localLock);
+        configureServices(services);
+
+        return new ShellContext
+        {
+            Settings = new ShellSettings { Name = "Test" }.AsInitializing(),
+            ServiceProvider = services.BuildServiceProvider(),
+        };
+    }
+
+    private sealed class TestOptions
+    {
+        public bool IsValid { get; set; }
+    }
+
+    private sealed class RecordingTenantEvents : ModularTenantEvents
+    {
+        private readonly List<string> _executionOrder;
+
+        public RecordingTenantEvents(List<string> executionOrder)
+        {
+            _executionOrder = executionOrder;
+        }
+
+        public override Task ActivatingAsync()
+        {
+            _executionOrder.Add("Activating");
+            return Task.CompletedTask;
+        }
+
+        public override Task ActivatedAsync()
+        {
+            _executionOrder.Add("Activated");
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MutableStartupValidator : IStartupValidator
+    {
+        public bool ShouldFail { get; set; }
+
+        public int CallCount { get; private set; }
+
+        public void Validate()
+        {
+            CallCount++;
+
+            if (ShouldFail)
+            {
+                throw new InvalidOperationException("Sync validation failed.");
+            }
+        }
+    }
+
+    private sealed class RecordingAsyncStartupValidator : IAsyncStartupValidator
+    {
+        private readonly Func<CancellationToken, Task> _validateAsync;
+
+        public RecordingAsyncStartupValidator(Func<CancellationToken, Task> validateAsync)
+        {
+            _validateAsync = validateAsync;
+        }
+
+        public int CallCount { get; private set; }
+
+        public CancellationToken CancellationToken { get; private set; }
+
+        public Task ValidateAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            CancellationToken = cancellationToken;
+            return _validateAsync(cancellationToken);
+        }
+    }
+
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime
+    {
+        public TestHostApplicationLifetime(CancellationToken applicationStopping)
+        {
+            ApplicationStopping = applicationStopping;
+        }
+
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+
+        public CancellationToken ApplicationStopping { get; }
+
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication()
+        {
+        }
     }
 }


### PR DESCRIPTION
<!--- Please make sure that you are familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

## Summary

- Run tenant-scoped startup options validation during shell activation using the .NET 11 RC1 validation contracts.
- Preserve RC1 legacy synchronous-validator precedence, run all asynchronous validators, and retain cancellation and exception aggregation behavior.
- Pass the host application stopping token to asynchronous validators while preserving tenant activation failure and retry behavior.
- Move Azure Data Protection container provisioning from synchronous options configuration into async tenant startup validation.
- Add focused shell and Azure Data Protection tests and document the behavior.

## Dependency

Depends on #19620, which upgrades Orchard Core to the go-live .NET 11 RC1 release and provides these standard options validation contracts. This is intentionally separate so the framework upgrade remains focused while the tenant activation lifecycle behavior, coverage, documentation, and first adoption can be reviewed independently.

## Validation

- `git diff --check`
- Static source and registration review against .NET runtime tag `v11.0.0-rc.1.26425.128`
- Targeted tests are deferred to PR CI because the required .NET 11 RC1 SDK was intentionally not installed locally.