### PR TITLE
Simplify Activity Outcome overload

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
@@ -48,7 +48,7 @@ public abstract class ContentActivity : Activity
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Outcomes(S["Done"]);
+        return Outcome(S["Done"]);
     }
 
     public override Task OnInputReceivedAsync(WorkflowExecutionContext workflowContext, IDictionary<string, object> input)
@@ -69,9 +69,7 @@ public abstract class ContentActivity : Activity
     }
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes("Done");
-    }
+        => Outcome("Done");
 
     public override async Task OnWorkflowRestartingAsync(WorkflowExecutionContext workflowContext, CancellationToken cancellationToken = default)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
@@ -62,9 +62,7 @@ public class CreateContentTask : ContentTask
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -122,13 +120,13 @@ public class CreateContentTask : ContentTask
             workflowContext.Properties[ContentEventConstants.ContentItemInputKey] = contentItem;
             workflowContext.LastResult = contentItem;
 
-            return Outcomes("Done");
+            return Outcome("Done");
         }
 
         workflowContext.LastResult = result;
 
         await _session.CancelAsync();
 
-        return Outcomes("Failed");
+        return Outcome("Failed");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/DeleteContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/DeleteContentTask.cs
@@ -23,9 +23,7 @@ public class DeleteContentTask : ContentTask
     public override LocalizedString Category => S["Content"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Deleted"], S["Noop"]);
-    }
+        => Outcome(S["Deleted"], S["Noop"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -34,7 +32,7 @@ public class DeleteContentTask : ContentTask
 
         if (string.Equals(InlineEvent.ContentItemId, content.ContentItem.ContentItemId, StringComparison.OrdinalIgnoreCase))
         {
-            return Outcomes("Noop");
+            return Outcome("Noop");
         }
 
         var contentItem = await ContentManager.GetAsync(content.ContentItem.ContentItemId, VersionOptions.Latest);
@@ -56,6 +54,6 @@ public class DeleteContentTask : ContentTask
 
         await ContentManager.RemoveAsync(contentItem);
 
-        return Outcomes("Deleted");
+        return Outcome("Deleted");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
@@ -24,9 +24,7 @@ public class PublishContentTask : ContentTask
     public override LocalizedString Category => S["Content"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Published"], S["Noop"]);
-    }
+        => Outcome(S["Published"], S["Noop"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -35,7 +33,7 @@ public class PublishContentTask : ContentTask
 
         if (!content.HasDraft())
         {
-            return Outcomes("Noop");
+            return Outcome("Noop");
         }
 
         var contentItem = await ContentManager.GetAsync(content.ContentItem.ContentItemId, VersionOptions.DraftRequired);
@@ -57,6 +55,6 @@ public class PublishContentTask : ContentTask
 
         await ContentManager.PublishAsync(contentItem);
 
-        return Outcomes("Published");
+        return Outcome("Published");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -25,9 +25,7 @@ public class RetrieveContentTask : ContentTask
     public override LocalizedString Category => S["Content"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Retrieved"]);
-    }
+        => Outcome(S["Retrieved"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -45,6 +43,6 @@ public class RetrieveContentTask : ContentTask
         workflowContext.Properties[ContentEventConstants.ContentItemInputKey] = contentItem;
         workflowContext.LastResult = contentItem;
 
-        return Outcomes("Retrieved");
+        return Outcome("Retrieved");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/UnpublishContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/UnpublishContentTask.cs
@@ -24,9 +24,7 @@ public class UnpublishContentTask : ContentTask
     public override LocalizedString Category => S["Content"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Unpublished"], S["Noop"]);
-    }
+        => Outcome(S["Unpublished"], S["Noop"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -35,7 +33,7 @@ public class UnpublishContentTask : ContentTask
 
         if (string.Equals(InlineEvent.ContentItemId, content.ContentItem.ContentItemId, StringComparison.OrdinalIgnoreCase))
         {
-            return Outcomes("Noop");
+            return Outcome("Noop");
         }
 
         var contentItem = await ContentManager.GetAsync(content.ContentItem.ContentItemId, VersionOptions.Latest);
@@ -57,6 +55,6 @@ public class UnpublishContentTask : ContentTask
 
         await ContentManager.UnpublishAsync(contentItem);
 
-        return Outcomes("Unpublished");
+        return Outcome("Unpublished");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/UpdateContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/UpdateContentTask.cs
@@ -67,9 +67,7 @@ public class UpdateContentTask : ContentTask
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -160,7 +158,7 @@ public class UpdateContentTask : ContentTask
             workflowContext.Properties[ContentEventConstants.ContentItemInputKey] = contentItem;
             workflowContext.LastResult = contentItem;
 
-            return Outcomes("Done");
+            return Outcome("Done");
         }
 
         if (inlineEventOfSameContentItemId)
@@ -174,6 +172,6 @@ public class UpdateContentTask : ContentTask
 
         await _session.CancelAsync();
 
-        return Outcomes("Failed");
+        return Outcome("Failed");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
@@ -127,9 +127,7 @@ public class EmailTask : TaskActivity<EmailTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -181,9 +179,9 @@ public class EmailTask : TaskActivity<EmailTask>
 
         if (!result.Succeeded)
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Activities/HttpRedirectToFormLocationTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Activities/HttpRedirectToFormLocationTask.cs
@@ -26,7 +26,7 @@ public class HttpRedirectToFormLocationTask : TaskActivity<HttpRedirectToFormLoc
     public override LocalizedString Category => S["HTTP"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-        => Outcomes(S["Done"], S["Failed"]);
+        => Outcome(S["Done"], S["Failed"]);
 
     public string FormLocationKey
     {
@@ -43,10 +43,10 @@ public class HttpRedirectToFormLocationTask : TaskActivity<HttpRedirectToFormLoc
             {
                 _httpContextAccessor.HttpContext.Items[WorkflowConstants.FormOriginatedLocationItemsKey] = path;
 
-                return Task.FromResult(Outcomes("Done"));
+                return Task.FromResult(Outcome("Done"));
             }
         }
 
-        return Task.FromResult(Outcomes("Failed"));
+        return Task.FromResult(Outcome("Failed"));
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/AddModelValidationErrorTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/AddModelValidationErrorTask.cs
@@ -37,9 +37,7 @@ public class AddModelValidationErrorTask : TaskActivity<AddModelValidationErrorT
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -47,6 +45,7 @@ public class AddModelValidationErrorTask : TaskActivity<AddModelValidationErrorT
             ?? throw new InvalidOperationException("Cannot add model validation errors when there's no Updater present.");
 
         updater.ModelState.AddModelError(Key, ErrorMessage);
-        return Outcomes("Done");
+
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/BindModelStateTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/BindModelStateTask.cs
@@ -29,9 +29,7 @@ public class BindModelStateTask : TaskActivity<BindModelStateTask>
     public override LocalizedString Category => S["Validation"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -60,6 +58,6 @@ public class BindModelStateTask : TaskActivity<BindModelStateTask>
             updater.ModelState.SetModelValue(item.Key, rawValue, item.Value.ToString());
         }
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateAntiforgeryTokenTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateAntiforgeryTokenTask.cs
@@ -31,19 +31,17 @@ public class ValidateAntiforgeryTokenTask : TaskActivity<ValidateAntiforgeryToke
     public override bool HasEditor => false;
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
-    }
+        => Outcome(S["Done"], S["Valid"], S["Invalid"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (await _antiforgery.IsRequestValidAsync(_httpContextAccessor.HttpContext))
         {
-            return Outcomes("Done", "Valid");
+            return Outcome("Done", "Valid");
         }
         else
         {
-            return Outcomes("Done", "Invalid");
+            return Outcome("Done", "Invalid");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormFieldTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormFieldTask.cs
@@ -42,9 +42,7 @@ public class ValidateFormFieldTask : TaskActivity<ValidateFormFieldTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
-    }
+        => Outcome(S["Done"], S["Valid"], S["Invalid"]);
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -60,6 +58,6 @@ public class ValidateFormFieldTask : TaskActivity<ValidateFormFieldTask>
             updater?.ModelState.TryAddModelError(FieldName, ErrorMessage);
         }
 
-        return Outcomes("Done", outcome);
+        return Outcome("Done", outcome);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormTask.cs
@@ -27,9 +27,7 @@ public class ValidateFormTask : TaskActivity<ValidateFormTask>
     public override bool HasEditor => false;
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Valid"], S["Invalid"]);
-    }
+        => Outcome(S["Valid"], S["Invalid"]);
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -38,6 +36,7 @@ public class ValidateFormTask : TaskActivity<ValidateFormTask>
 
         var isValid = updater.ModelState.ErrorCount == 0;
         var outcome = isValid ? "Valid" : "Invalid";
-        return Outcomes(outcome);
+
+        return Outcome(outcome);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Activities/NotifyUserTaskActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Activities/NotifyUserTaskActivity.cs
@@ -72,7 +72,7 @@ public abstract class NotifyUserTaskActivity : TaskActivity
     /// <param name="activityContext">The activity context.</param>
     /// <returns>The possible workflow outcomes.</returns>
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-        => Outcomes(S["Done"], S["Failed"], S["Failed: no user found"]);
+        => Outcome(S["Done"], S["Failed"], S["Failed: no user found"]);
 
     /// <summary>
     /// Sends the configured notification message to each resolved user.
@@ -86,7 +86,7 @@ public abstract class NotifyUserTaskActivity : TaskActivity
 
         if (users == null || !users.Any())
         {
-            return Outcomes("Failed: no user found");
+            return Outcome("Failed: no user found");
         }
 
         var message = await GetMessageAsync(workflowContext);
@@ -101,12 +101,9 @@ public abstract class NotifyUserTaskActivity : TaskActivity
 
         workflowContext.LastResult = totalSent;
 
-        if (totalSent == 0)
-        {
-            return Outcomes("Failed");
-        }
-
-        return Outcomes("Done");
+        return totalSent == 0
+            ? Outcome("Failed")
+            : Outcome("Done");
     }
 
     /// <summary>

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Workflows/ValidateReCaptchaTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Workflows/ValidateReCaptchaTask.cs
@@ -31,9 +31,7 @@ public class ValidateReCaptchaTask : TaskActivity<ValidateReCaptchaTask>
     public override bool HasEditor => false;
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
-    }
+        => Outcome(S["Done"], S["Valid"], S["Invalid"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -47,6 +45,6 @@ public class ValidateReCaptchaTask : TaskActivity<ValidateReCaptchaTask>
             updater?.ModelState.TryAddModelError(Constants.ReCaptchaServerResponseHeaderName, S["Captcha validation failed. Try again."]);
         });
 
-        return Outcomes("Done", outcome);
+        return Outcome("Done", outcome);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Workflows/Activities/GetUsersByRoleTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Workflows/Activities/GetUsersByRoleTask.cs
@@ -41,7 +41,7 @@ public class GetUsersByRoleTask : TaskActivity<GetUsersByRoleTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-        => Outcomes(S["Done"], S["Failed"]);
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -66,9 +66,9 @@ public class GetUsersByRoleTask : TaskActivity<GetUsersByRoleTask>
 
             workflowContext.Output[outputKeyName] = FluidValue.Create(usersInRole, new TemplateOptions());
 
-            return Outcomes("Done");
+            return Outcome("Done");
         }
 
-        return Outcomes("Failed");
+        return Outcome("Failed");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Workflows/Activities/UnassignUserRoleTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Workflows/Activities/UnassignUserRoleTask.cs
@@ -42,7 +42,7 @@ public class UnassignUserRoleTask : TaskActivity<UnassignUserRoleTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-        => Outcomes(S["Done"], S["Failed"]);
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -63,9 +63,9 @@ public class UnassignUserRoleTask : TaskActivity<UnassignUserRoleTask>
                 }
             }
 
-            return Outcomes("Done");
+            return Outcome("Done");
         }
 
-        return Outcomes("Failed");
+        return Outcome("Failed");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Sms/Activities/SmsTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/Activities/SmsTask.cs
@@ -40,9 +40,7 @@ public class SmsTask : TaskActivity<SmsTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -54,9 +52,9 @@ public class SmsTask : TaskActivity<SmsTask>
 
         if (result.Succeeded)
         {
-            return Outcomes("Done");
+            return Outcome("Done");
         }
 
-        return Outcomes("Failed");
+        return Outcome("Failed");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/CreateTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/CreateTenantTask.cs
@@ -81,27 +81,25 @@ public class CreateTenantTask : TenantTask
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (!ShellScope.Context.Settings.IsDefaultShell())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         var tenantName = (await ExpressionEvaluator.EvaluateAsync(TenantName, workflowContext, null))?.Trim();
 
         if (string.IsNullOrEmpty(tenantName))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (ShellHost.TryGetSettings(tenantName, out _))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         var description = (await ExpressionEvaluator.EvaluateAsync(Description, workflowContext, null))?.Trim();
@@ -177,6 +175,6 @@ public class CreateTenantTask : TenantTask
         workflowContext.LastResult = reloadedSettings;
         workflowContext.CorrelationId = reloadedSettings.Name;
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/DisableTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/DisableTenantTask.cs
@@ -21,41 +21,39 @@ public class DisableTenantTask : TenantTask
     public override LocalizedString DisplayText => S["Disable Tenant Task"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Disabled"], S["Failed"]);
-    }
+        => Outcome(S["Disabled"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (!ShellScope.Context.Settings.IsDefaultShell())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         var tenantName = (await ExpressionEvaluator.EvaluateAsync(TenantName, workflowContext, null))?.Trim();
 
         if (string.IsNullOrEmpty(tenantName))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (!ShellHost.TryGetSettings(tenantName, out var shellSettings))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (shellSettings.IsDefaultShell())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (!shellSettings.IsRunning())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         await ShellHost.UpdateShellSettingsAsync(shellSettings.AsDisabled());
 
-        return Outcomes("Disabled");
+        return Outcome("Disabled");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/EnableTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/EnableTenantTask.cs
@@ -23,40 +23,40 @@ public class EnableTenantTask : TenantTask
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Outcomes(S["Enabled"], S["Failed"]);
+        return Outcome(S["Enabled"], S["Failed"]);
     }
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (!ShellScope.Context.Settings.IsDefaultShell())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         var tenantName = (await ExpressionEvaluator.EvaluateAsync(TenantName, workflowContext, null))?.Trim();
 
         if (string.IsNullOrEmpty(tenantName))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (!ShellHost.TryGetSettings(tenantName, out var shellSettings))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (shellSettings.IsDefaultShell())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (!shellSettings.IsDisabled())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         await ShellHost.UpdateShellSettingsAsync(shellSettings.AsRunning());
 
-        return Outcomes("Enabled");
+        return Outcome("Enabled");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/SetupTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/SetupTenantTask.cs
@@ -105,37 +105,35 @@ public class SetupTenantTask : TenantTask
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (!ShellScope.Context.Settings.IsDefaultShell())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         var tenantName = (await ExpressionEvaluator.EvaluateAsync(TenantName, workflowContext, null))?.Trim();
 
         if (string.IsNullOrWhiteSpace(tenantName))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (!ShellHost.TryGetSettings(tenantName, out var shellSettings))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (shellSettings.IsRunning())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (!shellSettings.IsUninitialized())
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         var siteName = (await ExpressionEvaluator.EvaluateAsync(SiteName, workflowContext, null))?.Trim();
@@ -144,12 +142,12 @@ public class SetupTenantTask : TenantTask
 
         if (string.IsNullOrEmpty(adminUsername) || adminUsername.Any(c => !_identityOptions.User.AllowedUserNameCharacters.Contains(c)))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         if (string.IsNullOrEmpty(adminEmail) || !_emailAddressValidator.Validate(adminEmail))
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
         var adminPassword = (await ExpressionEvaluator.EvaluateAsync(AdminPassword, workflowContext, null))?.Trim();
@@ -220,9 +218,9 @@ public class SetupTenantTask : TenantTask
                 updater.ModelState.AddModelError(error.Key, error.Value);
             }
 
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/TenantActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/TenantActivity.cs
@@ -35,11 +35,11 @@ public abstract class TenantActivity : Activity
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Outcomes(S["Done"]);
+        return Outcome(S["Done"]);
     }
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Workflows/Activities/UpdateTwitterStatusTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Workflows/Activities/UpdateTwitterStatusTask.cs
@@ -38,9 +38,7 @@ public class UpdateTwitterStatusTask : TaskActivity<UpdateTwitterStatusTask>
 
     // Returns the possible outcomes of this activity.
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     // This is the heart of the activity and actually performs the work to be done.
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
@@ -51,11 +49,8 @@ public class UpdateTwitterStatusTask : TaskActivity<UpdateTwitterStatusTask>
         var result = await _twitterClient.UpdateStatus(status);
         workflowContext.Properties.Add("TwitterResponse", await result.Content.ReadAsStringAsync());
 
