### PR TITLE
style: distinguish static field names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -141,6 +141,17 @@ dotnet_naming_rule.private_fields_should_be_camel_case_leading_underscore.severi
 dotnet_naming_rule.private_fields_should_be_camel_case_leading_underscore.symbols = private_fields
 dotnet_naming_rule.private_fields_should_be_camel_case_leading_underscore.style = camel_case_leading_underscore
 
+# Static fields use a distinct prefix so their lifetime is visible at a glance.
+dotnet_naming_style.static_fields_leading_s.prefix = s_
+dotnet_naming_style.static_fields_leading_s.capitalization = camel_case
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+dotnet_naming_rule.private_static_fields_should_have_prefix.severity = warning
+dotnet_naming_rule.private_static_fields_should_have_prefix.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_have_prefix.style = static_fields_leading_s
 # Define the 'private_const_fields' symbol group.
 dotnet_naming_symbols.private_const_fields.applicable_kinds = field
 dotnet_naming_symbols.private_const_fields.applicable_accessibilities = private


### PR DESCRIPTION
## Summary

Resolves #19618.

Adds the proposed `s_` naming rule for private, internal, and private-protected static fields while preserving the existing `_` convention for instance fields. The rule is a warning so it can guide incremental adoption without making the existing codebase fail builds.

## Validation

- Compared the resulting `.editorconfig` against `main`; the change is limited to the requested naming rule.
- No source files were renamed or reformatted.

Let me know what you think.