### PR TITLE
Reuse JavaScript engines between evaluations

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Rules/Services/JavascriptConditionEvaluator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Services/JavascriptConditionEvaluator.cs
@@ -3,7 +3,7 @@ using OrchardCore.Scripting;
 
 namespace OrchardCore.Rules.Services;
 
-public class JavascriptConditionEvaluator : ConditionEvaluator<JavascriptCondition>
+public class JavascriptConditionEvaluator : ConditionEvaluator<JavascriptCondition>, IDisposable
 {
     private readonly IScriptingManager _scriptingManager;
     private readonly IServiceProvider _serviceProvider;
@@ -11,7 +11,7 @@ public class JavascriptConditionEvaluator : ConditionEvaluator<JavascriptConditi
     // The scope is built lazily once per request.
     private IScriptingScope _scope;
     private IScriptingEngine _engine;
-
+    private bool _disposed;
 
     public JavascriptConditionEvaluator(IScriptingManager scriptingManager, IServiceProvider serviceProvider)
     {
@@ -21,9 +21,35 @@ public class JavascriptConditionEvaluator : ConditionEvaluator<JavascriptConditi
 
     public override async ValueTask<bool> EvaluateAsync(JavascriptCondition condition)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         _engine ??= _scriptingManager.GetScriptingEngine("js");
         _scope ??= _engine.CreateScope(_scriptingManager.GlobalMethodProviders.SelectMany(x => x.GetMethods()), _serviceProvider, null, null);
 
         return Convert.ToBoolean(await _engine.EvaluateAsync(_scope, condition.Script));
+    }
+
+    /// <summary>
+    /// Releases the scope held for the request. This type is registered as a scoped service precisely so
+    /// that every condition of a request shares one scope, which makes it the only thing that knows when
+    /// that scope ends; the container disposes it at the end of the request.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing || _disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        (_scope as IDisposable)?.Dispose();
+        _scope = null;
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
@@ -35,7 +35,19 @@ public class DefaultScriptingManager : IScriptingManager
 
         var methodProviders = scopedMethodProviders != null ? GlobalMethodProviders.Concat(scopedMethodProviders) : GlobalMethodProviders;
         var scope = engine.CreateScope(methodProviders.SelectMany(x => x.GetMethods()), ShellScope.Services, fileProvider, basePath);
-        return engine.Evaluate(scope, script);
+
+        try
+        {
+            return engine.Evaluate(scope, script);
+        }
+        finally
+        {
+            // A scope may own state an engine wants back — the JavaScript engine reuses its engines between
+            // evaluations and only learns the evaluation is over from here. The 'finally' is the point: a
+            // script that throws has still left its declarations behind, and skipping the release on that
+            // path is exactly how the next evaluation would inherit them.
+            DisposeScope(scope);
+        }
     }
 
     public async Task<object> EvaluateAsync(string directive,
@@ -57,13 +69,33 @@ public class DefaultScriptingManager : IScriptingManager
 
         var methodProviders = scopedMethodProviders != null ? GlobalMethodProviders.Concat(scopedMethodProviders) : GlobalMethodProviders;
         var scope = engine.CreateScope(methodProviders.SelectMany(x => x.GetMethods()), ShellScope.Services, fileProvider, basePath);
-        return await engine.EvaluateAsync(scope, script, cancellationToken);
+
+        try
+        {
+            // Awaited here rather than returned, so that the scope is released after the evaluation has
+            // actually finished. An engine cannot be reset while an asynchronous evaluation it started is
+            // still outstanding.
+            return await engine.EvaluateAsync(scope, script, cancellationToken);
+        }
+        finally
+        {
+            DisposeScope(scope);
+        }
     }
 
     public IScriptingEngine GetScriptingEngine(string prefix)
     {
         return _engines.FirstOrDefault(x => x.Prefix == prefix);
     }