-        if (!result.IsSuccessStatusCode)
-        {
-            return Outcomes("Failed");
-        }
-
-        return Outcomes("Done");
+        return result.IsSuccessStatusCode
+            ? Outcome("Done")
+            : Outcome("Failed");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/AssignUserRoleTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/AssignUserRoleTask.cs
@@ -45,9 +45,7 @@ public class AssignUserRoleTask : TaskActivity<AssignUserRoleTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Failed"]);
-    }
+        => Outcome(S["Done"], S["Failed"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -63,11 +61,11 @@ public class AssignUserRoleTask : TaskActivity<AssignUserRoleTask>
                 await _userManager.AddToRoleAsync(user, roleName);
             }
 
-            return Outcomes("Done");
+            return Outcome("Done");
         }
         else
         {
-            return Outcomes("Failed");
+            return Outcome("Failed");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
@@ -83,9 +83,7 @@ public class RegisterUserTask : TaskActivity<RegisterUserTask>
 
     // Returns the possible outcomes of this activity.
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
-    }
+        => Outcome(S["Done"], S["Valid"], S["Invalid"]);
 
     // This is the heart of the activity and actually performs the work to be done.
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
@@ -93,7 +91,7 @@ public class RegisterUserTask : TaskActivity<RegisterUserTask>
         var email = GetPropertyFromContextOrForm(workflowContext, "Email");
         if (string.IsNullOrWhiteSpace(email))
         {
-            return Outcomes("Done", "Invalid");
+            return Outcome("Done", "Invalid");
         }
 
         var userName = GetPropertyFromContextOrForm(workflowContext, "UserName") ?? email.Replace('@', '+');
