### PR TITLE
Add permission implication support to security system

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RolesPermissionsHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RolesPermissionsHandler.cs
@@ -1,7 +1,10 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Security;
+using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Roles;
 
@@ -13,14 +16,16 @@ public class RolesPermissionsHandler : AuthorizationHandler<PermissionRequiremen
     private readonly RoleManager<IRole> _roleManager;
     private readonly IPermissionGrantingService _permissionGrantingService;
 
-
     private IEnumerable<RoleClaim> _anonymousClaims;
     private IEnumerable<RoleClaim> _authenticatedClaims;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
     public RolesPermissionsHandler(
         RoleManager<IRole> roleManager,
-        IPermissionGrantingService permissionGrantingService)
+        IPermissionGrantingService permissionGrantingService,
+        IHttpContextAccessor httpContextAccessor)
     {
+        _httpContextAccessor = httpContextAccessor;
         _roleManager = roleManager;
         _permissionGrantingService = permissionGrantingService;
     }
@@ -50,7 +55,24 @@ public class RolesPermissionsHandler : AuthorizationHandler<PermissionRequiremen
         if (_permissionGrantingService.IsGranted(requirement, claims))
         {
             context.Succeed(requirement);
-            return;
+        }
+        else
+        {
+            var permissionService = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService<IPermissionService>();
+
+            foreach (var impliedBy in await permissionService.GetImplyingPermissionsAsync(requirement.Permission.Name))
+            {
+                if (impliedBy == null)
+                {
+                    continue;
+                }
+
+                if (_permissionGrantingService.IsGranted(new PermissionRequirement(impliedBy), context.User.Claims))
+                {
+                    context.Succeed(requirement);
+                    break;
+                }
+            }
         }
     }
 

--- a/src/OrchardCore/OrchardCore.Email.Core/EmailPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Email.Core/EmailPermissions.cs
@@ -1,8 +1,9 @@
 using OrchardCore.Security.Permissions;
+using OrchardCore.Settings;
 
 namespace OrchardCore.Email;
 
 public static class EmailPermissions
 {
-    public static readonly Permission ManageEmailSettings = new("ManageEmailSettings", "Manage Email Settings");
+    public static readonly Permission ManageEmailSettings = new("ManageEmailSettings", "Manage Email Settings", null, [new Permission("ManageCustomSettings_email", "", [SettingsPermissions.ManageGroupSettings])]);
 }

--- a/src/OrchardCore/OrchardCore.Email.Core/OrchardCore.Email.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Email.Core/OrchardCore.Email.Core.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Email.Abstractions\OrchardCore.Email.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.Infrastructure.Abstractions\OrchardCore.Infrastructure.Abstractions.csproj" />
+    <ProjectReference Include="..\OrchardCore.Settings.Core\OrchardCore.Settings.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/DefaultPermissionService.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/DefaultPermissionService.cs
@@ -29,6 +29,28 @@ public sealed class DefaultPermissionService : IPermissionService
         return null;
     }
 
+    public async ValueTask<IEnumerable<Permission>> GetImplyingPermissionsAsync(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        if (_permissions is null)
+        {
+            await LoadPermissionsAsync();
+        }
+
+        List<Permission> permissions = null;
+        foreach (var permission in _permissions.Values)
+        {
+            if (permission.Implies?.Any(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase)) == true)
+            {
+                permissions ??= new List<Permission>();
+                permissions.Add(permission);
+            }
+        }
+
+        return permissions ?? Enumerable.Empty<Permission>();
+    }
+
     public async ValueTask<IEnumerable<Permission>> GetPermissionsAsync()
     {
         if (_permissions == null)

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/IPermissionService.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/IPermissionService.cs
@@ -4,5 +4,7 @@ public interface IPermissionService
 {
     ValueTask<Permission> FindByNameAsync(string name);
 
+    ValueTask<IEnumerable<Permission>> GetImplyingPermissionsAsync(string name);
+
     ValueTask<IEnumerable<Permission>> GetPermissionsAsync();
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/Permission.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/Permission.cs
@@ -58,6 +58,20 @@ public class Permission
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="Permission"/> class with a description, implying permissions, implied by permissions, and security flag.
+    /// </summary>
+    /// <param name="name">The name of the permission.</param>
+    /// <param name="description">The description of the permission.</param>
+    /// <param name="impliedBy">The permissions implying this permission.</param>
+    /// <param name="implies">The permissions implied by this permission.</param>
+    /// <param name="isSecurityCritical">Indicates whether the permission is security critical.</param>
+    public Permission(string name, string description, IEnumerable<Permission> impliedBy, IEnumerable<Permission> implies, bool isSecurityCritical = false)
+        : this(name, description, impliedBy, isSecurityCritical)
+    {
+        Implies = implies;
+    }
+
+    /// <summary>
     /// Gets the name of the permission.
     /// </summary>
     /// <remarks>
@@ -79,6 +93,11 @@ public class Permission
     /// Gets the permissions implying this permission.
     /// </summary>
     public IEnumerable<Permission> ImpliedBy { get; }
+    
+    /// <summary>
+    /// Gets the permissions implied by this permission.
+    /// </summary>
+    public IEnumerable<Permission> Implies { get; }
 
     /// <summary>
     /// Gets a value indicating whether the permission is security critical.

--- a/src/OrchardCore/OrchardCore.Infrastructure/Security/AuthorizationHandlers/PermissionHandler.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Security/AuthorizationHandlers/PermissionHandler.cs
@@ -1,4 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Security.AuthorizationHandlers;
 
@@ -8,23 +11,42 @@ namespace OrchardCore.Security.AuthorizationHandlers;
 public class PermissionHandler : AuthorizationHandler<PermissionRequirement>
 {
     private readonly IPermissionGrantingService _permissionGrantingService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public PermissionHandler(IPermissionGrantingService permissionGrantingService)
+    public PermissionHandler(IPermissionGrantingService permissionGrantingService, IHttpContextAccessor httpContextAccessor)
     {
         _permissionGrantingService = permissionGrantingService;
+        _httpContextAccessor = httpContextAccessor;
     }
 
-    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
     {
         if (context.HasSucceeded || !(context?.User?.Identity?.IsAuthenticated ?? false))
         {
-            return Task.CompletedTask;
+            return;
         }
-        else if (_permissionGrantingService.IsGranted(requirement, context.User.Claims))
+
+        if (_permissionGrantingService.IsGranted(requirement, context.User.Claims))
         {
             context.Succeed(requirement);
         }
+        else
+        {
+            var permissionService = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService<IPermissionService>();
 
-        return Task.CompletedTask;
+            foreach (var impliedBy in await permissionService.GetImplyingPermissionsAsync(requirement.Permission.Name))
+            {
+                if (impliedBy == null)
+                {
+                    continue;
+                }
+
+                if (_permissionGrantingService.IsGranted(new PermissionRequirement(impliedBy), context.User.Claims))
+                {
+                    context.Succeed(requirement);
+                    break;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Introduce Permission.Implies and update handlers to check implying permissions when direct permission is not granted. Extend IPermissionService with GetImplyingPermissionsAsync. Update EmailPermissions and project references accordingly.

Fixes #5328