### PR TITLE
Allow granular permissions for site settings editors

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Settings.Core\OrchardCore.Settings.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Email/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Startup.cs
@@ -15,6 +15,7 @@ public sealed class Startup : StartupBase
     {
         services.AddEmailServices()
             .AddSiteDisplayDriver<EmailSettingsDisplayDriver>()
+            .AddSiteSettingsPermission(EmailSettings.GroupId, EmailPermissions.ManageEmailSettings)
             .AddPermissionProvider<Permissions>()
             .AddNavigationProvider<AdminMenu>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -40,14 +40,14 @@ public sealed class AdminMenu : AdminNavigationProvider
                             .AddClass("general")
                             .Id("general")
                             .Action("Index", "Admin", _generalRouteValues)
-                            .Permission(SettingsPermissions.ManageGroupSettings)
+                            .Permission(SettingsPermissions.ManageGeneralSettings)
                             .LocalNav()
                         )
                         .Add(S["Debugging"], "2", entry => entry
                             .AddClass("debugging")
                             .Id("debugging")
                             .Action("Index", "Admin", _debuggingRouteValues)
-                            .Permission(SettingsPermissions.ManageGroupSettings)
+                            .Permission(SettingsPermissions.ManageDebuggingSettings)
                             .LocalNav()
                         ),
                     priority: 1)
@@ -68,14 +68,14 @@ public sealed class AdminMenu : AdminNavigationProvider
                     .AddClass("general")
                     .Id("general")
                     .Action("Index", "Admin", _generalRouteValues)