+
+    /// <summary>
+    /// Releases a scope that holds resources. <see cref="IScriptingScope"/> is a marker interface and most
+    /// implementations hold nothing, so the capability is discovered rather than required: adding
+    /// <see cref="IDisposable"/> to the interface would break every engine implemented outside this
+    /// repository.
+    /// </summary>
+    private static void DisposeScope(IScriptingScope scope)
+        => (scope as IDisposable)?.Dispose();
 
     private static bool TryParseDirective(string directive, out string prefix, out string script)
     {

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
@@ -9,6 +9,35 @@ using JintOptions = Jint.Options;
 
 namespace OrchardCore.Scripting.JavaScript;
 
+/// <summary>
+/// Evaluates JavaScript with Jint.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Engines are reused between evaluations. A scope returns its engine to a pool when it is disposed, after
+/// the engine's global bindings have been reset to the state they were captured in when it was built, so a
+/// later evaluation starts from the same global surface a brand-new engine would have given it. Reuse also
+/// keeps the engine's warm-up caches, which is where most of the saving comes from: the parsed form of a
+/// script is already shared through <see cref="IMemoryCache"/>, but the interpreter state Jint builds while
+/// running it is per engine and used to be thrown away after a single evaluation.
+/// </para>
+/// <para>
+/// <b>Reuse is confined to one tenant.</b> This service is registered per tenant, so the pool is too, and an
+/// engine can only ever be handed to another evaluation of the tenant it was built for. That matters because
+/// resetting the global bindings is not an isolation boundary: it does not undo what a script did to the
+/// built-in prototypes, to <c>Symbol.for</c>, or to an object graph reachable from a global it left in
+/// place. Scripts within a tenant are authored by its administrators and already run at one trust level —
+/// this is the same trust level as before, not a wider one — but two tenants must never share an engine, and
+/// nothing here lets them.
+/// </para>
+/// <para>
+/// One consequence is worth knowing when writing a global method or a caller. The value an evaluation
+/// returns must not depend on the engine still being in the state that produced it. <see cref="Evaluate"/>
+/// converts its result to CLR values, which detaches objects, arrays and dates, but a script that returns a
+/// <em>function</em> hands back a delegate bound to the engine. Invoking it after the scope has been
+/// disposed runs it against whatever the engine has been reset — or re-rented — to.
+/// </para>
+/// </remarks>
 public sealed class JavaScriptEngine : IScriptingEngine
 {
     private static readonly MemoryCacheEntryOptions ScriptCacheEntryOptions = new MemoryCacheEntryOptions()
@@ -23,34 +52,79 @@ public sealed class JavaScriptEngine : IScriptingEngine
     private readonly JintOptions _jintOptions;
     private readonly Dictionary<string, LazyGlobalMethod> _lazyGlobals;
 
+    // Null when engine reuse is turned off, in which case every scope gets an engine of its own.
+    private readonly JavaScriptEnginePool _pool;
+
     public JavaScriptEngine(
         IMemoryCache memoryCache,
         IOptions<JintOptions> jintOptions,
         IEnumerable<IGlobalMethodProvider> globalMethodProviders)
+        : this(memoryCache, jintOptions, globalMethodProviders, engineOptions: null)
+    {
+    }
+
+    public JavaScriptEngine(
+        IMemoryCache memoryCache,
+        IOptions<JintOptions> jintOptions,
+        IEnumerable<IGlobalMethodProvider> globalMethodProviders,
+        IOptions<JavaScriptEngineOptions> engineOptions)
     {
         _memoryCache = memoryCache;
         _jintOptions = jintOptions.Value;
         _jintOptions.ExperimentalFeatures |= ExperimentalFeature.TaskInterop;
         _lazyGlobals = RegisterLazyGlobals(_jintOptions, globalMethodProviders);
+
+        var poolSize = engineOptions?.Value?.EnginePoolSize ?? JavaScriptEngineOptions.DefaultEnginePoolSize;
+
+        // This instance is resolved once per tenant, so the pool it holds is per tenant as well. Engines
+        // must never be shared across tenants and this is the only thing that keeps them from being.
+        _pool = poolSize > 0 ? new JavaScriptEnginePool(_jintOptions, poolSize) : null;
     }
 
     public string Prefix => "js";
 
     /// <summary>
-    /// Creates a scope backed by a new engine.
+    /// Creates a scope backed by an engine, either reused from the tenant's pool or newly built.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The globals of the registered <see cref="IGlobalMethodProvider"/> instances are installed on every
     /// engine as lazy properties, whether or not <paramref name="methods"/> contains them. A lazy property
     /// only builds its delegate when a script actually reads the name, so the ones a script does not use
     /// cost nothing. Methods that are not registered by a provider, such as the ones a caller adds for a
     /// single evaluation, are installed eagerly and take precedence over a registered global of the same name.
+    /// </para>
+    /// <para>
+    /// <b>Dispose the returned scope</b> when the evaluations that use it are done, and not before — an
+    /// engine is single-threaded, and disposing releases it to the next evaluation. Disposing is what makes
+    /// the engine reusable; a scope that is never disposed still behaves correctly, its engine is simply
+    /// collected instead of reused.
+    /// </para>
     /// </remarks>
     public IScriptingScope CreateScope(IEnumerable<GlobalMethod> methods, IServiceProvider serviceProvider, IFileProvider fileProvider, string basePath)
     {
-        var engine = new Engine(_jintOptions);
+        var pool = _pool;
 
-        return new JavaScriptScope(engine, serviceProvider, methods, _lazyGlobals);
+        if (pool is null)
+        {
+            return new JavaScriptScope(new Engine(_jintOptions), serviceProvider, methods, _lazyGlobals, pool: null, rental: null);
+        }
+
+        var rental = pool.Rent();
+
+        try
+        {
+            return new JavaScriptScope(rental.Engine, serviceProvider, methods, _lazyGlobals, pool, rental);
+        }
+        catch
+        {
+            // Building the eagerly installed globals is the only thing that can fail here, and it fails
+            // having already installed some of them. Hand the engine back so that the reset removes them,
+            // rather than leaking a half-configured engine that no scope owns.
+            pool.Return(rental);
+
+            throw;
+        }
     }
 
     public object Evaluate(IScriptingScope scope, string script)

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngineOptions.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngineOptions.cs
@@ -1,0 +1,35 @@
+namespace OrchardCore.Scripting.JavaScript;
+
+/// <summary>
+/// Options controlling how <see cref="JavaScriptEngine"/> reuses Jint engines between evaluations.
+/// </summary>
+public class JavaScriptEngineOptions
+{
+    /// <summary>
+    /// The number of idle engines a tenant keeps for reuse when nothing is configured.
+    /// </summary>
+    public const int DefaultEnginePoolSize = 8;
+
+    /// <summary>
+    /// Gets or sets how many idle engines the tenant keeps for reuse. Defaults to
+    /// <see cref="DefaultEnginePoolSize"/>. Set it to <c>0</c> to build a new engine for every evaluation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is not a concurrency limit. An evaluation that starts while every pooled engine is in use builds
+    /// its own, and releases it to the garbage collector afterwards, so raising or lowering the value can
+    /// never make an evaluation wait or fail.
+    /// </para>
+    /// <para>
+    /// What it bounds is retained state. A reused engine remembers the last object each script member access
+    /// and each call resolved against, so a pooled engine can hold one such object — a request's
+    /// <c>HttpContext</c>, a workflow execution context — per site in the scripts it has run, until that
+    /// site next resolves something else. The default keeps that bounded to a handful of engines per tenant
+    /// while comfortably covering the number of evaluations a site normally has in flight at once, since
+    /// scripts are short and usually evaluated synchronously. Raise it for a tenant that evaluates scripts
+    /// on many concurrent requests, and lower it — or set it to <c>0</c> — for one whose scripts project
+    /// large object graphs into script and would rather not have them outlive the request.
+    /// </para>
+    /// </remarks>
+    public int EnginePoolSize { get; set; } = DefaultEnginePoolSize;
+}

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEnginePool.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEnginePool.cs
@@ -1,0 +1,169 @@
+using Jint;
+using JintOptions = Jint.Options;
+
+namespace OrchardCore.Scripting.JavaScript;
+
+/// <summary>
+/// Keeps a bounded set of idle Jint engines so that consecutive evaluations of the same tenant can share
+/// one, instead of paying for a new engine — and for re-declaring every registered global on it — per
+/// evaluated expression.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An engine is handed back to the pool only after its global bindings have been returned to the state they
+/// were captured in right after construction, through Jint's <c>GlobalSnapshot</c>. That reverts the
+/// variables and functions the evaluation declared, the eagerly installed per-scope methods, the top-level
+/// <c>let</c>/<c>const</c>/<c>class</c> declarations, and the interop wrapper caches, and it puts the
+/// registered globals back in their not-yet-created state so that the next evaluation builds them from its
+/// own services. What it deliberately does not revert is anything a script did to the built-in prototypes,
+/// or to an object graph reachable from a global it did not replace. Reuse is therefore confined to one
+/// tenant, where scripts are authored at a single trust level; see the remarks on
+/// <see cref="JavaScriptEngine"/>.
+/// </para>
+/// <para>
+/// The pool never blocks and never limits concurrency. A rental that finds no idle engine builds one, and a
+/// return that finds no free slot drops the engine on the floor for the garbage collector — exactly the
+/// behavior of every evaluation before pooling existed. The size is therefore a bound on how much state is
+/// <em>retained</em> between requests, not on how many evaluations can run at once.
+/// </para>
+/// </remarks>
+internal sealed class JavaScriptEnginePool
+{
+    private readonly JintOptions _options;
+
+    // One slot per pooled engine. A slot holds either an idle engine or null, and an engine is taken out of
+    // (and put back into) a slot with a single interlocked operation, so it is the exchange itself that
+    // hands the engine over: two callers can never come away with the same engine.
+    private readonly PooledJavaScriptEngine[] _idle;
+
+    // Set at most once, and only in the one direction. A realm whose global object resolves its properties
+    // from outside the engine cannot be captured, and cannot become capturable later, so the first refusal
+    // retires reuse for the lifetime of the tenant rather than being retried per evaluation.
+    private volatile bool _resetUnsupported;
+
+    internal JavaScriptEnginePool(JintOptions options, int size)
+    {
+        _options = options;
+        _idle = new PooledJavaScriptEngine[size];
+    }
+
+    /// <summary>
+    /// Gets an engine to evaluate on. The caller owns it until it passes the same rental to
+    /// <see cref="Return"/>, and must not use it afterwards.
+    /// </summary>
+    internal PooledJavaScriptEngine Rent()
+    {
+        var idle = _idle;
+
+        // Both ends scan from the lowest slot, which is what a tenant evaluating one expression at a time
+        // wants: the engine it just gave back goes into slot zero and comes straight back out of it, so the
+        // interpreter state that engine built for a script keeps paying off. Under real concurrency the
+        // rentals spread over the slots and each engine warms up for itself.
+        for (var i = 0; i < idle.Length; i++)
+        {
+            var candidate = Volatile.Read(ref idle[i]);
+
+            if (candidate is not null && Interlocked.CompareExchange(ref idle[i], null, candidate) == candidate)
+            {
+                return candidate;
+            }
+        }
+
+        return Create();
+    }
+
+    /// <summary>
+    /// Resets the engine of the given rental and makes it available again. A rental must be returned at most
+    /// once; <see cref="JavaScriptScope"/> guarantees that by handing the rental over with an interlocked
+    /// exchange, so the engine cannot still be reachable from the caller when this runs.
+    /// </summary>
+    internal void Return(PooledJavaScriptEngine rental)
+    {
+        var engine = rental.Engine;
+        var snapshot = rental.Snapshot;
+
+        // The service provider of the evaluation that has just ended must not be reachable from an idle
+        // engine, and must not be found by a global that somehow gets built on one. Detaching it turns a use
+        // of a returned engine into an exception on the first registered global it reads, rather than a
+        // delegate quietly built from another request's services.
+        JavaScriptScope.DetachServiceProvider(engine);
+
+        if (snapshot is null)
+        {
+            // This engine was built while resetting was known to be unsupported. It is not poolable and
+            // there is nothing to undo, so let it go.
+            return;
+        }
+
+        try
+        {
+            engine.Advanced.RestoreGlobalSnapshot(snapshot);
+        }
+        catch (Exception)
+        {
+            // The engine keeps whatever the evaluation left on it, so it must never be handed out again.
+            // The realistic cause is a caller ending the scope while an asynchronous evaluation it started
+            // is still outstanding, which Jint refuses to reset underneath. Dropping the engine is always
+            // correct and costs only the reuse; rethrowing would turn a caller's timing mistake into a
+            // failure of the disposal that is trying to clean up after it.
+            return;
+        }
+
+        var idle = _idle;
+
+        for (var i = 0; i < idle.Length; i++)
+        {
+            if (Volatile.Read(ref idle[i]) is null && Interlocked.CompareExchange(ref idle[i], rental, null) is null)
+            {
+                return;
+            }
+        }
+
+        // Every slot is taken: more evaluations were in flight at once than the pool is sized for. Dropping
+        // the engine is what keeps the size a real bound on retained state.
+    }
+
+    private PooledJavaScriptEngine Create()
+    {
+        var engine = new Engine(_options);
+
+        if (_resetUnsupported)
+        {
+            return new PooledJavaScriptEngine(engine, snapshot: null);
+        }
+
+        try
+        {
+            // Captured before anything of an evaluation has touched the engine, so the registered globals
+            // are recorded in their not-yet-created state and a reset puts them back that way. Capturing
+            // does not create them.
+            return new PooledJavaScriptEngine(engine, engine.Advanced.CaptureGlobalSnapshot());
+        }
+        catch (NotSupportedException)
+        {
+            // A host replaced the global object with one that stores its properties itself, so a snapshot
+            // could not tell what to put back. Reuse is off; evaluation is unaffected.
+            _resetUnsupported = true;
+
+            return new PooledJavaScriptEngine(engine, snapshot: null);
+        }
+    }
+}
+
+/// <summary>
+/// An engine and the snapshot of the global bindings it has to be returned to before it can be reused. The
+/// snapshot is <see langword="null"/> for an engine that cannot be reset, which is how <see cref="JavaScriptEnginePool.Return"/>
+/// knows to drop it.
+/// </summary>
+internal sealed class PooledJavaScriptEngine
+{
+    internal PooledJavaScriptEngine(Engine engine, GlobalSnapshot snapshot)
+    {
+        Engine = engine;
+        Snapshot = snapshot;
+    }
+
+    internal Engine Engine { get; }
+
+    internal GlobalSnapshot Snapshot { get; }
+}

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptScope.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptScope.cs
@@ -3,7 +3,7 @@ using Jint;
 
 namespace OrchardCore.Scripting.JavaScript;
 
-public class JavaScriptScope : IScriptingScope
+public class JavaScriptScope : IScriptingScope, IDisposable
 {
     // A lazily registered global is only materialized when a script reads it, which happens long after
     // the engine was built. The delegate it wraps is produced by a factory that takes the service
@@ -11,8 +11,17 @@ public class JavaScriptScope : IScriptingScope
     // The table holds the engine weakly, so an entry disappears together with the engine that keys it.
     private static readonly ConditionalWeakTable<Engine, IServiceProvider> _engineServiceProviders = new();
 
+    private readonly Engine _engine;
+    private readonly JavaScriptEnginePool _pool;
+
+    // The rental this scope has to give back, or null when the engine is not pooled or has already been
+    // given back. Exchanged rather than assigned, so that disposing twice returns the engine once.
+    private PooledJavaScriptEngine _rental;
+
+    private volatile bool _disposed;
+
     public JavaScriptScope(Engine engine, IServiceProvider serviceProvider, IEnumerable<GlobalMethod> methods)
-        : this(engine, serviceProvider, methods, lazyGlobals: null)
+        : this(engine, serviceProvider, methods, lazyGlobals: null, pool: null, rental: null)
     {
     }
 
@@ -20,9 +29,14 @@ public class JavaScriptScope : IScriptingScope
         Engine engine,
         IServiceProvider serviceProvider,
         IEnumerable<GlobalMethod> methods,
-        IReadOnlyDictionary<string, JavaScriptEngine.LazyGlobalMethod> lazyGlobals)
+        IReadOnlyDictionary<string, JavaScriptEngine.LazyGlobalMethod> lazyGlobals,
+        JavaScriptEnginePool pool,
+        PooledJavaScriptEngine rental)
     {
-        Engine = engine;
+        _engine = engine;
+        _pool = pool;
+        _rental = rental;
+
         ServiceProvider = serviceProvider;
 
         _engineServiceProviders.AddOrUpdate(engine, serviceProvider);
@@ -43,23 +57,79 @@ public class JavaScriptScope : IScriptingScope
 
             if (method.Method != null && !lazyGlobal.HasSyncGlobal)
             {
-                Engine.SetValue(method.Name, method.Method(ServiceProvider));
+                _engine.SetValue(method.Name, method.Method(ServiceProvider));
             }
 
             if (method.AsyncMethod != null && !lazyGlobal.HasAsyncGlobal)
             {
-                Engine.SetValue(method.Name + "Async", method.AsyncMethod(ServiceProvider));
+                _engine.SetValue(method.Name + "Async", method.AsyncMethod(ServiceProvider));
             }
         }
     }
 
