### PR TITLE
Harden TUS uploads against client disconnects

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Services/S3TusTempStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Services/S3TusTempStore.cs
@@ -2,6 +2,7 @@ using System.IO.Pipelines;
 using System.Text.Json;
 using Amazon.S3;
 using Amazon.S3.Model;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,6 +19,7 @@ namespace OrchardCore.Media.AmazonS3.Services;
 public sealed class S3TusTempStore : ITusTempStore
 {
     private const string TusTempPrefix = "_tus-uploads";
+    private const string UnexpectedEndOfRequestContent = "Unexpected end of request content.";
 
     private readonly IAmazonS3 _s3Client;
     private readonly string _bucketName;
@@ -94,6 +96,10 @@ public sealed class S3TusTempStore : ITusTempStore
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            bytesWritten = 0;
+        }
+        catch (BadHttpRequestException exception) when (IsUnexpectedEndOfRequest(exception))
         {
             bytesWritten = 0;
         }
@@ -314,6 +320,10 @@ public sealed class S3TusTempStore : ITusTempStore
             GetCacheOptions(),
             cancellationToken);
     }
+
+    private static bool IsUnexpectedEndOfRequest(BadHttpRequestException exception) =>
+        exception.StatusCode == StatusCodes.Status400BadRequest
+        && string.Equals(exception.Message, UnexpectedEndOfRequestContent, StringComparison.Ordinal);
 
     private sealed class PartInfo
     {

--- a/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Services/S3TusTempStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Services/S3TusTempStore.cs
@@ -74,9 +74,9 @@ public sealed class S3TusTempStore : ITusTempStore
             // Read the entire stream into a buffer for S3 (S3 requires content-length for parts).
             using var memoryStream = new MemoryStream();
             await stream.CopyToAsync(memoryStream, cancellationToken);
-            bytesWritten = memoryStream.Length;
+            var bufferedBytes = memoryStream.Length;
 
-            if (bytesWritten > 0)
+            if (bufferedBytes > 0)
             {
                 memoryStream.Position = 0;
                 var uploadPartRequest = new UploadPartRequest
@@ -90,14 +90,15 @@ public sealed class S3TusTempStore : ITusTempStore
 
                 var response = await _s3Client.UploadPartAsync(uploadPartRequest, cancellationToken);
                 parts.Add(new PartInfo { PartNumber = partNumber, ETag = response.ETag });
+                bytesWritten = bufferedBytes;
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // Client disconnected. Parts already uploaded are durable.
+            bytesWritten = 0;
         }
 
-        await SavePartListAsync(fileId, parts, cancellationToken);
+        await SavePartListAsync(fileId, parts, CancellationToken.None);
 
         return bytesWritten;
     }
@@ -114,51 +115,67 @@ public sealed class S3TusTempStore : ITusTempStore
         var partNumber = parts.Count + 1;
 
         long bytesWritten = 0;
+        var clientDisconnected = false;
         try
         {
-            // Buffer the pipe data, then upload as a single part.
-            using var memoryStream = new MemoryStream();
-            while (true)
+            try
             {
-                var result = await pipeReader.ReadAsync(cancellationToken);
-                var buffer = result.Buffer;
-
-                foreach (var segment in buffer)
+                // Buffer the pipe data, then upload as a single part.
+                using var memoryStream = new MemoryStream();
+                while (true)
                 {
-                    memoryStream.Write(segment.Span);
-                    bytesWritten += segment.Length;
+                    var result = await pipeReader.ReadAsync(cancellationToken);
+                    var buffer = result.Buffer;
+
+                    foreach (var segment in buffer)
+                    {
+                        memoryStream.Write(segment.Span);
+                    }
+
+                    pipeReader.AdvanceTo(buffer.End);
+
+                    if (result.IsCanceled || cancellationToken.IsCancellationRequested)
+                    {
+                        clientDisconnected = true;
+                        break;
+                    }
+
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
                 }
 
-                pipeReader.AdvanceTo(buffer.End);
-
-                if (result.IsCompleted)
+                var bufferedBytes = memoryStream.Length;
+                if (!clientDisconnected && bufferedBytes > 0)
                 {
-                    break;
+                    memoryStream.Position = 0;
+                    var uploadPartRequest = new UploadPartRequest
+                    {
+                        BucketName = _bucketName,
+                        Key = GetObjectKey(fileId),
+                        UploadId = uploadId,
+                        PartNumber = partNumber,
+                        InputStream = memoryStream,
+                    };
+
+                    var response = await _s3Client.UploadPartAsync(uploadPartRequest, cancellationToken);
+                    parts.Add(new PartInfo { PartNumber = partNumber, ETag = response.ETag });
+                    bytesWritten = bufferedBytes;
                 }
             }
-
-            if (bytesWritten > 0)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                memoryStream.Position = 0;
-                var uploadPartRequest = new UploadPartRequest
-                {
-                    BucketName = _bucketName,
-                    Key = GetObjectKey(fileId),
-                    UploadId = uploadId,
-                    PartNumber = partNumber,
-                    InputStream = memoryStream,
-                };
-
-                var response = await _s3Client.UploadPartAsync(uploadPartRequest, cancellationToken);
-                parts.Add(new PartInfo { PartNumber = partNumber, ETag = response.ETag });
+                clientDisconnected = true;
+                bytesWritten = 0;
             }