-                    .Permission(SettingsPermissions.ManageGroupSettings)
+                    .Permission(SettingsPermissions.ManageGeneralSettings)
                     .LocalNav()
                 )
                 .Add(S["Debugging"], "after", debugging => debugging
                     .AddClass("debugging")
                     .Id("debugging")
                     .Action("Index", "Admin", _debuggingRouteValues)
-                    .Permission(SettingsPermissions.ManageGroupSettings)
+                    .Permission(SettingsPermissions.ManageDebuggingSettings)
                     .LocalNav()
                 )
             , priority: 1);

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DebugSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DebugSettingsDisplayDriver.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -10,18 +12,32 @@ public sealed class DebugSettingsDisplayDriver : SiteDisplayDriver<DebugSettings
 {
     public const string GroupId = "debugging";
 
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAuthorizationService _authorizationService;
     private readonly IShellReleaseManager _shellReleaseManager;
 
     protected override string SettingsGroupId
         => GroupId;
 
-    public DebugSettingsDisplayDriver(IShellReleaseManager shellReleaseManager)
+    public DebugSettingsDisplayDriver(
+        IHttpContextAccessor httpContextAccessor,
+        IAuthorizationService authorizationService,
+        IShellReleaseManager shellReleaseManager)
     {
+        _httpContextAccessor = httpContextAccessor;
+        _authorizationService = authorizationService;
         _shellReleaseManager = shellReleaseManager;
     }
 
-    public override IDisplayResult Edit(ISite site, DebugSettings settings, BuildEditorContext context)
+    public override async Task<IDisplayResult> EditAsync(ISite site, DebugSettings settings, BuildEditorContext context)
     {
+        if (!await _authorizationService.AuthorizeAsync(
+            _httpContextAccessor.HttpContext?.User,
+            SettingsPermissions.ManageDebuggingSettings))
+        {
+            return null;
+        }
+
         context.AddTenantReloadWarningWrapper();
 
         return Initialize<DebugSettingsViewModel>("DebugSettings_Edit", model =>
@@ -33,6 +49,13 @@ public sealed class DebugSettingsDisplayDriver : SiteDisplayDriver<DebugSettings
 
     public override async Task<IDisplayResult> UpdateAsync(ISite site, DebugSettings settings, UpdateEditorContext context)
     {
+        if (!await _authorizationService.AuthorizeAsync(
+            _httpContextAccessor.HttpContext?.User,
+            SettingsPermissions.ManageDebuggingSettings))
+        {
+            return null;
+        }
+
         var model = new DebugSettingsViewModel();
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
@@ -44,6 +67,6 @@ public sealed class DebugSettingsDisplayDriver : SiteDisplayDriver<DebugSettings
 
         settings.WriteShapeDebugInformation = model.WriteShapeDebugInformation;
 
-        return Edit(site, settings, context);
+        return await EditAsync(site, settings, context);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Localization;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -11,21 +13,33 @@ public sealed class DefaultSiteSettingsDisplayDriver : DisplayDriver<ISite>
 {
     public const string GroupId = "general";
 
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAuthorizationService _authorizationService;
     private readonly IShellReleaseManager _shellReleaseManager;
-
     internal readonly IStringLocalizer S;
 
     public DefaultSiteSettingsDisplayDriver(
+        IHttpContextAccessor httpContextAccessor,
+        IAuthorizationService authorizationService,
         IShellReleaseManager shellReleaseManager,
         IStringLocalizer<DefaultSiteSettingsDisplayDriver> stringLocalizer)
     {
+        _httpContextAccessor = httpContextAccessor;
+        _authorizationService = authorizationService;
         _shellReleaseManager = shellReleaseManager;
         S = stringLocalizer;
     }
 
-    public override IDisplayResult Edit(ISite site, BuildEditorContext context)
+    public override async Task<IDisplayResult> EditAsync(ISite site, BuildEditorContext context)
     {
         if (!IsGeneralGroup(context))
+        {
+            return null;
+        }
+
+        if (!await _authorizationService.AuthorizeAsync(
+            _httpContextAccessor.HttpContext?.User,
+            SettingsPermissions.ManageGeneralSettings))
         {
             return null;
         }
@@ -50,6 +64,13 @@ public sealed class DefaultSiteSettingsDisplayDriver : DisplayDriver<ISite>
     public override async Task<IDisplayResult> UpdateAsync(ISite site, UpdateEditorContext context)
     {
         if (!IsGeneralGroup(context))
+        {
+            return null;
+        }
+
+        if (!await _authorizationService.AuthorizeAsync(
+            _httpContextAccessor.HttpContext?.User,
+            SettingsPermissions.ManageGeneralSettings))
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Permissions.cs
@@ -7,6 +7,8 @@ public sealed class Permissions : IPermissionProvider
     private readonly IEnumerable<Permission> _allPermissions =
     [
         SettingsPermissions.ManageSettings,
+        SettingsPermissions.ManageGeneralSettings,
+        SettingsPermissions.ManageDebuggingSettings,
     ];
 
     [Obsolete("This will be removed in a future release. Instead use 'SettingsPermissions.ManageSettings'.")]

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Services/SiteSettingsAuthorizationHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Services/SiteSettingsAuthorizationHandler.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Security;
+
+namespace OrchardCore.Settings.Services;
+
+/// <summary>
+/// Grants access to a site settings group when the user has a permission registered for that group.
+/// </summary>
+public sealed class SiteSettingsAuthorizationHandler : AuthorizationHandler<PermissionRequirement>
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly SiteSettingsPermissionOptions _options;
+
+    public SiteSettingsAuthorizationHandler(
+        IServiceProvider serviceProvider,
+        IOptions<SiteSettingsPermissionOptions> options)
+    {
+        _serviceProvider = serviceProvider;
+        _options = options.Value;
+    }
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        PermissionRequirement requirement)
+    {
+        if (context.HasSucceeded ||
+            requirement.Permission.Name != SettingsPermissions.ManageGroupSettings.Name ||
+            context.Resource is not string groupId ||
+            string.IsNullOrEmpty(groupId) ||
+            !_options.GroupPermissions.TryGetValue(groupId, out var permissions))
+        {
+            return;
+        }
+
+        var authorizationService = _serviceProvider.GetRequiredService<IAuthorizationService>();
+
+        foreach (var permission in permissions)
+        {
+            if (await authorizationService.AuthorizeAsync(context.User, permission))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
@@ -69,7 +69,8 @@ public sealed class Startup : StartupBase
         services.AddPermissionProvider<Permissions>();
 
         services.AddRolesCoreServices()
-            .AddScoped<IAuthorizationHandler, SuperUserHandler>();
+            .AddScoped<IAuthorizationHandler, SuperUserHandler>()
+            .AddScoped<IAuthorizationHandler, SiteSettingsAuthorizationHandler>();
 
         services.AddRecipeExecutionStep<SettingsStep>();
         services.AddSingleton<ISiteService, SiteService>();
@@ -78,6 +79,8 @@ public sealed class Startup : StartupBase
         services.AddSiteDisplayDriver<DefaultSiteSettingsDisplayDriver>();
         services.AddSiteDisplayDriver<DebugSettingsDisplayDriver>();
         services.AddSiteDisplayDriver<ButtonsSettingsDisplayDriver>();
+        services.AddSiteSettingsPermission(DefaultSiteSettingsDisplayDriver.GroupId, SettingsPermissions.ManageGeneralSettings);
+        services.AddSiteSettingsPermission(DebugSettingsDisplayDriver.GroupId, SettingsPermissions.ManageDebuggingSettings);
         services.AddNavigationProvider<AdminMenu>();
 
         services.AddScoped<ITimeZoneSelector, DefaultTimeZoneSelector>();

--- a/src/OrchardCore/OrchardCore.Settings.Core/SettingsPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Settings.Core/SettingsPermissions.cs
@@ -6,6 +6,16 @@ public static class SettingsPermissions
 {
     public static readonly Permission ManageSettings = new("ManageSettings", "Manage settings");
 
+    /// <summary>
+    /// Grants permission to manage the built-in General settings group.
+    /// </summary>
+    public static readonly Permission ManageGeneralSettings = new("ManageGeneralSettings", "Manage general settings", [ManageSettings]);
+
+    /// <summary>
+    /// Grants permission to manage the built-in Debugging settings group.
+    /// </summary>
+    public static readonly Permission ManageDebuggingSettings = new("ManageDebuggingSettings", "Manage debugging settings", [ManageSettings]);
+
     // This permission is not exposed, it's just used for the APIs to generate/check custom ones.
     public static readonly Permission ManageGroupSettings = new("ManageResourceSettings", "Manage settings", new[] { ManageSettings });
 }

--- a/src/OrchardCore/OrchardCore.Settings.Core/SiteSettingsPermissionOptions.cs
+++ b/src/OrchardCore/OrchardCore.Settings.Core/SiteSettingsPermissionOptions.cs
@@ -1,0 +1,15 @@
+using OrchardCore.Security.Permissions;
+
+namespace OrchardCore.Settings;
+
+/// <summary>
+/// Contains the permissions that grant access to each site settings group.
+/// </summary>
+public sealed class SiteSettingsPermissionOptions
+{
+    /// <summary>
+    /// Gets the permissions indexed by site settings group identifier.
+    /// </summary>
+    public IDictionary<string, IList<Permission>> GroupPermissions { get; } =
+        new Dictionary<string, IList<Permission>>(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/OrchardCore/OrchardCore.Settings.Core/SiteSettingsServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Settings.Core/SiteSettingsServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+using OrchardCore.Security.Permissions;
+using OrchardCore.Settings;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides extensions for registering site settings permissions.
+/// </summary>
+public static class SiteSettingsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a permission that grants access to a site settings group.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="groupId">The site settings group identifier.</param>
+    /// <param name="permission">The permission that grants access to the group.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddSiteSettingsPermission(
+        this IServiceCollection services,
+        string groupId,
+        Permission permission)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(groupId);
+        ArgumentNullException.ThrowIfNull(permission);
+
+        services.Configure<SiteSettingsPermissionOptions>(options =>
+        {
+            if (!options.GroupPermissions.TryGetValue(groupId, out var permissions))
+            {
+                permissions = [];
+                options.GroupPermissions[groupId] = permissions;
+            }
+
+            if (!permissions.Any(existing => existing.Name.Equals(permission.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                permissions.Add(permission);
+            }
+        });
+
+        return services;
+    }
+}

--- a/src/docs/reference/modules/Settings/README.md
+++ b/src/docs/reference/modules/Settings/README.md
@@ -8,7 +8,7 @@ For user-defined settings managed from the admin without writing code, see [Cust
 
 ## General settings
 
-The built-in **General** group is available in the admin under **Settings** > **General** (requires the `Manage settings` permission). It exposes options such as:
+The built-in **General** group is available in the admin under **Settings** > **General** (requires the `Manage general settings` permission). It exposes options such as:
 
 | Setting             | Description                                                                 |
 |---------------------|-----------------------------------------------------------------------------|
@@ -29,12 +29,22 @@ A separate **Debugging** group exposes diagnostic options.
 
 ## Permissions
 
-| Permission               | Description                                                                  |
-|--------------------------|------------------------------------------------------------------------------|
-| `Manage settings`        | Grants access to all site settings groups.                                   |
-| `Manage group settings`  | Grants access to a specific settings group only. Used to scope access per section. |
+| Permission                  | Description                                                               |
+|-----------------------------|---------------------------------------------------------------------------|
+| `Manage settings`           | Grants both built-in settings permissions for backward compatibility.     |
+| `Manage general settings`   | Grants access to the built-in General settings group.                      |
+| `Manage debugging settings` | Grants access to the built-in Debugging settings group.                    |
+| `Manage group settings`     | Internal resource permission used to authorize registered and custom settings groups. |
 
-Both are granted to the `Administrator` role by default. Modules that add a settings group typically authorize against `Manage group settings` for their own group id.
+The assignable permissions are granted to the `Administrator` role by default. Modules that contribute a settings group must register the permission that grants access to the group and enforce the same permission in both the edit and update methods of their display driver:
+
+```csharp
+services
+    .AddSiteDisplayDriver<MySettingsDisplayDriver>()
+    .AddSiteSettingsPermission(MySettingsDisplayDriver.GroupId, Permissions.ManageMySettings);
+```
+
+Registering the group permission lets the shared settings controller authorize the route without requiring the broader `Manage settings` permission. The display-driver checks remain necessary to prevent unauthorized settings from rendering or updating when multiple drivers contribute to the same group.
 
 ## Accessing settings in code
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Settings/SettingsAuthorizationTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Settings/SettingsAuthorizationTests.cs
@@ -1,0 +1,303 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.DisplayManagement.Shapes;
+using OrchardCore.DisplayManagement.Zones;
+using OrchardCore.Email;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Localization;
+using OrchardCore.Security;
+using OrchardCore.Security.Permissions;
+using OrchardCore.Settings;
+using OrchardCore.Settings.Drivers;
+using OrchardCore.Settings.Services;
+using OrchardCore.Settings.ViewModels;
+using AdminController = OrchardCore.Settings.Controllers.AdminController;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Settings;
+
+public class SettingsAuthorizationTests
+{
+    [Fact]
+    public void ManageSettings_GranularBuiltInPermissions_GrantsBoth()
+    {
+        var claims = new[]
+        {
+            new Claim(Permission.ClaimType, SettingsPermissions.ManageSettings.Name),
+        };
+        var permissionGrantingService = new DefaultPermissionGrantingService();
+
+        Assert.True(permissionGrantingService.IsGranted(
+            new PermissionRequirement(SettingsPermissions.ManageGeneralSettings),
+            claims));
+        Assert.True(permissionGrantingService.IsGranted(
+            new PermissionRequirement(SettingsPermissions.ManageDebuggingSettings),
+            claims));
+    }
+
+    [Fact]
+    public async Task PermissionProvider_GranularBuiltInPermissions_ExposesBoth()
+    {
+        var permissions = await new global::OrchardCore.Settings.Permissions().GetPermissionsAsync();
+
+        Assert.Contains(SettingsPermissions.ManageGeneralSettings, permissions);
+        Assert.Contains(SettingsPermissions.ManageDebuggingSettings, permissions);
+    }
+
+    [Fact]
+    public async Task GroupAuthorization_EmailPermission_GrantsAccess()
+    {
+        using var serviceProvider = CreateGroupAuthorizationServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<SiteSettingsPermissionOptions>>();
+        var handler = new SiteSettingsAuthorizationHandler(serviceProvider, options);
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(Permission.ClaimType, EmailPermissions.ManageEmailSettings.Name)],
+            "Test"));
+        var requirement = new PermissionRequirement(SettingsPermissions.ManageGroupSettings);
+        var context = new AuthorizationHandlerContext([requirement], user, EmailSettings.GroupId);
+
+        await handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task GroupAuthorization_UnregisteredGroup_DoesNotGrantAccess()
+    {
+        using var serviceProvider = CreateGroupAuthorizationServiceProvider();
+        var options = serviceProvider.GetRequiredService<IOptions<SiteSettingsPermissionOptions>>();
+        var handler = new SiteSettingsAuthorizationHandler(serviceProvider, options);
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(Permission.ClaimType, EmailPermissions.ManageEmailSettings.Name)],
+            "Test"));
+        var requirement = new PermissionRequirement(SettingsPermissions.ManageGroupSettings);
+        var context = new AuthorizationHandlerContext([requirement], user, "legacy");
+
+        await handler.HandleAsync(context);
+
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task DefaultDriver_EditWithGeneralPermission_ReturnsEditor()
+    {
+        var driver = CreateDefaultDriver(granted: true);
+        var context = CreateBuildEditorContext(DefaultSiteSettingsDisplayDriver.GroupId);
+
+        var result = await driver.EditAsync(new SiteSettings(), context);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task DefaultDriver_UpdateWithoutGeneralPermission_DoesNotUpdate()
+    {
+        var driver = CreateDefaultDriver(granted: false);
+        var site = new SiteSettings { SiteName = "Original" };
+        var context = CreateUpdateEditorContext(DefaultSiteSettingsDisplayDriver.GroupId);
+
+        var result = await driver.UpdateAsync(site, context);
+
+        Assert.Null(result);
+        Assert.Equal("Original", site.SiteName);
+    }
+
+    [Fact]
+    public async Task DebugDriver_EditWithDebuggingPermission_ReturnsEditor()
+    {
+        var driver = CreateDebugDriver(granted: true);
+        var context = CreateBuildEditorContext(DebugSettingsDisplayDriver.GroupId);
+
+        var result = await driver.EditAsync(new SiteSettings(), new DebugSettings(), context);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task DebugDriver_UpdateWithoutDebuggingPermission_DoesNotUpdate()
+    {
+        var driver = CreateDebugDriver(granted: false);
+        var settings = new DebugSettings { WriteShapeDebugInformation = true };
+        var context = CreateUpdateEditorContext(DebugSettingsDisplayDriver.GroupId);
+
+        var result = await driver.UpdateAsync(new SiteSettings(), settings, context);
+
+        Assert.Null(result);
+        Assert.True(settings.WriteShapeDebugInformation);
+    }
+
+    [Fact]
+    public async Task Index_AuthorizedSpecializedEditor_ReturnsView()
+    {
+        var shape = await CreateEditorShapeAsync(hasEditorContent: true);
+        var displayManager = new Mock<IDisplayManager<ISite>>();
+        displayManager
+            .Setup(x => x.BuildEditorAsync(
+                It.IsAny<ISite>(),
+                It.IsAny<IUpdateModel>(),
+                false,
+                "email",
+                string.Empty))
+            .ReturnsAsync(shape);
+        var siteService = CreateSiteService();
+        var controller = CreateController(displayManager.Object, siteService.Object, granted: true);
+
+        var result = await controller.Index("email");
+
+        var viewResult = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<AdminIndexViewModel>(viewResult.Model);
+        Assert.Same(shape, model.Shape);
+    }
+
+    [Fact]
+    public async Task IndexPost_NoAuthorizedEditorContent_DoesNotSave()
+    {
+        var shape = await CreateEditorShapeAsync(hasEditorContent: false);
+        var displayManager = new Mock<IDisplayManager<ISite>>();
+        displayManager
+            .Setup(x => x.UpdateEditorAsync(
+                It.IsAny<ISite>(),
+                It.IsAny<IUpdateModel>(),
+                false,
+                "email",
+                string.Empty))
+            .ReturnsAsync(shape);
+        var siteService = CreateSiteService();
+        var controller = CreateController(displayManager.Object, siteService.Object, granted: true);
+
+        var result = await controller.IndexPost("email");
+
+        Assert.IsType<NotFoundResult>(result);
+        siteService.Verify(x => x.UpdateSiteSettingsAsync(It.IsAny<ISite>()), Times.Never);
+    }
+
+    private static DefaultSiteSettingsDisplayDriver CreateDefaultDriver(bool granted)
+        => new(
+            CreateHttpContextAccessor(),
+            CreateAuthorizationService(SettingsPermissions.ManageGeneralSettings, granted),
+            Mock.Of<IShellReleaseManager>(),
+            Mock.Of<IStringLocalizer<DefaultSiteSettingsDisplayDriver>>());
+
+    private static DebugSettingsDisplayDriver CreateDebugDriver(bool granted)
+        => new(
+            CreateHttpContextAccessor(),
+            CreateAuthorizationService(SettingsPermissions.ManageDebuggingSettings, granted),
+            Mock.Of<IShellReleaseManager>());
+
+    private static HttpContextAccessor CreateHttpContextAccessor()
+        => new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
+
+    private static IAuthorizationService CreateAuthorizationService(Permission permission, bool granted)
+    {
+        var authorizationService = new Mock<IAuthorizationService>();
+        authorizationService
+            .Setup(x => x.AuthorizeAsync(
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<object>(),
+                It.Is<IEnumerable<IAuthorizationRequirement>>(requirements =>
+                    requirements.OfType<PermissionRequirement>().Any(requirement =>
+                        requirement.Permission.Name == permission.Name))))
+            .ReturnsAsync(granted ? AuthorizationResult.Success() : AuthorizationResult.Failed());
+
+        return authorizationService.Object;
+    }
+
+    private static IAuthorizationService CreatePermissionAuthorizationService()
+    {
+        var permissionGrantingService = new DefaultPermissionGrantingService();
+        var authorizationService = new Mock<IAuthorizationService>();
+        authorizationService
+            .Setup(x => x.AuthorizeAsync(
+                It.IsAny<ClaimsPrincipal>(),
+                It.IsAny<object>(),
+                It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
+            .Returns<ClaimsPrincipal, object, IEnumerable<IAuthorizationRequirement>>((user, _, requirements) =>
+            {
+                var isGranted = requirements
+                    .OfType<PermissionRequirement>()
+                    .All(requirement => permissionGrantingService.IsGranted(requirement, user.Claims));
+
+                return Task.FromResult(isGranted ? AuthorizationResult.Success() : AuthorizationResult.Failed());
+            });
+
+        return authorizationService.Object;
+    }
+
+    private static ServiceProvider CreateGroupAuthorizationServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSiteSettingsPermission(EmailSettings.GroupId, EmailPermissions.ManageEmailSettings);
+        services.AddSingleton(CreatePermissionAuthorizationService());
+
+        return services.BuildServiceProvider();
+    }
+
+    private static BuildEditorContext CreateBuildEditorContext(string groupId)
+        => new(new Shape(), groupId, false, string.Empty, null, null, null);
+
+    private static UpdateEditorContext CreateUpdateEditorContext(string groupId)
+        => new(new Shape(), groupId, false, string.Empty, null, null, null);
+
+    private static Mock<ISiteService> CreateSiteService()
+    {
+        var site = new SiteSettings();
+        var siteService = new Mock<ISiteService>();
+        siteService.Setup(x => x.GetSiteSettingsAsync()).ReturnsAsync(site);
+        siteService.Setup(x => x.LoadSiteSettingsAsync()).ReturnsAsync(site);
+
+        return siteService;
+    }
+
+    private static AdminController CreateController(
+        IDisplayManager<ISite> displayManager,
+        ISiteService siteService,
+        bool granted)
+        => new(
+                Mock.Of<IShellReleaseManager>(),
+                siteService,
+                displayManager,
+                CreateAuthorizationService(SettingsPermissions.ManageGroupSettings, granted),
+                Mock.Of<INotifier>(),
+                Options.Create(new CultureOptions()),
+                Mock.Of<IUpdateModelAccessor>(),
+                Mock.Of<IHtmlLocalizer<AdminController>>())
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = new ClaimsPrincipal(new ClaimsIdentity(authenticationType: "Test")),
+                    },
+                },
+            };
+
+    private static async Task<IShape> CreateEditorShapeAsync(bool hasEditorContent)
+    {
+        var shape = new ZoneHolding(() => ValueTask.FromResult<IShape>(new Shape()));
+        var actions = new Shape();
+        await actions.AddAsync(new Shape());
+        shape.Properties["Actions"] = actions;
+
+        if (hasEditorContent)
+        {
+            var content = new Shape();
+            await content.AddAsync(new Shape());
+            shape.Properties["Content"] = content;
+        }
+
+        return shape;
+    }
+}


### PR DESCRIPTION
Users granted a settings-specific permission such as `ManageEmailSettings` are currently blocked by the shared settings route unless they also receive the broader `ManageSettings` permission. This prevents safely delegating individual settings groups.

## Changes

- Adds `AddSiteSettingsPermission()` so modules can register which granular permissions authorize each settings group.
- Adds a resource-aware authorization handler that satisfies the existing `ManageGroupSettings` gate for registered permissions, preserving the secure fallback for legacy drivers.
- Registers `ManageEmailSettings` for the Email group.
- Introduces separate `ManageGeneralSettings` and `ManageDebuggingSettings` permissions, enforced by their menus and display drivers while remaining implied by `ManageSettings`.
- Documents the registration and display-driver authorization contract.

## Tests

- Adds focused coverage for permission implication, registered and unregistered group authorization, built-in driver edit/update protection, and controller safeguards.

Fixes: #5328