@@ -101,15 +99,15 @@ public class RegisterUserTask : TaskActivity<RegisterUserTask>
 
         if (user == null)
         {
-            return Outcomes("Done", "Invalid");
+            return Outcome("Done", "Invalid");
         }
 
         if (SendConfirmationEmail && !await SendConfirmationEmailAsync(user, workflowContext, email))
         {
-            return Outcomes("Done", "Invalid");
+            return Outcome("Done", "Invalid");
         }
 
-        return Outcomes("Done", "Valid");
+        return Outcome("Done", "Valid");
     }
 
     private string GetPropertyFromContextOrForm(WorkflowExecutionContext context, string key)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserActivity.cs
@@ -36,11 +36,11 @@ public abstract class UserActivity : Activity
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Outcomes(S["Done"]);
+        return Outcome(S["Done"]);
     }
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/ValidateUserTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/ValidateUserTask.cs
@@ -38,9 +38,7 @@ public class ValidateUserTask : TaskActivity<ValidateUserTask>
     public override LocalizedString DisplayText => S["Validate User Task"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Anonymous"], S["Authenticated"], S["InRole"]);
-    }
+        => Outcome(S["Anonymous"], S["Authenticated"], S["InRole"]);
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -66,14 +64,15 @@ public class ValidateUserTask : TaskActivity<ValidateUserTask>
                     if (userRoleNames.Contains(role))
                     {
                         workflowContext.LastResult = userRoleNames;
-                        return Outcomes("InRole");
+
+                        return Outcome("InRole");
                     }
                 }
             }
 