+
+            await SavePartListAsync(fileId, parts, CancellationToken.None);
         }
-        catch (OperationCanceledException)
+        finally
         {
-            // Client disconnected. Parts already uploaded are durable.
+            await pipeReader.CompleteAsync();
         }
-
-        await SavePartListAsync(fileId, parts, cancellationToken);
 
         return bytesWritten;
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Services/AzureBlobTusTempStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Services/AzureBlobTusTempStore.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,6 +20,7 @@ namespace OrchardCore.Media.Azure.Services;
 public sealed class AzureBlobTusTempStore : ITusTempStore
 {
     private const string TusTempPrefix = "_tus-uploads";
+    private const string UnexpectedEndOfRequestContent = "Unexpected end of request content.";
 
     private readonly BlobContainerClient _containerClient;
     private readonly IDistributedCache _cache;
@@ -65,6 +67,10 @@ public sealed class AzureBlobTusTempStore : ITusTempStore
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Blocks already staged are durable and their IDs are persisted below.
+        }
+        catch (BadHttpRequestException exception) when (IsUnexpectedEndOfRequest(exception))
         {
             // Blocks already staged are durable and their IDs are persisted below.
         }
@@ -195,6 +201,12 @@ public sealed class AzureBlobTusTempStore : ITusTempStore
         // Block IDs must be the same length and Base64 encoded.
         return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(index.ToString("D8")));
     }
+
+    private static bool IsUnexpectedEndOfRequest(BadHttpRequestException exception) =>
+        // Kestrel does not expose its internal rejection reason, so the message is the
+        // only way to distinguish a truncated body from other malformed requests.
+        exception.StatusCode == StatusCodes.Status400BadRequest
+        && string.Equals(exception.Message, UnexpectedEndOfRequestContent, StringComparison.Ordinal);
 
     private string BlockListKey(string fileId) => $"tus:blocks:{_tenantId}:{fileId}";
 

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Services/AzureBlobTusTempStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Services/AzureBlobTusTempStore.cs
@@ -64,12 +64,12 @@ public sealed class AzureBlobTusTempStore : ITusTempStore
                 bytesWritten += bytesRead;
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // Client disconnected. Blocks already staged are durable.
+            // Blocks already staged are durable and their IDs are persisted below.
         }
 
-        await SaveBlockListAsync(fileId, blockIds, cancellationToken);
+        await SaveBlockListAsync(fileId, blockIds, CancellationToken.None);
 
         return bytesWritten;
     }
