### PR TITLE
Ensure unique field names for ContainedQueryObjectType

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedPartContentItemTypeInitializer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedPartContentItemTypeInitializer.cs
@@ -43,12 +43,14 @@ internal sealed class ContainedPartContentItemTypeInitializer : IContentItemType
             if (contentItemType.Fields.Any(f => f.Name == parentFieldName))
             {
                 var i = 1;
-                while (contentItemType.Fields.Any(f => f.Name == $"{parentFieldName}_{i}"))
+                string fieldName;
+                do
                 {
+                    fieldName = $"{parentFieldName}_{i}";
                     i++;
-                }
+                } while (contentItemType.Fields.Any(f => f.Name == fieldName));
 
-                parentFieldName = $"{parentFieldName}_{i}";
+                parentFieldName = fieldName;
             }
 
             contentItemType.Field<ContainedQueryObjectType>(parentFieldName)

--- a/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedPartContentItemTypeInitializer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedPartContentItemTypeInitializer.cs
@@ -39,7 +39,19 @@ internal sealed class ContainedPartContentItemTypeInitializer : IContentItemType
                 schema.RegisterType(fieldType);
             }
 
-            contentItemType.Field<ContainedQueryObjectType>(type.Name.ToFieldName())
+            var parentFieldName = type.Name.ToFieldName();
+            if (contentItemType.Fields.Any(f => f.Name == parentFieldName))
+            {
+                var i = 1;
+                while (contentItemType.Fields.Any(f => f.Name == $"{parentFieldName}_{i}"))
+                {
+                    i++;
+                }
+
+                parentFieldName = $"{parentFieldName}_{i}";
+            }
+
+            contentItemType.Field<ContainedQueryObjectType>(parentFieldName)
                 .Description(S["The parent content item of type {0}.", type.Name])
                 .Type(fieldType)
                 .Resolve(context =>


### PR DESCRIPTION
Prevent duplicate field names when registering ContainedQueryObjectType fields by appending an incrementing suffix if a name collision is detected. This guarantees that each field added to contentItemType has a unique name.