-            return Outcomes(OrchardCoreConstants.Roles.Authenticated);
+            return Outcome(OrchardCoreConstants.Roles.Authenticated);
         }
 
-        return Outcomes(OrchardCoreConstants.Roles.Anonymous);
+        return Outcome(OrchardCoreConstants.Roles.Anonymous);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CommitTransactionTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CommitTransactionTask.cs
@@ -27,18 +27,17 @@ public class CommitTransactionTask : TaskActivity<CommitTransactionTask>
     public override LocalizedString Category => S["Session"];
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
-    }
+        => Outcome(S["Done"], S["Valid"], S["Invalid"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (!_updateModelAccessor.ModelUpdater.ModelState.IsValid)
         {
-            return Outcomes("Done", "Invalid");
+            return Outcome("Done", "Invalid");
         }
 
         await _session.SaveChangesAsync();
-        return Outcomes("Done", "Valid");
+
+        return Outcome("Done", "Valid");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CorrelateTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CorrelateTask.cs
@@ -39,9 +39,7 @@ public class CorrelateTask : TaskActivity<CorrelateTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -54,6 +52,6 @@ public class CorrelateTask : TaskActivity<CorrelateTask>
 
         workflowContext.CorrelationId = value?.Trim();
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForEachTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForEachTask.cs
@@ -76,9 +76,7 @@ public class ForEachTask : TaskActivity<ForEachTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Iterate"], S["Done"]);
-    }
+        => Outcome(S["Iterate"], S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -99,12 +97,14 @@ public class ForEachTask : TaskActivity<ForEachTask>
             workflowContext.Properties[LoopVariableName] = current;
             workflowContext.LastResult = current;
             Index++;
-            return Outcomes("Iterate");
+
+            return Outcome("Iterate");
         }
         else
         {
             Index = 0;
-            return Outcomes("Done");
+
+            return Outcome("Done");
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForLoopTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForLoopTask.cs
@@ -95,9 +95,7 @@ public class ForLoopTask : TaskActivity<ForLoopTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Iterate"], S["Done"]);
-    }
+        => Outcome(S["Iterate"], S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -115,12 +113,14 @@ public class ForLoopTask : TaskActivity<ForLoopTask>
             workflowContext.LastResult = Index;
             workflowContext.Properties[LoopVariableName] = Index;
             Index += step;
-            return Outcomes("Iterate");
+
+            return Outcome("Iterate");
         }
         else
         {
             Index = from;
-            return Outcomes("Done");
+
+            return Outcome("Done");
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForkTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForkTask.cs
@@ -24,12 +24,10 @@ public class ForkTask : TaskActivity<ForkTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Forks.Select(x => Outcome(S[x]));
-    }
+        => Forks.SelectMany(f => Outcome(S[f]));
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Outcomes(Forks);
+        return Outcome(Forks);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/IfElseTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/IfElseTask.cs
@@ -47,9 +47,7 @@ public class IfElseTask : TaskActivity<IfElseTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["True"], S["False"]);
-    }
+        => Outcome(S["True"], S["False"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -60,6 +58,6 @@ public class IfElseTask : TaskActivity<IfElseTask>
             _ => throw new NotSupportedException($"The syntax {Syntax} isn't supported for IfElseTask.")
         };
 
-        return Outcomes(result ? "True" : "False");
+        return Outcome(result ? "True" : "False");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/JoinTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/JoinTask.cs
@@ -36,9 +36,7 @@ public class JoinTask : TaskActivity<JoinTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Joined"]);
-    }
+        => Outcome(S["Joined"]);
 
     public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -70,7 +68,7 @@ public class JoinTask : TaskActivity<JoinTask>
 
         if (done)
         {
-            return Outcomes("Joined");
+            return Outcome("Joined");
         }
 
         return Noop();

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/LiquidTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/LiquidTask.cs
@@ -29,14 +29,12 @@ public class LiquidTask : TaskActivity<LiquidTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         workflowContext.LastResult = await _expressionEvaluator.EvaluateAsync(Expression, workflowContext, null);
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/LogTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/LogTask.cs
@@ -36,9 +36,7 @@ public class LogTask : TaskActivity<LogTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -46,6 +44,7 @@ public class LogTask : TaskActivity<LogTask>
         var logLevel = LogLevel;
 
         _logger.Log(logLevel, 0, text, null, (state, error) => state.ToString());
