### PR TITLE
Update release notes for admin menu reorganization

### DIFF
--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -557,8 +557,8 @@ The `AdminMenu` format has changed. Admin menus already stored in the database a
 The admin menu has been reorganized to improve navigation and discoverability. See [PR #17112](https://github.com/OrchardCMS/OrchardCore/pull/17112). Key changes:
 
 - All site settings are now consolidated under a single **Settings** menu.
-- The **Configuration** menu has been replaced by a new **Tools** menu. **Workflows** and **Audit Trail** were moved from the root level into **Tools**.
-- **Content Definitions** has been moved to the **Design** menu.
+- The **Configuration** menu has been replaced by a new **Tools** menu. **Audit Trail** were moved from the root level into **Tools**.
+- **Workflows** and **Content Definitions** has been moved to the **Design** menu.
 - User, role, and authentication-related items are grouped under a new **Access Control** menu.
 
 **Impact:**

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -552,7 +552,7 @@ The `AdminMenu` format has changed. Admin menus already stored in the database a
 - Add a `MenuName` property to each menu item, set to the same value as the `Name` property of the `AdminMenu` that contains the item.
 - In every `OrchardCore.Contents.AdminNodes.ContentTypesAdminNode, OrchardCore.Contents` node, update each entry of the `ContentTypes` array: remove the `ContentTypeId` property and add a `ContentTypeName` property (set to the former `ContentTypeId` value) and a `ContentTypeDisplayName` property (set to the content type's `DisplayName`).
 
-### Admin Menu Reorganization
+#### Admin Menu Reorganization
 
 The admin menu has been reorganized to improve navigation and discoverability. See [PR #17112](https://github.com/OrchardCMS/OrchardCore/pull/17112). Key changes:
 

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -552,6 +552,31 @@ The `AdminMenu` format has changed. Admin menus already stored in the database a
 - Add a `MenuName` property to each menu item, set to the same value as the `Name` property of the `AdminMenu` that contains the item.
 - In every `OrchardCore.Contents.AdminNodes.ContentTypesAdminNode, OrchardCore.Contents` node, update each entry of the `ContentTypes` array: remove the `ContentTypeId` property and add a `ContentTypeName` property (set to the former `ContentTypeId` value) and a `ContentTypeDisplayName` property (set to the content type's `DisplayName`).
 
+### Admin Menu Reorganization
+
+The admin menu has been reorganized to improve navigation and discoverability. See [PR #17112](https://github.com/OrchardCMS/OrchardCore/pull/17112). Key changes:
+
+- All site settings are now consolidated under a single **Settings** menu.
+- The **Configuration** menu has been replaced by a new **Tools** menu. **Workflows** and **Audit Trail** were moved from the root level into **Tools**.
+- **Content Definitions** has been moved to the **Design** menu.
+- User, role, and authentication-related items are grouped under a new **Access Control** menu.
+
+**Impact:**
+
+- If your module registers admin menu items via `INavigationProvider`, verify their placement under the new structure and update the parent menu names ("Configuration" no longer exists).
+- If you have custom `AdminMenu` nodes, recipes, or documentation/training material referencing old menu paths, update them accordingly.
+- Permission-trimmed menus are unaffected functionally, but items may appear in different locations.
+
+**Legacy mode:**
+
+If you are not ready to adopt the new menu structure, you can restore the legacy layout by adding the following to your startup project:
+
+```csharp
+AppContext.SetSwitch("LegacyAdminMenuNavigation", true);
+```
+
+Note that legacy mode is intended as a transitional aid and may be removed in a future release.
+
 ### Removed APIs
 
 The following APIs have been removed from Orchard Core:


### PR DESCRIPTION
Documented the reorganization of the admin menu for better navigation, detailing key changes and impacts on existing modules and customizations.
PR [#17112](https://github.com/OrchardCMS/OrchardCore/pull/17112) reorganizes the admin menu (Settings consolidated, "Configuration" replaced by "Tools", Content definitions moved to Design, new Access Control grouping, with a legacy opt-out switch).

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