-    public Engine Engine { get; }
+    /// <summary>
+    /// Gets the engine this scope evaluates on.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    /// The scope has been disposed. The engine may already be evaluating something else, so reaching it
+    /// through a scope that has given it up is reported rather than allowed.
+    /// </exception>
+    public Engine Engine
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            return _engine;
+        }
+    }
 
     public IServiceProvider ServiceProvider { get; }
+
+    /// <summary>
+    /// Ends the scope, releasing the engine for reuse by a later evaluation of the same tenant.
+    /// </summary>
+    /// <remarks>
+    /// Disposing more than once is safe and releases the engine once. Not disposing at all is safe too: the
+    /// engine is simply never reused, which is what every evaluation did before pooling existed. That is the
+    /// deliberate failure mode — an engine is single-threaded, so a scope that let go of one it might still
+    /// be using would be far worse than one that keeps an engine to itself forever.
+    /// </remarks>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        // The exchange, not the flag, is what makes the release happen exactly once: two threads disposing
+        // at the same time both set the flag, and only one of them comes away with the rental.
+        var rental = Interlocked.Exchange(ref _rental, null);
+
+        if (rental != null)
+        {
+            _pool.Return(rental);
+        }
+    }
 
     /// <summary>
     /// Gets the services of the scope that owns the given engine.
     /// </summary>
     internal static bool TryGetServiceProvider(Engine engine, out IServiceProvider serviceProvider)
         => _engineServiceProviders.TryGetValue(engine, out serviceProvider);