-        return Outcomes("Done");
+
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/NotifyTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/NotifyTask.cs
@@ -44,9 +44,7 @@ public class NotifyTask : TaskActivity<NotifyTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -55,6 +53,6 @@ public class NotifyTask : TaskActivity<NotifyTask>
         // The notification message can contain HTML by design
         await _notifier.AddAsync(NotificationType, new LocalizedHtmlString(nameof(NotifyTask), message));
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
@@ -37,15 +37,13 @@ public class ScriptTask : TaskActivity<ScriptTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(AvailableOutcomes.Select(x => S[x]).ToArray());
-    }
+        => Outcome(AvailableOutcomes.Select(x => S[x]).ToArray());
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         var outcomes = new List<string>();
         workflowContext.LastResult = await _scriptEvaluator.EvaluateAsync(Script, workflowContext, new OutcomeMethodProvider(outcomes));
 
-        return Outcomes(outcomes);
+        return Outcome(outcomes);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetOutputTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetOutputTask.cs
@@ -50,9 +50,7 @@ public class SetOutputTask : TaskActivity<SetOutputTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -65,6 +63,6 @@ public class SetOutputTask : TaskActivity<SetOutputTask>
 
         workflowContext.Output[OutputName] = value;
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetPropertyTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetPropertyTask.cs
@@ -50,9 +50,7 @@ public class SetPropertyTask : TaskActivity<SetPropertyTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -65,6 +63,6 @@ public class SetPropertyTask : TaskActivity<SetPropertyTask>
 
         workflowContext.Properties[PropertyName] = value;
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/WhileLoopTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/WhileLoopTask.cs
@@ -47,9 +47,7 @@ public class WhileLoopTask : TaskActivity<WhileLoopTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Iterate"], S["Done"]);
-    }
+        => Outcome(S["Iterate"], S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -60,6 +58,6 @@ public class WhileLoopTask : TaskActivity<WhileLoopTask>
             _ => throw new NotSupportedException($"The syntax {Syntax} isn't supported for WhileLoopTask.")
         };
 