@@ -82,39 +82,51 @@ public sealed class AzureBlobTusTempStore : ITusTempStore
         long bytesWritten = 0;
         try
         {
-            while (true)
+            try
             {
-                var result = await pipeReader.ReadAsync(cancellationToken);
-                var buffer = result.Buffer;
-
-                foreach (var segment in buffer)
+                while (true)
                 {
-                    if (segment.Length == 0)
+                    var result = await pipeReader.ReadAsync(cancellationToken);
+                    var buffer = result.Buffer;
+
+                    foreach (var segment in buffer)
                     {
-                        continue;
+                        if (segment.Length == 0)
+                        {
+                            continue;
+                        }
+
+                        var blockId = GenerateBlockId(blockIds.Count);
+                        using var blockStream = new MemoryStream(segment.ToArray());
+                        await blockBlob.StageBlockAsync(blockId, blockStream, cancellationToken: cancellationToken);
+                        blockIds.Add(blockId);
+                        bytesWritten += segment.Length;
                     }
 
-                    var blockId = GenerateBlockId(blockIds.Count);
-                    using var blockStream = new MemoryStream(segment.ToArray());
-                    await blockBlob.StageBlockAsync(blockId, blockStream, cancellationToken: cancellationToken);
-                    blockIds.Add(blockId);
-                    bytesWritten += segment.Length;
-                }
+                    pipeReader.AdvanceTo(buffer.End);
 
-                pipeReader.AdvanceTo(buffer.End);
+                    if (result.IsCanceled || cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
 
-                if (result.IsCompleted)
-                {
-                    break;
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
                 }
             }
-        }
-        catch (OperationCanceledException)
-        {
-            // Client disconnected. Blocks already staged are durable.
-        }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Blocks already staged are durable and their IDs are persisted below.
+            }
 
-        await SaveBlockListAsync(fileId, blockIds, cancellationToken);
+            await SaveBlockListAsync(fileId, blockIds, CancellationToken.None);
+        }
+        finally
+        {
+            await pipeReader.CompleteAsync();
+        }
 
         return bytesWritten;
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/ClientDisconnectAwarePipeReader.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/ClientDisconnectAwarePipeReader.cs
@@ -1,0 +1,85 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http;
+
+namespace OrchardCore.Media.Services;
+
+internal sealed class ClientDisconnectAwarePipeReader : PipeReader
+{
+    private const string UnexpectedEndOfRequestContent = "Unexpected end of request content.";
+
+    private readonly PipeReader _inner;
+    private bool _disconnected;
+
+    public ClientDisconnectAwarePipeReader(PipeReader inner)
+    {
+        _inner = inner;
+    }
+
+    public override void AdvanceTo(SequencePosition consumed)
+    {
+        if (!_disconnected)
+        {
+            _inner.AdvanceTo(consumed);
+        }
+    }
+
+    public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+    {
+        if (!_disconnected)
+        {
+            _inner.AdvanceTo(consumed, examined);
+        }
+    }
+
+    public override void CancelPendingRead() => _inner.CancelPendingRead();
+
+    public override void Complete(Exception exception = null) => _inner.Complete(exception);
+
+    public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+    {
+        if (_disconnected)
+        {
+            return CanceledReadResult();
+        }
+
+        try
+        {
+            return await _inner.ReadAsync(cancellationToken);
+        }
+        catch (BadHttpRequestException exception) when (IsUnexpectedEndOfRequest(exception))
+        {
+            _disconnected = true;
+            return CanceledReadResult();
+        }
+    }
+
+    public override bool TryRead(out ReadResult result)
+    {
+        if (_disconnected)
+        {
+            result = CanceledReadResult();
+            return true;
+        }
+
+        try
+        {
+            return _inner.TryRead(out result);
+        }
+        catch (BadHttpRequestException exception) when (IsUnexpectedEndOfRequest(exception))
+        {
+            _disconnected = true;
+            result = CanceledReadResult();
+            return true;
+        }
+    }
+
+    internal static bool IsUnexpectedEndOfRequest(BadHttpRequestException exception) =>
+        // Kestrel does not expose its internal rejection reason, so the message is the
+        // only way to distinguish a truncated body from other malformed requests.
+        exception.StatusCode == StatusCodes.Status400BadRequest
+        && string.Equals(exception.Message, UnexpectedEndOfRequestContent, StringComparison.Ordinal);
+
+    private static ReadResult CanceledReadResult() =>
+        new(ReadOnlySequence<byte>.Empty, isCanceled: true, isCompleted: false);
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/DiskTusTempStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/DiskTusTempStore.cs
@@ -1,4 +1,5 @@
 using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
@@ -49,16 +50,18 @@ public sealed class DiskTusTempStore : ITusTempStore
             await stream.CopyToAsync(fs, cancellationToken);
             bytesWritten = fs.Position - offset;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // Client disconnected (pause or browser refresh). Flush buffered data
-            // and read the stream position to persist correct progress.
-            try { fs.Flush(); } catch { /* best effort */ }
             bytesWritten = fs.Position - offset;
             if (bytesWritten < 0)
             {
                 bytesWritten = 0;
             }
+        }
+        catch (BadHttpRequestException exception)
+            when (ClientDisconnectAwarePipeReader.IsUnexpectedEndOfRequest(exception))
+        {
+            bytesWritten = Math.Max(0, fs.Position - offset);
         }
         finally
         {
@@ -91,26 +94,35 @@ public sealed class DiskTusTempStore : ITusTempStore
 
                 pipeReader.AdvanceTo(buffer.End);
 
-                if (result.IsCompleted)
+                if (result.IsCanceled || result.IsCompleted)
                 {
                     break;
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // Client disconnected (pause or browser refresh). Flush buffered data
-            // and use stream position as the most accurate byte count.
-            try { fs.Flush(); } catch { /* best effort */ }
             bytesWritten = fs.Position - offset;
             if (bytesWritten < 0)
             {
                 bytesWritten = 0;
             }
         }
+        catch (BadHttpRequestException exception)
+            when (ClientDisconnectAwarePipeReader.IsUnexpectedEndOfRequest(exception))
+        {
+            bytesWritten = Math.Max(0, fs.Position - offset);
+        }
         finally
         {
-            await fs.DisposeAsync();
+            try
+            {
+                await pipeReader.CompleteAsync();
+            }
+            finally
+            {
+                await fs.DisposeAsync();
+            }
         }
 
         return bytesWritten;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/DistributedMediaTusStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/DistributedMediaTusStore.cs
@@ -117,8 +117,7 @@ public sealed class DistributedMediaTusStore :
 
         var bytesWritten = await _tempStore.AppendDataAsync(fileId, stream, offset, cancellationToken);
 
-        var newOffset = offset + bytesWritten;
-        await _cache.SetStringAsync(OffsetKey(fileId), newOffset.ToString(), GetCacheOptions(), cancellationToken);
+        await SetUploadOffsetAsync(fileId, offset + bytesWritten);
 
         return bytesWritten;
     }