+
+    /// <summary>
+    /// Forgets the services associated with an engine whose scope has ended, so that neither the engine nor
+    /// anything it later builds can reach the service provider of a finished evaluation.
+    /// </summary>
+    internal static void DetachServiceProvider(Engine engine)
+        => _engineServiceProviders.Remove(engine);
 }

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -26,12 +26,27 @@ var globalMethods = _scriptingManager.GlobalMethodProviders.SelectMany(x => x.Ge
 // Create scope for the engine
 var scope = engine.CreateScope(globalMethods, serviceProvider, null, null);
 
-// Evaluate the given script
-var date = engine.Evaluate("js: new Date().toISOString()");
+try
+{
+    // Evaluate the given script
+    var date = engine.Evaluate(scope, "new Date().toISOString()");
+}
+finally
+{
+    // A scope may hold resources the engine wants back. IScriptingScope is a marker interface, so the
+    // capability is discovered rather than required.
+    (scope as IDisposable)?.Dispose();
+}
 ```
 
 The `js:` prefix is used to describe in which language the code is written. Any module can provide
 a new scripting engine by implementing the `IScriptingEngine` interface.
+
+Release the scope when the evaluations that use it are done, and not before. The JavaScript engine reuses
+its engines between evaluations and only learns that an evaluation is over when its scope is disposed, so a
+scope that is never disposed simply keeps its engine to itself — correct, but it gives up the reuse. Dispose
+it in a `finally`, because a script that throws has still left its declarations behind. Using
+`IScriptingManager.Evaluate()` instead of talking to an engine directly does all of this for you.
 
 ### Customizing the scripting environment
 
@@ -86,6 +101,65 @@ Three kinds of method are created eagerly instead, so a factory backing one of t
 - Methods passed directly to `IScriptingEngine.CreateScope()` rather than registered through DI, such as a recipe's `variables()` or a workflow's `workflow()`. These also take precedence over a registered global of the same name.
 - A name contributed by more than one registered provider, because which provider wins depends on the order the methods are set in.
 - A method carrying an asynchronous variant whose `<name>Async` global is also claimed by a method literally named `<name>Async`.
+
+### Engines are reused between evaluations
+
+A tenant keeps a small number of idle Jint engines and hands one to each scope instead of building an
+engine per evaluated expression. When a scope is disposed, the engine's global bindings are put back exactly
+as they were when it was built, and the engine becomes available to the next evaluation of the same tenant.
+
+What the reset undoes, so that no evaluation can observe the one before it:
+
+- the variables, functions and `globalThis` properties the script declared, and any global it overwrote;
+- top-level `let`, `const` and `class` declarations, which is what lets the same script run twice on one
+  engine;
+- the methods that were installed for that scope only, such as a recipe's `variables()` or a workflow's
+  `workflow()`;
+- the registered globals, which go back to their not-yet-created state, so the next evaluation builds them
+  from *its own* service provider — this is what keeps a request's services from reaching the next request;
+- the interop wrapper caches, so a property a script set on a wrapped CLR object does not reappear the next
+  time that object is wrapped;
+- any promise that was still pending, including one waiting on a CLR `Task`. It is dropped rather than
+  resumed, so a task that completes after the evaluation ended cannot write into the next one's globals.
+
+Execution constraints are unaffected: Jint rewinds a statement counter and a timeout deadline at the start
+of every evaluation, on a reused engine exactly as on a new one.
+
+!!! warning
+    **The reset is not an isolation boundary.** It reverts the global bindings; it does not revert what a
+    script did to the built-in prototypes (`Object.prototype.x = 1`, a frozen intrinsic), to
+    `Symbol.for`, or to an object graph reachable from a global it left in place. Engines are only ever
+    reused within one tenant, whose scripts are authored by its administrators and already run at a single
+    trust level — this is the same trust level as before, not a wider one. Do not use it to run scripts that
+    distrust each other.
+
+One thing to watch when writing a caller or a global method: **the value an evaluation returns must not
+depend on the engine still being in the state that produced it.** Results are converted to CLR values, which
+detaches objects, arrays and dates, but a script that returns a *function* hands back a delegate bound to the
+engine. Invoking it after the scope was disposed runs it against whatever that engine has since been reset —
+or re-rented — to.
+
+#### Sizing the pool
+
+```csharp
+services.Configure<JavaScriptEngineOptions>(options => options.EnginePoolSize = 16);
+```
+
+The default is `8`, and `0` turns reuse off and builds a new engine for every evaluation.
+
+This is **not** a concurrency limit. An evaluation that starts while every pooled engine is in use builds
+its own and lets it go afterwards, exactly as every evaluation did before pooling existed, so the value can
+never make an evaluation wait or fail. What it bounds is *retained state*: a reused engine remembers the
+last object each member access and each call in the scripts it has run resolved against, so it can hold one
+such object — a request's `HttpContext`, a workflow execution context — per site in those scripts, until
+that site next resolves something else. It is one live object per site per engine, and it is corrected the
+next time the same script runs, but it is real, and it is the reason the default is a handful of engines
+rather than one per concurrent request.
+
+Raise it for a tenant that evaluates scripts on many concurrent requests — JavaScript layer rules are the
+usual case, because the rules evaluator holds its scope for the whole request rather than for one
+expression. Lower it, or set it to `0`, for a tenant whose global methods project large object graphs into
+script and would rather not have them outlive the request.
 
 ### Methods
 

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -26,13 +26,28 @@ var globalMethods = _scriptingManager.GlobalMethodProviders.SelectMany(x => x.Ge
 // Create scope for the engine
 var scope = engine.CreateScope(globalMethods, serviceProvider, null, null);
 
-// Evaluate the given script. The engine is already the JavaScript one, so the
-// script is passed without the `js:` prefix, which only a directive carries.
-var date = engine.Evaluate(scope, "new Date().toISOString()");
+try
+{
+    // Evaluate the given script. The engine is already the JavaScript one, so the
+    // script is passed without the `js:` prefix, which only a directive carries.
+    var date = engine.Evaluate(scope, "new Date().toISOString()");
+}
+finally
+{
+    // A scope may hold resources the engine wants back. IScriptingScope is a marker interface, so the
+    // capability is discovered rather than required.
+    (scope as IDisposable)?.Dispose();
+}
 ```
 
 The `js:` prefix is used to describe in which language the code is written. Any module can provide
 a new scripting engine by implementing the `IScriptingEngine` interface.
+
+Release the scope when the evaluations that use it are done, and not before. The JavaScript engine reuses
+its engines between evaluations and only learns that an evaluation is over when its scope is disposed, so a
+scope that is never disposed simply keeps its engine to itself — correct, but it gives up the reuse. Dispose
+it in a `finally`, because a script that throws has still left its declarations behind. Using
+`IScriptingManager.Evaluate()` instead of talking to an engine directly does all of this for you.
 
 ### Customizing the scripting environment
 
@@ -87,6 +102,65 @@ Three kinds of method are created eagerly instead, so a factory backing one of t
 - Methods passed directly to `IScriptingEngine.CreateScope()` rather than registered through DI, such as a recipe's `variables()` or a workflow's `workflow()`. These also take precedence over a registered global of the same name.
 - A name contributed by more than one registered provider, because which provider wins depends on the order the methods are set in.
 - A method carrying an asynchronous variant whose `<name>Async` global is also claimed by a method literally named `<name>Async`.
+
+### Engines are reused between evaluations
+
+A tenant keeps a small number of idle Jint engines and hands one to each scope instead of building an
+engine per evaluated expression. When a scope is disposed, the engine's global bindings are put back exactly
+as they were when it was built, and the engine becomes available to the next evaluation of the same tenant.
+
+What the reset undoes, so that no evaluation can observe the one before it:
+
+- the variables, functions and `globalThis` properties the script declared, and any global it overwrote;
+- top-level `let`, `const` and `class` declarations, which is what lets the same script run twice on one
+  engine;
+- the methods that were installed for that scope only, such as a recipe's `variables()` or a workflow's
+  `workflow()`;
+- the registered globals, which go back to their not-yet-created state, so the next evaluation builds them
+  from *its own* service provider — this is what keeps a request's services from reaching the next request;
+- the interop wrapper caches, so a property a script set on a wrapped CLR object does not reappear the next
+  time that object is wrapped;
+- any promise that was still pending, including one waiting on a CLR `Task`. It is dropped rather than
+  resumed, so a task that completes after the evaluation ended cannot write into the next one's globals.
+
+Execution constraints are unaffected: Jint rewinds a statement counter and a timeout deadline at the start
+of every evaluation, on a reused engine exactly as on a new one.
+
+!!! warning
+    **The reset is not an isolation boundary.** It reverts the global bindings; it does not revert what a
+    script did to the built-in prototypes (`Object.prototype.x = 1`, a frozen intrinsic), to
+    `Symbol.for`, or to an object graph reachable from a global it left in place. Engines are only ever
+    reused within one tenant, whose scripts are authored by its administrators and already run at a single
+    trust level — this is the same trust level as before, not a wider one. Do not use it to run scripts that
+    distrust each other.
+
+One thing to watch when writing a caller or a global method: **the value an evaluation returns must not
+depend on the engine still being in the state that produced it.** Results are converted to CLR values, which
+detaches objects, arrays and dates, but a script that returns a *function* hands back a delegate bound to the
+engine. Invoking it after the scope was disposed runs it against whatever that engine has since been reset —
+or re-rented — to.
+
+#### Sizing the pool
+
+```csharp
+services.Configure<JavaScriptEngineOptions>(options => options.EnginePoolSize = 16);
+```
+
+The default is `8`, and `0` turns reuse off and builds a new engine for every evaluation.
+
+This is **not** a concurrency limit. An evaluation that starts while every pooled engine is in use builds
+its own and lets it go afterwards, exactly as every evaluation did before pooling existed, so the value can
+never make an evaluation wait or fail. What it bounds is *retained state*: a reused engine remembers the
+last object each member access and each call in the scripts it has run resolved against, so it can hold one
+such object — a request's `HttpContext`, a workflow execution context — per site in those scripts, until
+that site next resolves something else. It is one live object per site per engine, and it is corrected the
+next time the same script runs, but it is real, and it is the reason the default is a handful of engines
+rather than one per concurrent request.
+
+Raise it for a tenant that evaluates scripts on many concurrent requests — JavaScript layer rules are the
+usual case, because the rules evaluator holds its scope for the whole request rather than for one
+expression. Lower it, or set it to `0`, for a tenant whose global methods project large object graphs into
+script and would rather not have them outlive the request.
 
 ### Methods
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -81,6 +81,23 @@ Every engine created by `JavaScriptEngine` now exposes the globals of the regist
 
 Saving a JavaScript rule condition that contains a syntax error no longer fails with an unhandled exception. `Engine.PrepareScript()` wraps parser failures in `Jint.ScriptPreparationException`, which is now caught by the condition editor and reported as the intended validation message.
 
+### JavaScript Engines Are Reused Between Evaluations
+
+A tenant now keeps a small pool of Jint engines and hands one to each scripting scope, instead of building an engine for every evaluated expression. When a scope is disposed the engine's global bindings are restored to the state they were captured in when it was built, and the engine goes back into the pool.
+
+Building an engine, and declaring the tenant's registered globals on it, was the dominant cost of evaluating a short expression: for a recipe directive such as `[js:uuid()]` it is most of the work, and none of the interpreter state Jint builds while running a script survived to a second evaluation, because there never was one. Reuse keeps that state, so the second and later evaluations of the same script on a tenant are the ones that get faster.
+
+The reset undoes everything an evaluation can leave in the global scope — declared variables and functions, top-level `let`/`const`/`class`, overwritten globals, the methods installed for that scope only, and the interop wrapper caches. The registered globals go back to their not-yet-created state, so the next evaluation builds them from its own service provider; a pending promise, including one waiting on a CLR `Task`, is dropped rather than resumed into the next evaluation. Execution constraints are unaffected, since Jint rewinds a statement counter and a timeout deadline at the start of every evaluation.
+
+Points worth knowing:
+
+- **Engines are never shared between tenants.** `JavaScriptEngine` is registered per tenant, so its pool is too. The reset reverts global bindings and nothing else — not what a script did to the built-in prototypes, to `Symbol.for`, or to an object graph behind a global it left in place — so it is a configuration-reuse mechanism at one trust level, not an isolation boundary. Scripts within a tenant are authored by its administrators and already ran at a single trust level, so this is not a wider one than before.
+- **Scopes should be disposed.** `IScriptingScope` is a marker interface and gains no members, so nothing about implementing an engine changes; `JavaScriptScope` now implements `IDisposable` and `DefaultScriptingManager` releases the scope it creates in a `finally`. A caller that creates its own scope and never disposes it stays correct, its engine is simply collected instead of reused. Disposing while an asynchronous evaluation is still outstanding is the one case that gives the engine up without reusing it.
+- **The pool size is configurable** through `JavaScriptEngineOptions.EnginePoolSize`, which defaults to `8`; `0` restores the previous behavior of an engine per evaluation. It is not a concurrency limit — an evaluation that finds no idle engine builds one — but a bound on how much state is retained between requests, because a reused engine remembers the last object each script member access and call resolved against.
+- **A returned function outlives its engine's state.** Results are converted to CLR values, but a script returning a function hands back a delegate bound to the engine; invoking it after the scope was disposed runs it against whatever that engine has since been reset to.
+
+See the [Scripting documentation](../reference/modules/Scripting/README.md#engines-are-reused-between-evaluations) for the current behavior.
+
 ### JavaScript Engine Update
 
 The bundled JavaScript engine, Jint, was updated. Besides enabling the lazy globals described below, it changes two things that matter to sites configuring `IOptions<Jint.Options>`:

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -177,6 +177,23 @@ Every engine created by `JavaScriptEngine` now exposes the globals of the regist
 
 Saving a JavaScript rule condition that contains a syntax error no longer fails with an unhandled exception. `Engine.PrepareScript()` wraps parser failures in `Jint.ScriptPreparationException`, which is now caught by the condition editor and reported as the intended validation message.
 
+### JavaScript Engines Are Reused Between Evaluations
+
+A tenant now keeps a small pool of Jint engines and hands one to each scripting scope, instead of building an engine for every evaluated expression. When a scope is disposed the engine's global bindings are restored to the state they were captured in when it was built, and the engine goes back into the pool.
+
+Building an engine, and declaring the tenant's registered globals on it, was the dominant cost of evaluating a short expression: for a recipe directive such as `[js:uuid()]` it is most of the work, and none of the interpreter state Jint builds while running a script survived to a second evaluation, because there never was one. Reuse keeps that state, so the second and later evaluations of the same script on a tenant are the ones that get faster.
+
+The reset undoes everything an evaluation can leave in the global scope — declared variables and functions, top-level `let`/`const`/`class`, overwritten globals, the methods installed for that scope only, and the interop wrapper caches. The registered globals go back to their not-yet-created state, so the next evaluation builds them from its own service provider; a pending promise, including one waiting on a CLR `Task`, is dropped rather than resumed into the next evaluation. Execution constraints are unaffected, since Jint rewinds a statement counter and a timeout deadline at the start of every evaluation.
+
+Points worth knowing:
+
+- **Engines are never shared between tenants.** `JavaScriptEngine` is registered per tenant, so its pool is too. The reset reverts global bindings and nothing else — not what a script did to the built-in prototypes, to `Symbol.for`, or to an object graph behind a global it left in place — so it is a configuration-reuse mechanism at one trust level, not an isolation boundary. Scripts within a tenant are authored by its administrators and already ran at a single trust level, so this is not a wider one than before.
+- **Scopes should be disposed.** `IScriptingScope` is a marker interface and gains no members, so nothing about implementing an engine changes; `JavaScriptScope` now implements `IDisposable` and `DefaultScriptingManager` releases the scope it creates in a `finally`. A caller that creates its own scope and never disposes it stays correct, its engine is simply collected instead of reused. Disposing while an asynchronous evaluation is still outstanding is the one case that gives the engine up without reusing it.
+- **The pool size is configurable** through `JavaScriptEngineOptions.EnginePoolSize`, which defaults to `8`; `0` restores the previous behavior of an engine per evaluation. It is not a concurrency limit — an evaluation that finds no idle engine builds one — but a bound on how much state is retained between requests, because a reused engine remembers the last object each script member access and call resolved against.
+- **A returned function outlives its engine's state.** Results are converted to CLR values, but a script returning a function hands back a delegate bound to the engine; invoking it after the scope was disposed runs it against whatever that engine has since been reset to.
+
+See the [Scripting documentation](../reference/modules/Scripting/README.md#engines-are-reused-between-evaluations) for the current behavior.
+
 ### JavaScript Engine Update
 
 The bundled JavaScript engine, Jint, was updated. Besides enabling the lazy globals described below, it changes two things that matter to sites configuring `IOptions<Jint.Options>`:

--- a/test/OrchardCore.Benchmarks/EngineResetBenchmark.cs
+++ b/test/OrchardCore.Benchmarks/EngineResetBenchmark.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Acornima.Ast;
+using BenchmarkDotNet.Attributes;
+using Jint;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Scripting;
+using OrchardCore.Scripting.JavaScript;
+using JintOptions = Jint.Options;
+
+namespace OrchardCore.Benchmarks;
+
+/// <summary>
+/// Weighs the two ways of giving an evaluation a clean set of globals: building an engine, which is what
+/// every evaluated expression used to do, and resetting one that already exists, which is what reusing
+/// engines does instead.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="GlobalCount"/> parameter is the axis that matters. A tenant registers on the order of
+/// forty globals through <see cref="IGlobalMethodProvider"/>, and both operations scale with that number —
+/// construction because it installs a lazy property per global, the reset because it rebuilds the global
+/// object's property table. Running at zero as well as at forty separates the fixed cost of each operation
+/// from its per-global slope, which is what decides whether reuse is worth its plumbing: if resetting costs
+/// a large fraction of constructing, reuse buys only the engine's warm interpreter caches.
+/// </para>
+/// <para>
+/// Each row that mutates an engine owns one, built in <see cref="GlobalSetup"/> and warmed with that row's
+/// own script and nothing else. Sharing one engine between rows would make each row's number depend on which
+/// other rows exist, because an engine caches interpreter state per script it has run and because the
+/// scripts declare their globals on one global object.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class EngineResetBenchmark
+{
+    // The expression the campaign measured end to end: a literal, so that nothing but the cost of getting an
+    // engine ready to evaluate on ends up in the number.
+    private const string LiteralSource = "'literal'";
+
+    // A registered global being read, which is the shape of a real directive such as [js:uuid()]. Only this
+    // row makes the reset put a global that was actually built back into its unbuilt state.
+    private const string GlobalSource = "global0()";
+
+    private IServiceProvider _serviceProvider;
+    private JintOptions _options;
+
+    private Prepared<Script> _literal;
+    private Prepared<Script> _global;
+
+    private Engine _resetOnly;
+    private GlobalSnapshot _resetOnlySnapshot;
+
+    private Engine _evaluateLiteral;
+    private GlobalSnapshot _evaluateLiteralSnapshot;
+
+    private Engine _evaluateGlobal;
+    private GlobalSnapshot _evaluateGlobalSnapshot;
+
+    [Params(0, 40)]
+    public int GlobalCount { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var services = new ServiceCollection()
+            .AddMemoryCache()
+            .AddScripting()
+            .AddJavaScriptEngine();
+
+        if (GlobalCount > 0)
+        {
+            services.AddSingleton<IGlobalMethodProvider>(new CountedMethodProvider(GlobalCount));
+        }
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        // Resolving the scripting engine is what declares the registered globals on the shared Jint options,
+        // so the options can only be read back afterwards.
+        _serviceProvider.GetRequiredService<IScriptingManager>().GetScriptingEngine("js");
+        _options = _serviceProvider.GetRequiredService<IOptions<JintOptions>>().Value;
+
+        _literal = Engine.PrepareScript(LiteralSource);
+        _global = Engine.PrepareScript(GlobalCount > 0 ? GlobalSource : LiteralSource);
+
+        _resetOnly = CreateWarmEngine(default, warmUp: false, out _resetOnlySnapshot);
+        _evaluateLiteral = CreateWarmEngine(_literal, warmUp: true, out _evaluateLiteralSnapshot);
+        _evaluateGlobal = CreateWarmEngine(_global, warmUp: true, out _evaluateGlobalSnapshot);
+    }
+
+    /// <summary>
+    /// What <c>CreateScope</c> paid for every evaluated expression before engines were reused: an engine, its
+    /// realm, and one lazy property per registered global.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public Engine NewEngine() => new(_options);
+
+    /// <summary>
+    /// What ending a scope pays instead. Against <see cref="NewEngine"/> this is the whole question.
+    /// </summary>
+    [Benchmark]
+    public void ResetEngine() => _resetOnly.Advanced.RestoreGlobalSnapshot(_resetOnlySnapshot);
+
+    [Benchmark]
+    public object NewEngineThenEvaluateLiteral() => new Engine(_options).Evaluate(_literal).ToObject();
+
+    [Benchmark]
+    public object ResetEngineThenEvaluateLiteral()
+    {
+        var result = _evaluateLiteral.Evaluate(_literal).ToObject();
+        _evaluateLiteral.Advanced.RestoreGlobalSnapshot(_evaluateLiteralSnapshot);
+
+        return result;
+    }
+
+    /// <summary>
+    /// The same pair over a script that reads a registered global, so that the reset has a global which was
+    /// really built to put back into its unbuilt state, and the construction has one to build.
+    /// </summary>
+    [Benchmark]
+    public object NewEngineThenEvaluateGlobal()
+    {
+        var engine = new Engine(_options);
+
+        // Associating the engine with the services its registered globals are built from is part of what
+        // creating a scope does, so it belongs in the row that stands for creating one.
+        _ = new JavaScriptScope(engine, _serviceProvider, []);
+
+        return engine.Evaluate(_global).ToObject();
+    }
+
+    [Benchmark]
+    public object ResetEngineThenEvaluateGlobal()
+    {
+        var result = _evaluateGlobal.Evaluate(_global).ToObject();
+        _evaluateGlobal.Advanced.RestoreGlobalSnapshot(_evaluateGlobalSnapshot);
+
+        return result;
+    }
+
+    private Engine CreateWarmEngine(Prepared<Script> warmUpWith, bool warmUp, out GlobalSnapshot snapshot)
+    {
+        var engine = new Engine(_options);
+
+        // A scope is what associates the engine with the services a registered global is built from; without
+        // it, reading one throws.
+        _ = new JavaScriptScope(engine, _serviceProvider, []);
+
+        snapshot = engine.Advanced.CaptureGlobalSnapshot();
+
+        if (warmUp)
+        {
+            // One run of this row's own script, so the row measures a warm engine the way a reused one is,
+            // rather than the interpreter state Jint builds on a script's first evaluation.
+            engine.Evaluate(warmUpWith);
+            engine.Advanced.RestoreGlobalSnapshot(snapshot);
+        }
+
+        return engine;
+    }
+
+    private sealed class CountedMethodProvider : IGlobalMethodProvider
+    {
+        private readonly GlobalMethod[] _methods;
+
+        public CountedMethodProvider(int count)
+        {
+            _methods = Enumerable.Range(0, count)
+                .Select(i => new GlobalMethod
+                {
+                    Name = "global" + i.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    Method = _ => (Func<string>)(() => "value"),
+                })
+                .ToArray();
+        }
+
+        public IEnumerable<GlobalMethod> GetMethods() => _methods;
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Rules/JavascriptConditionEvaluatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Rules/JavascriptConditionEvaluatorTests.cs
@@ -1,0 +1,75 @@
+using OrchardCore.Rules.Models;
+using OrchardCore.Rules.Services;
+using OrchardCore.Scripting;
+using OrchardCore.Scripting.JavaScript;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Rules;
+
+/// <summary>
+/// The rules evaluator is the one caller that keeps a scripting scope alive for a whole request instead of
+/// for a single expression, so it is also the one that has to hand it back when the request ends.
+/// </summary>
+public class JavascriptConditionEvaluatorTests
+{
+    [Fact]
+    public async Task EvaluateAsync_ForSeveralConditions_KeepsOneScopeForTheRequest()
+    {
+        var (services, _) = CreateScriptingServices();
+
+        using var evaluator = new JavascriptConditionEvaluator(services.GetRequiredService<IScriptingManager>(), services);
+
+        // The second condition sees what the first left on the engine, which is what sharing one scope for
+        // the whole request means and what makes building it once worthwhile.
+        Assert.True(await evaluator.EvaluateAsync(new JavascriptCondition { Script = "return (globalThis.n = (globalThis.n || 0) + 1) === 1;" }));
+        Assert.True(await evaluator.EvaluateAsync(new JavascriptCondition { Script = "return (globalThis.n = (globalThis.n || 0) + 1) === 2;" }));
+    }
+
+    [Fact]
+    public async Task Dispose_AtTheEndOfTheRequest_ReleasesTheEngineForReuse()
+    {
+        var (services, scriptingEngine) = CreateScriptingServices();
+
+        // With a single pooled engine, the identity of the one the pool hands out is enough to tell whether
+        // the evaluator gave its engine back.
+        var warmUp = (JavaScriptScope)scriptingEngine.CreateScope([], services, null, null);
+        var engine = warmUp.Engine;
+        warmUp.Dispose();
+
+        var evaluator = new JavascriptConditionEvaluator(services.GetRequiredService<IScriptingManager>(), services);
+
+        Assert.True(await evaluator.EvaluateAsync(new JavascriptCondition { Script = "return true;" }));
+
+        evaluator.Dispose();
+
+        using var afterRequest = (JavaScriptScope)scriptingEngine.CreateScope([], services, null, null);
+
+        Assert.Same(engine, afterRequest.Engine);
+
+        // And what the request's conditions left behind did not come back with it.
+        Assert.Equal("undefined", scriptingEngine.Evaluate(afterRequest, "return typeof n;"));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_AfterDisposal_Throws()
+    {
+        var (services, _) = CreateScriptingServices();
+
+        var evaluator = new JavascriptConditionEvaluator(services.GetRequiredService<IScriptingManager>(), services);
+        evaluator.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await evaluator.EvaluateAsync(new JavascriptCondition { Script = "return true;" }));
+    }
+
+    private static (IServiceProvider Services, IScriptingEngine ScriptingEngine) CreateScriptingServices()
+    {
+        var services = new ServiceCollection()
+            .AddMemoryCache()
+            .AddScripting()
+            .AddJavaScriptEngine()
+            .Configure<JavaScriptEngineOptions>(options => options.EnginePoolSize = 1)
+            .BuildServiceProvider();
+
+        return (services, services.GetRequiredService<IScriptingManager>().GetScriptingEngine("js"));
+    }
+}

--- a/test/OrchardCore.Tests/Scripting/DefaultScriptingManagerTests.cs
+++ b/test/OrchardCore.Tests/Scripting/DefaultScriptingManagerTests.cs
@@ -1,0 +1,127 @@
+using OrchardCore.Scripting;
+
+namespace OrchardCore.Tests.Scripting;
+
+/// <summary>
+/// Pins that <see cref="DefaultScriptingManager"/> ends the scope it opens for a directive. Nothing else
+/// can: it creates one scope per evaluated expression and never hands it to the caller, so an engine that
+/// wants to know when the evaluation is over can only learn it from here.
+/// </summary>
+public class DefaultScriptingManagerTests
+{
+    [Fact]
+    public void Evaluate_WhenTheScriptSucceeds_DisposesTheScope()
+    {
+        var engine = new RecordingScriptingEngine();
+        var manager = new DefaultScriptingManager([engine], []);
+
+        Assert.Equal("evaluated", manager.Evaluate("test:anything", null, null, null));
+        Assert.Equal(1, engine.Scope.DisposeCount);
+    }
+
+    [Fact]
+    public void Evaluate_WhenTheScriptThrows_StillDisposesTheScope()
+    {
+        var engine = new RecordingScriptingEngine { Throw = true };
+        var manager = new DefaultScriptingManager([engine], []);
+
+        Assert.Throws<InvalidOperationException>(() => manager.Evaluate("test:anything", null, null, null));
+        Assert.Equal(1, engine.Scope.DisposeCount);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenTheScriptSucceeds_DisposesTheScopeAfterTheEvaluationCompletes()
+    {
+        var engine = new RecordingScriptingEngine();
+        var manager = new DefaultScriptingManager([engine], []);
+
+        var result = await manager.EvaluateAsync("test:anything", null, null, null, TestContext.Current.CancellationToken);
+
+        Assert.Equal("evaluated", result);
+
+        // Not merely disposed, but disposed after the awaited evaluation had finished: an engine cannot be
+        // reset while an asynchronous evaluation it started is still outstanding.
+        Assert.Equal(1, engine.Scope.DisposeCount);
+        Assert.True(engine.Scope.DisposedAfterEvaluation);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenTheScriptThrows_StillDisposesTheScope()
+    {
+        var engine = new RecordingScriptingEngine { Throw = true };
+        var manager = new DefaultScriptingManager([engine], []);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => manager.EvaluateAsync("test:anything", null, null, null, TestContext.Current.CancellationToken));
+
+        Assert.Equal(1, engine.Scope.DisposeCount);
+    }
+
+    [Fact]
+    public void Evaluate_WhenTheScopeIsNotDisposable_Succeeds()
+    {
+        // IScriptingScope is a marker interface, so an engine implemented outside this repository is under
+        // no obligation to return something disposable.
+        var manager = new DefaultScriptingManager([new PlainScriptingEngine()], []);
+
+        Assert.Equal("evaluated", manager.Evaluate("plain:anything", null, null, null));
+    }
+
+    private sealed class RecordingScriptingEngine : IScriptingEngine
+    {
+        public RecordingScope Scope { get; } = new();
+
+        public bool Throw { get; set; }
+
+        public string Prefix => "test";
+
+        public IScriptingScope CreateScope(IEnumerable<GlobalMethod> methods, IServiceProvider serviceProvider, IFileProvider fileProvider, string basePath)
+            => Scope;
+
+        public object Evaluate(IScriptingScope scope, string script)
+        {
+            if (Throw)
+            {
+                throw new InvalidOperationException("boom");
+            }
+
+            Scope.Evaluated = true;
+
+            return "evaluated";
+        }
+
+        public async Task<object> EvaluateAsync(IScriptingScope scope, string script, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+
+            return Evaluate(scope, script);
+        }
+    }
+
+    private sealed class RecordingScope : IScriptingScope, IDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public bool Evaluated { get; set; }
+
+        public bool DisposedAfterEvaluation { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            DisposedAfterEvaluation = Evaluated;
+        }
+    }
+
+    private sealed class PlainScriptingEngine : IScriptingEngine
+    {
+        public string Prefix => "plain";
+
+        public IScriptingScope CreateScope(IEnumerable<GlobalMethod> methods, IServiceProvider serviceProvider, IFileProvider fileProvider, string basePath)
+            => new PlainScope();
+
+        public object Evaluate(IScriptingScope scope, string script) => "evaluated";
+
+        private sealed class PlainScope : IScriptingScope;
+    }
+}

--- a/test/OrchardCore.Tests/Scripting/JavaScriptEnginePoolTests.cs
+++ b/test/OrchardCore.Tests/Scripting/JavaScriptEnginePoolTests.cs
@@ -1,0 +1,430 @@
+using Jint;
+using Jint.Runtime;
+using OrchardCore.Scripting;
+using OrchardCore.Scripting.JavaScript;
+
+namespace OrchardCore.Tests.Scripting;
+
+/// <summary>
+/// Pins the engine reuse that <see cref="JavaScriptEngine"/> does between evaluations: what a reused engine
+/// must have forgotten, and what must be true of it even when a caller uses a scope badly.
+/// </summary>
+public class JavaScriptEnginePoolTests
+{
+    [Fact]
+    public void DisposingAScope_LetsTheNextScopeReuseTheEngine()
+    {
+        var host = new TestHost();
+
+        var first = host.CreateScope();
+        var engine = first.Engine;
+        first.Dispose();
+
+        using var second = host.CreateScope();
+
+        Assert.Same(engine, second.Engine);
+    }
+
+    [Fact]
+    public void GlobalsDeclaredByOneEvaluation_AreNotVisibleToTheNext()
+    {
+        var host = new TestHost();
+
+        var first = host.CreateScope();
+        var engine = first.Engine;
+
+        Assert.Equal(1, Convert.ToInt32(host.Evaluate(first, "globalThis.leaked = 1; var alsoLeaked = 2; return 1;")));
+
+        first.Dispose();
+
+        using var second = host.CreateScope();
+
+        Assert.Same(engine, second.Engine);
+        Assert.Equal("undefined,undefined", host.Evaluate(second, "return typeof leaked + ',' + typeof alsoLeaked;"));
+    }
+
+    [Fact]
+    public void LexicalDeclarationsMadeByOneEvaluation_AreNotVisibleToTheNext()
+    {
+        var host = new TestHost();
+
+        var first = host.CreateScope();
+        var engine = first.Engine;
+
+        // Nothing in Jint's public API other than a snapshot restore can undo a top-level let/const, so
+        // re-running the same script on the same engine would otherwise fail with a redeclaration error.
+        Assert.Equal(1, Convert.ToInt32(host.Evaluate(first, "let declaredOnce = 1; return declaredOnce;")));
+
+        first.Dispose();
+
+        using var second = host.CreateScope();
+
+        Assert.Same(engine, second.Engine);
+        Assert.Equal(2, Convert.ToInt32(host.Evaluate(second, "let declaredOnce = 2; return declaredOnce;")));
+    }
+
+    [Fact]
+    public void AScriptThatThrows_StillLeavesACleanEngineForTheNextScope()
+    {
+        var host = new TestHost();
+
+        var first = host.CreateScope();
+        var engine = first.Engine;
+
+        try
+        {
+            Assert.Throws<JavaScriptException>(() => host.Evaluate(first, "globalThis.dirty = 1; throw new Error('boom');"));
+        }
+        finally
+        {
+            first.Dispose();
+        }
+
+        using var second = host.CreateScope();
+
+        Assert.Same(engine, second.Engine);
+        Assert.Equal("undefined", host.Evaluate(second, "return typeof dirty;"));
+    }
+
+    [Fact]
+    public void ARegisteredGlobal_IsRebuiltFromTheServicesOfTheScopeThatReadsIt()
+    {
+        // The whole reason a reused engine is safe: a registered global is a delegate built from the
+        // services of one evaluation, so reusing the engine without putting the global back in its
+        // not-yet-built state would serve the next request a delegate closed over the previous request's
+        // service provider.
+        var host = new TestHost();
+
+        using var firstServices = host.CreateServiceScope("first");
+        var first = host.CreateScope(firstServices);
+        var engine = first.Engine;
+
+        Assert.Equal("first", host.Evaluate(first, "return owningScope();"));
+        Assert.Equal(1, host.Provider.BuildCount);
+
+        first.Dispose();
+
+        using var secondServices = host.CreateServiceScope("second");
+        using var second = host.CreateScope(secondServices);
+
+        Assert.Same(engine, second.Engine);
+        Assert.Equal("second", host.Evaluate(second, "return owningScope();"));
+        Assert.Equal(2, host.Provider.BuildCount);
+    }
+
+    [Fact]
+    public void AMethodShadowingARegisteredGlobal_DoesNotOutliveItsScope()
+    {
+        var host = new TestHost();
+
+        var shadow = new GlobalMethod
+        {
+            Name = "owningScope",
+            Method = _ => (Func<string>)(() => "shadowed"),
+        };
+
+        using var firstServices = host.CreateServiceScope("first");
+        var first = host.CreateScope(firstServices, shadow);
+        var engine = first.Engine;
+
+        Assert.Equal("shadowed", host.Evaluate(first, "return owningScope();"));
+
+        first.Dispose();
+
+        using var secondServices = host.CreateServiceScope("second");
+        using var second = host.CreateScope(secondServices);
+
+        Assert.Same(engine, second.Engine);
+        Assert.Equal("second", host.Evaluate(second, "return owningScope();"));
+    }
+
+    [Fact]
+    public async Task APromiseRegisteredBeforeAResetDoesNotSettleIntoTheNextEvaluation()
+    {
+        var host = new TestHost();
+
+        using var firstServices = host.CreateServiceScope("first");
+        var first = host.CreateScope(firstServices);
+        var engine = first.Engine;
+
+        // A fire-and-forget async function suspended on a CLR task. Nothing awaits the promise it returns,
+        // so the assignment happens whenever the task completes — which here is after the scope has ended.
+        host.Evaluate(first, "(async () => { globalThis.settled = await pendingAsync(); })(); return 1;");
+
+        first.Dispose();
+
+        host.Pending.SetResult("late");
+
+        // Give the task's continuation a chance to reach the engine. The assertion holds whether or not it
+        // gets there in time, so this cannot make the test flaky; it only makes it exercise the fence.
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        using var secondServices = host.CreateServiceScope("second");
+        using var second = host.CreateScope(secondServices);
+
+        Assert.Same(engine, second.Engine);
+        Assert.Equal("undefined", host.Evaluate(second, "return typeof settled;"));
+    }
+
+    [Fact]
+    public async Task ConcurrentScopes_NeverShareAnEngine()
+    {
+        var host = new TestHost(poolSize: 4);
+
+        var inUse = new ConcurrentDictionary<Engine, Holder>();
+        var shared = 0;
+
+        await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            for (var iteration = 0; iteration < 40; iteration++)
+            {
+                var scope = host.CreateScope();
+                var holder = inUse.GetOrAdd(scope.Engine, static _ => new Holder());
+
+                if (Interlocked.Increment(ref holder.Count) != 1)
+                {
+                    Interlocked.Increment(ref shared);
+                }
+
+                try
+                {
+                    // Every scope starts from a reset engine, so the counter can only ever reach 1. Two
+                    // scopes sharing an engine would be caught here as well as by the holder above.
+                    var marks = Convert.ToInt32(host.Evaluate(scope, "globalThis.marks = (globalThis.marks || 0) + 1; return globalThis.marks;"));
+
+                    Assert.Equal(1, marks);
+                }
+                finally
+                {
+                    // Released before the engine is, because disposing is what makes it available to
+                    // another worker.
+                    Interlocked.Decrement(ref holder.Count);
+                    scope.Dispose();
+                }
+            }
+        })));
+
+        Assert.Equal(0, shared);
+    }
+
+    [Fact]
+    public void ALeakedScope_KeepsItsEngineOutOfThePoolWithoutDisturbingIt()
+    {
+        var host = new TestHost();
+
+        // Deliberately never disposed: the failure mode of a caller that forgets has to be "this engine is
+        // never reused", never "this engine is handed to somebody else as well".
+        var leaked = host.CreateScope();
+        var leakedEngine = leaked.Engine;
+
+        var second = host.CreateScope();
+        var secondEngine = second.Engine;
+
+        Assert.NotSame(leakedEngine, secondEngine);
+
+        second.Dispose();
+
+        using var third = host.CreateScope();
+
+        Assert.Same(secondEngine, third.Engine);
+
+        // The leaked scope keeps working; it simply owns its engine forever.
+        Assert.Equal(2, Convert.ToInt32(host.Evaluate(leaked, "return 1 + 1;")));
+    }
+
+    [Fact]
+    public void DisposingAScopeTwice_ReleasesTheEngineOnce()
+    {
+        var host = new TestHost();
+
+        var scope = host.CreateScope();
+        var engine = scope.Engine;
+
+        scope.Dispose();
+        scope.Dispose();
+
+        using var second = host.CreateScope();
+        using var third = host.CreateScope();
+
+        // Had the double disposal put the engine into two slots, both of these would be the same instance
+        // and two callers would be evaluating on one engine.
+        Assert.Same(engine, second.Engine);
+        Assert.NotSame(second.Engine, third.Engine);
+    }
+
+    [Fact]
+    public void UsingAScopeAfterItHasBeenDisposed_Throws()
+    {
+        var host = new TestHost();
+
+        var scope = host.CreateScope();
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => host.Evaluate(scope, "return 1;"));
+    }
+
+    [Fact]
+    public void ExecutionConstraints_AreRewoundForEachEvaluation()
+    {
+        // A tenant configures its statement budget and its timeout once, on options shared by every engine.
+        // Both keep per-execution state, so a reused engine that did not rewind them would start each
+        // evaluation with the previous one's budget already spent.
+        var host = new TestHost(configureJint: options => options.MaxStatements(50));
+
+        var first = host.CreateScope();
+        var engine = first.Engine;
+
+        Assert.Throws<StatementsCountOverflowException>(() => host.Evaluate(first, "for (var i = 0; i < 1000; i++) { }"));
+
+        first.Dispose();
+
+        using var second = host.CreateScope();
+
+        Assert.Same(engine, second.Engine);
+        Assert.Equal(1, Convert.ToInt32(host.Evaluate(second, "return 1;")));
+    }
+
+    [Fact]
+    public void APoolSizeOfZero_BuildsANewEngineForEveryScope()
+    {
+        var host = new TestHost(poolSize: 0);
+
+        var first = host.CreateScope();
+        var engine = first.Engine;
+        first.Dispose();
+
+        using var second = host.CreateScope();
+
+        Assert.NotSame(engine, second.Engine);
+    }
+
+    [Fact]
+    public void ThePoolSize_BoundsHowManyEnginesAreKept()
+    {
+        var host = new TestHost(poolSize: 2);
+
+        var scopes = new[] { host.CreateScope(), host.CreateScope(), host.CreateScope() };
+        var firstRound = scopes.Select(scope => scope.Engine).ToArray();
+
+        Assert.Equal(3, firstRound.Distinct().Count());
+
+        foreach (var scope in scopes)
+        {
+            scope.Dispose();
+        }
+
+        var reused = new[] { host.CreateScope(), host.CreateScope(), host.CreateScope() };
+        var secondRound = reused.Select(scope => scope.Engine).ToArray();
+
+        foreach (var scope in reused)
+        {
+            scope.Dispose();
+        }
+
+        // Two of the three were kept; the third was dropped when the pool had no free slot for it.
+        Assert.Equal(2, secondRound.Intersect(firstRound).Count());
+        Assert.Equal(4, firstRound.Concat(secondRound).Distinct().Count());
+    }
+
+    private sealed class Holder
+    {
+        public int Count;
+    }
+
+    /// <summary>
+    /// A tenant's worth of scripting services, with one registered global whose value identifies the service
+    /// scope it was built from and one that suspends on a task the test controls.
+    /// </summary>
+    private sealed class TestHost
+    {
+        private readonly IServiceProvider _rootServices;
+        private readonly IScriptingEngine _engine;
+        private readonly GlobalMethod[] _methods;
+
+        public TestHost(int? poolSize = null, Action<Jint.Options> configureJint = null)
+        {
+            Provider = new OwningScopeMethodProvider(this);
+
+            var services = new ServiceCollection()
+                .AddMemoryCache()
+                .AddScripting()
+                .AddJavaScriptEngine()
+                .AddScoped<ServiceScopeName>()
+                .AddSingleton<IGlobalMethodProvider>(Provider);
+
+            if (poolSize.HasValue)
+            {
+                services.Configure<JavaScriptEngineOptions>(options => options.EnginePoolSize = poolSize.Value);
+            }
+
+            if (configureJint != null)
+            {
+                services.Configure(configureJint);
+            }
+
+            _rootServices = services.BuildServiceProvider();
+
+            var scriptingManager = _rootServices.GetRequiredService<IScriptingManager>();
+
+            _engine = scriptingManager.GetScriptingEngine("js");
+            _methods = scriptingManager.GlobalMethodProviders.SelectMany(provider => provider.GetMethods()).ToArray();
+        }
+
+        public OwningScopeMethodProvider Provider { get; }
+
+        public TaskCompletionSource<string> Pending { get; } = new();
+
+        public IServiceScope CreateServiceScope(string name)
+        {
+            var serviceScope = _rootServices.CreateScope();
+            serviceScope.ServiceProvider.GetRequiredService<ServiceScopeName>().Value = name;
+
+            return serviceScope;
+        }
+
+        public JavaScriptScope CreateScope()
+            => (JavaScriptScope)_engine.CreateScope(_methods, _rootServices, null, null);
+
+        public JavaScriptScope CreateScope(IServiceScope serviceScope, params GlobalMethod[] extraMethods)
+            => (JavaScriptScope)_engine.CreateScope(_methods.Concat(extraMethods), serviceScope.ServiceProvider, null, null);
+
+        public object Evaluate(IScriptingScope scope, string script)
+            => _engine.Evaluate(scope, script);
+    }
+
+    private sealed class ServiceScopeName
+    {
+        public string Value { get; set; }
+    }
+
+    private sealed class OwningScopeMethodProvider : IGlobalMethodProvider
+    {
+        private readonly GlobalMethod[] _methods;
+
+        public OwningScopeMethodProvider(TestHost host)
+        {
+            _methods =
+            [
+                new GlobalMethod
+                {
+                    Name = "owningScope",
+                    Method = serviceProvider =>
+                    {
+                        BuildCount++;
+
+                        return (Func<string>)(() => serviceProvider.GetRequiredService<ServiceScopeName>().Value);
+                    },
+                },
+                new GlobalMethod
+                {
+                    Name = "pending",
+                    AsyncMethod = _ => (Func<Task<string>>)(() => host.Pending.Task),
+                },
+            ];
+        }
+
+        public int BuildCount { get; private set; }
+
+        public IEnumerable<GlobalMethod> GetMethods() => _methods;
+    }
+}