-        return Outcomes(loop ? "Iterate" : "Done");
+        return Outcome(loop ? "Iterate" : "Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Events/WorkflowFaultEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Events/WorkflowFaultEvent.cs
@@ -30,14 +30,10 @@ public class WorkflowFaultEvent : EventActivity
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes("Done");
-    }
+        => Outcome("Done");
 
     public override async Task<bool> CanExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRedirectTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRedirectTask.cs
@@ -42,9 +42,7 @@ public class HttpRedirectTask : TaskActivity<HttpRedirectTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -53,6 +51,6 @@ public class HttpRedirectTask : TaskActivity<HttpRedirectTask>
         _httpContextAccessor.HttpContext.Response.Redirect(location.ToUriComponents(), Permanent);
         _httpContextAccessor.HttpContext.Items[WorkflowHttpResult.Instance] = WorkflowHttpResult.Instance;
 
-        return Outcomes("Done");
+        return Outcome("Done");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestEvent.cs
@@ -82,14 +82,14 @@ public class HttpRequestEvent : EventActivity
             workflowContext.Output[WorkflowConstants.HttpFormLocationOutputKeyName] = formLocation;
         }
 
-        return Task.FromResult(Outcomes("Done"));
+        return Task.FromResult(Outcome("Done"));
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-        => Outcomes(S["Done"]);
+        => Outcome(S["Done"]);
 
     public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-        => Outcomes("Done");