@@ -129,12 +128,21 @@ public sealed class DistributedMediaTusStore :
     {
         var offset = await GetUploadOffsetAsync(fileId, cancellationToken);
 
-        var bytesWritten = await _tempStore.AppendDataAsync(fileId, pipeReader, offset, cancellationToken);
+        var guardedReader = new ClientDisconnectAwarePipeReader(pipeReader);
+        var bytesWritten = await _tempStore.AppendDataAsync(fileId, guardedReader, offset, cancellationToken);
 
-        var newOffset = offset + bytesWritten;
-        await _cache.SetStringAsync(OffsetKey(fileId), newOffset.ToString(), GetCacheOptions(), cancellationToken);
+        await SetUploadOffsetAsync(fileId, offset + bytesWritten);
 
         return bytesWritten;
+    }
+
+    private async Task SetUploadOffsetAsync(string fileId, long offset)
+    {
+        await _cache.SetStringAsync(
+            OffsetKey(fileId),
+            offset.ToString(),
+            GetCacheOptions(),
+            CancellationToken.None);
     }
 
     // ITusTerminationStore

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/MediaTusUploadTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/MediaTusUploadTests.cs
@@ -28,7 +28,15 @@ public sealed class MediaTusUploadTests : IAsyncLifetime
 
     public ValueTask DisposeAsync()
     {
-        MediaHelper.CleanupTestFiles();
+        try
+        {
+            _fixture.AssertNoLoggedIssues();
+        }
+        finally
+        {
+            MediaHelper.CleanupTestFiles();
+        }
+
         return ValueTask.CompletedTask;
     }
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/ClientDisconnectAwarePipeReaderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/ClientDisconnectAwarePipeReaderTests.cs
@@ -1,0 +1,82 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.Media.Services;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+public sealed class ClientDisconnectAwarePipeReaderTests
+{
+    [Fact]
+    public async Task ReadAsync_UnexpectedEndOfRequest_ReturnsCanceledRead()
+    {
+        var inner = new ThrowingPipeReader(
+            new BadHttpRequestException("Unexpected end of request content."));
+        var reader = new ClientDisconnectAwarePipeReader(inner);
+
+        var result = await reader.ReadAsync(TestContext.Current.CancellationToken);
+        reader.AdvanceTo(result.Buffer.End);
+
+        Assert.True(result.IsCanceled);
+        Assert.False(result.IsCompleted);
+        Assert.Equal(1, inner.ReadCount);
+
+        result = await reader.ReadAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsCanceled);
+        Assert.Equal(1, inner.ReadCount);
+    }
+
+    [Fact]
+    public async Task ReadAsync_OtherBadRequest_Throws()
+    {
+        var exception = new BadHttpRequestException("Invalid chunk terminator.");
+        var reader = new ClientDisconnectAwarePipeReader(new ThrowingPipeReader(exception));
+
+        var actual = await Assert.ThrowsAsync<BadHttpRequestException>(
+            async () => await reader.ReadAsync(TestContext.Current.CancellationToken));
+
+        Assert.Same(exception, actual);
+    }
+
+    private sealed class ThrowingPipeReader : PipeReader
+    {
+        private readonly Exception _exception;
+
+        public ThrowingPipeReader(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public int ReadCount { get; private set; }
+
+        public override void AdvanceTo(SequencePosition consumed)
+        {
+            throw new InvalidOperationException("A failed read must not be advanced.");
+        }
+
+        public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+        {
+            throw new InvalidOperationException("A failed read must not be advanced.");
+        }
+
+        public override void CancelPendingRead()
+        {
+        }
+
+        public override void Complete(Exception exception = null)
+        {
+        }
+
+        public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+        {
+            ReadCount++;
+            return ValueTask.FromException<ReadResult>(_exception);
+        }
+
+        public override bool TryRead(out ReadResult result)
+        {
+            throw _exception;
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/DiskTusTempStoreTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/DiskTusTempStoreTests.cs
@@ -1,0 +1,89 @@
+using System.Buffers;
+using System.IO.Pipelines;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Media;
+using OrchardCore.Media.Services;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+public sealed class DiskTusTempStoreTests : IDisposable
+{
+    private readonly string _tempPath = Path.Combine(
+        Path.GetTempPath(),
+        nameof(DiskTusTempStoreTests),
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task AppendDataAsync_CanceledPipeReader_PersistsPartialData()
+    {
+        var store = new DiskTusTempStore(
+            Options.Create(new MediaOptions { TusTempPath = _tempPath }),
+            new ShellSettings { VersionId = "tenant" },
+            NullLogger<DiskTusTempStore>.Instance);
+        var data = "partial upload"u8.ToArray();
+        var reader = new CanceledPipeReader(data);
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        await store.CreateFileAsync("file", cancellationToken);
+        var bytesWritten = await store.AppendDataAsync("file", reader, 0, cancellationToken);
+
+        Assert.Equal(data.Length, bytesWritten);
+
+        using var stream = store.OpenReadStream("file");
+        using var memoryStream = new MemoryStream();
+        await stream.CopyToAsync(memoryStream, cancellationToken);
+        Assert.Equal(data, memoryStream.ToArray());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempPath))
+        {
+            Directory.Delete(_tempPath, recursive: true);
+        }
+    }
+
+    private sealed class CanceledPipeReader : PipeReader
+    {
+        private readonly byte[] _data;
+        private bool _read;
+
+        public CanceledPipeReader(byte[] data)
+        {
+            _data = data;
+        }
+
+        public override void AdvanceTo(SequencePosition consumed)
+        {
+        }
+
+        public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+        {
+        }
+
+        public override void CancelPendingRead()
+        {
+        }
+
+        public override void Complete(Exception exception = null)
+        {
+        }
+
+        public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+        {
+            Assert.False(_read);
+            _read = true;
+
+            return ValueTask.FromResult(
+                new ReadResult(new ReadOnlySequence<byte>(_data), isCanceled: true, isCompleted: false));
+        }
+
+        public override bool TryRead(out ReadResult result)
+        {
+            result = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

Pausing or canceling a TUS upload can make Kestrel report an unexpected end of request content before the request-aborted token is canceled. This escaped tusdotnet's disconnect guard, produced an application error, and made the functional test suite fail through its shared log assertion.

This change:

- translates only Kestrel's truncated-body error into a canceled `PipeReader` result while preserving other malformed-request failures;
- makes the disk, Azure, and S3 temporary stores honor canceled reads and complete their readers;
- persists durable provider metadata and upload offsets independently of request cancellation;
- prevents the S3 store from advancing the TUS offset for bytes that were buffered but never uploaded;
- adds focused unit coverage and attributes unexpected server logs to the TUS pause/resume tests.