### PR DESCRIPTION
> Draft for review — this is the largest behavioural change of the scripting work and it deserves scrutiny before it goes ready. Measured with #19640's benchmark, which is now merged.
>
> Rebased onto current `main` (which carries Jint 4.16.0, #19733). Two files here will need a merge whichever of the scripting PRs lands second, and both are mechanical rather than design questions: #19648 also adds `test/OrchardCore.Tests/Scripting/DefaultScriptingManagerTests.cs` and rewrites the same `DefaultScriptingManager` methods, and #19647 restructures the same part of `JavaScriptScope`. Kept on `main` rather than stacked so that neither of those has to carry this one to be reviewed.

## The problem

`DefaultScriptingManager` builds a scope — and with it a Jint `Engine` — for **every** directive it evaluates. One per `[js:…]` value in a recipe (208 of them in this repository's own recipes), one per script expression in a workflow run, one per scripted external login.

Measured: evaluating the literal `'literal'` end to end costs **3.96 µs and 15.6 KB**. That is engine construction plus declaring ~40 registered globals, before any script does any work — **61–96% of every row** in the benchmark. Two consequences: the engine's interpreter caches only pay back on the second evaluation of a script on the same engine, which a fresh engine per operation never reaches; and the lazy-global registrations are replayed for every engine.

## The change

A per-tenant pool. `CreateScope` rents an engine; disposing the scope resets it with Jint's `GlobalSnapshot` and returns it.

`JavaScriptEnginePool` is a fixed-size array. An engine leaves a slot by `Interlocked.CompareExchange(ref slot, null, candidate)` and returns by `CompareExchange(ref slot, rental, null)` — **the exchange is the handover**, so two callers can never come away with the same engine. No locks, no counters, no blocking. Both ends scan from slot 0, so a quiet tenant reuses one engine and keeps its warm interpreter caches, while under load rentals spread out and each engine warms for itself.

The snapshot is captured immediately after construction, before anything has touched the engine. If `CaptureGlobalSnapshot` throws `NotSupportedException` (a host-substituted global object) pooling retires for that tenant and behaviour falls back to today's.

### Is the reset actually cheaper than construction?

That was the question the whole design turned on, and `EngineResetBenchmark` (added here) answers it. Forty registered globals:

| | new engine | reset | ratio |
|---|---:|---:|---:|
| get an engine ready | 1875 ns / 14544 B | **546 ns / 3024 B** | 0.29× / 0.21× |
| …then evaluate a global | 3098 ns / 16184 B | **933 ns / 3536 B** | **0.30× / 0.22×** |

The same 0.29 ratio holds at zero globals, so the saving is the engine scaffolding itself and not only the globals. The row is parameterised `[Params(0, 40)]` because the per-global *slope* was the real risk: reset re-inserts every registered global, so it does not save the property installs — it saves the descriptor allocations and everything around them. Reset's slope is ~8.8 ns per global against construction's ~30 ns.

### End to end

`ScriptingBenchmark` from #19640, same session:

| Row | before | after | time | alloc |
|---|---:|---:|---:|---:|
| `Recipe_OneGlobal` | 4.182 µs | 2.265 µs | **−45.8%** | **−73.4%** |
| `Recipe_Constant` | 3.958 µs | 1.726 µs | **−56.4%** | **−73.7%** |
| `Workflow_Input` | 5.188 µs | 3.113 µs | −40.0% | −63.7% |
| `Workflow_Composite` | 6.627 µs | 3.818 µs | −42.4% | −65.8% |
| `LayerRule_PerRequest_ThreeRules` | 6.755 µs | 4.121 µs | −39.0% | −67.3% |

## Scope lifetime

`IScriptingScope` is untouched — adding `IDisposable` to it would be source-breaking for third-party implementers. Three owners release instead: `DefaultScriptingManager` in a `finally` (the async path `await`s rather than returning the task, so release happens after the evaluation actually finished), and `JavascriptConditionEvaluator`, which is `AddScoped` so the container releases it at end of request.

**A leak is one-sided by construction.** A rental is handed over with `Interlocked.Exchange(ref _rental, null)`, so disposing twice returns once, and never disposing means the engine is simply never in a slot and is collected. The service provider is removed from the engine→services map on return, so an idle engine cannot reach a finished request's services and a use-after-return throws instead of building a delegate from another request's DI scope.

## What the pool size bounds

**Not concurrency.** An evaluation that starts while every engine is in use builds its own and lets it go. What it bounds is *retained state*: a reused engine remembers the last object each member access and each call resolved against, so it can hold one such object — a request's `HttpContext`, a workflow execution context — per site in the scripts it has run, until that site next resolves something else. One live object per site per engine, corrected the next time the same script runs, but real — and the reason the default is 8 rather than one per concurrent request. Configurable via `JavaScriptEngineOptions.EnginePoolSize`; `0` disables pooling entirely.

Sites using JavaScript layer rules should know that `JavascriptConditionEvaluator` holds its scope for the whole *request*, so they are sized against concurrent requests and may want to raise it.

## One behaviour change

A script returning a **function** yields a delegate bound to its engine. Invoking it after the scope is disposed now runs against a reset — possibly re-rented — engine. Nothing in-tree does this; a third party could. Documented in the XML docs, the README and the release note.

## Two hazards checked and cleared

- **Execution constraints.** `MaxStatements` and `TimeoutInterval` carry per-execution state; had Jint not rewound them, a site with a statement budget would start throwing after N evaluations on a pooled engine. Jint resets them on entry and exit of every non-nested execution, and there is a test.
- **Re-entrancy.** `VariablesMethodProvider` calls back into `IScriptingManager` from *inside* a global method. That nested call is safe precisely because renting removes an engine from its slot, so the outer engine is unreachable while checked out.

## A dependency on Jint, now a contract

The reset re-arms the lazy globals because the descriptor `Options.AddLazyGlobal` installs is one `RestoreGlobalSnapshot` knows how to revert. When this PR was opened that rested on an `internal` Jint interface with nothing in the public contract pinning it — and had it ever stopped holding, the failure would have been silent: a pooled engine serving a global closed over the previous request's `IServiceProvider`.

That is no longer the case. [jint#2892](https://github.com/sebastienros/jint/pull/2892) made the re-arm a documented guarantee with its own tests upstream, and it shipped in Jint 4.16.0, which `main` now uses. The test here asserting a registered global is rebuilt **from the next scope's services** stays as the local gate, but it is now pinning documented behaviour rather than an accident.

## Tests

24 new. `JavaScriptEnginePoolTests` (14) covers engine reuse, `globalThis`/`var`/`let` not leaking between evaluations, a throwing script still leaving a clean engine, a registered global rebuilt from the next scope's services, a promise pending across a reset never settling into the next evaluation, constraints rewound per evaluation, 8 workers × 40 iterations never sharing an engine, a leaked scope keeping its engine out of the pool without disturbing it, double dispose releasing once, use-after-dispose throwing, and pool sizes 0 and 2. `DefaultScriptingManagerTests` (5) and `JavascriptConditionEvaluatorTests` (3) cover the disposal plumbing.

Full suite: 2478 passed, 0 failed, 1 CI-only skip. The test assembly runs with Jint's host-contract verifiers on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