+        => Outcome("Done");
 
     private static string GetLocationUrl(string value)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestFilterEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestFilterEvent.cs
@@ -79,14 +79,10 @@ public class HttpRequestFilterEvent : EventActivity
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Matched"]);
-    }
+        => Outcome(S["Matched"]);
 
     public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes("Matched");
-    }
+        => Outcome("Matched");
 
     private void SetRouteValue<T>(string name, T value)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
@@ -61,9 +61,7 @@ public class HttpResponseTask : TaskActivity<HttpResponseTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -91,7 +89,8 @@ public class HttpResponseTask : TaskActivity<HttpResponseTask>
         }
 
         _httpContextAccessor.HttpContext.Items[WorkflowHttpResult.Instance] = WorkflowHttpResult.Instance;
-        return Outcomes("Done");
+
+        return Outcome("Done");
     }
 
     private static IEnumerable<KeyValuePair<string, StringValues>> ParseHeaders(string text)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/SignalEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/SignalEvent.cs
@@ -36,12 +36,8 @@ public class SignalEvent : EventActivity
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes("Done");
-    }
+        => Outcome("Done");
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
@@ -56,16 +56,15 @@ public class TimerEvent : EventActivity
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ResumeAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (await IsExpiredAsync())
         {
             workflowContext.LastResult = "TimerEvent";
-            return Outcomes("Done");
+
+            return Outcome("Done");
         }
 
         return Halt();

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
@@ -39,13 +39,14 @@ public class UserTaskEvent : EventActivity
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return Actions.Select(x => Outcome(S[x]));
+        return Actions.SelectMany(a => Outcome(S[a]));
     }
 
     public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         var action = GetProvidedAction(workflowContext);
-        return Outcomes(action);
+
+        return Outcome(action);
     }
 
     private static string GetProvidedAction(WorkflowExecutionContext workflowContext)

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/Activity.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/Activity.cs
@@ -99,35 +99,29 @@ public abstract class Activity : Entity, IActivity
         return Task.CompletedTask;
     }
 
-    protected static Outcome Outcome(LocalizedString name)
-    {
-        return new Outcome(name);
-    }
+    protected static IEnumerable<Outcome> Outcome(params LocalizedString[] names)
+        => names.Select(s => new Outcome(s));
 
-    protected static IEnumerable<Outcome> Outcomes(params LocalizedString[] names)
-    {
-        return names.Select(x => new Outcome(x));
-    }
+    protected static ActivityExecutionResult Outcome(params string[] names)
+        => new ActivityExecutionResult(names);
 
-    protected static IEnumerable<Outcome> Outcomes(IEnumerable<LocalizedString> names)
-    {
-        return names.Select(x => new Outcome(x));
-    }
+    protected static ActivityExecutionResult Outcome(params IEnumerable<string> names)
+        => new ActivityExecutionResult(names);
 
-    protected static ActivityExecutionResult Outcomes(string name)
-    {
-        return new ActivityExecutionResult(new string[] { name });
-    }
+    [Obsolete("This methods is deprecated. Use Outcome(params LocalizedString[] names) instead.")]
+    protected static IEnumerable<Outcome> Outcomes(params LocalizedString[] names) => Outcome(names);
 
-    protected static ActivityExecutionResult Outcomes(params string[] names)
-    {
-        return new ActivityExecutionResult(names);
-    }
+    [Obsolete("This methods is deprecated. Use Outcome(params LocalizedString[] names) instead.")]
+    protected static IEnumerable<Outcome> Outcomes(IEnumerable<LocalizedString> names) => Outcome(names.ToArray());
 
-    protected static ActivityExecutionResult Outcomes(IEnumerable<string> names)
-    {
-        return new ActivityExecutionResult(names);
-    }
+    [Obsolete("This methods is deprecated. Use Outcome(params string[] names) instead.")]
+    protected static ActivityExecutionResult Outcomes(string name) => Outcome(name);
+
+    [Obsolete("This methods is deprecated. Use Outcome(params string[] names) instead.")]
+    protected static ActivityExecutionResult Outcomes(params string[] names) => Outcome(names);
+
+    [Obsolete("This methods is deprecated. Use Outcome(params string[] names) instead.")]
+    protected static ActivityExecutionResult Outcomes(IEnumerable<string> names) => Outcome(names.ToArray());
 
     protected static ActivityExecutionResult Halt()
     {

--- a/test/OrchardCore.Tests/Workflows/Activities/AddTask.cs
+++ b/test/OrchardCore.Tests/Workflows/Activities/AddTask.cs
@@ -33,9 +33,7 @@ public class AddTask : TaskActivity<AddTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
@@ -44,6 +42,7 @@ public class AddTask : TaskActivity<AddTask>
         var result = a + b;
 
         workflowContext.LastResult = result;
-        return Outcomes("Done");
+
+        return Outcome("Done");
     }
 }

--- a/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
+++ b/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
@@ -29,14 +29,13 @@ public class WriteLineTask : TaskActivity<WriteLineTask>
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-    {
-        return Outcomes(S["Done"]);
-    }
+        => Outcome(S["Done"]);
 
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         var text = await _scriptEvaluator.EvaluateAsync(Text, workflowContext);
         await _output.WriteLineAsync(text);
-        return Outcomes("Done");
+
+        return Outcome("Done");
     }
 }

--- a/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
+++ b/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
@@ -597,15 +597,13 @@ public class WorkflowManagerTests
         public override LocalizedString Category => new("Test", "Test");
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
-        {
-            return Outcomes(new LocalizedString("Done", "Done"));
-        }
+            => Outcome(new LocalizedString("Done", "Done"));
 
         public override Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             _onExecute();
 
-            return Task.FromResult(Outcomes("Done"));
+            return Task.FromResult(Outcome("Done"));
         }
     }
 


### PR DESCRIPTION
Both `Outcome` and `Outcomes` refer to the same thing, let use Outcome for simplicity