### PR TITLE
Make the functional test warm-up diagnosable and bound its retries

### DIFF
--- a/.github/workflows/functional_all_db.yml
+++ b/.github/workflows/functional_all_db.yml
@@ -50,6 +50,9 @@ jobs:
       run: |
         pwsh test/OrchardCore.Tests.Functional/bin/Release/net10.0/playwright.ps1 install --with-deps chromium
     - name: Functional Tests
+      env:
+        # The MVC app uses neither Redis nor Azurite; don't start those containers for this run.
+        ORCHARD_TEST_DOCKER_SERVICES: "false"
       run: |
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Mvc*"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -52,6 +52,9 @@ jobs:
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Cms*"
     - name: Functional Tests - MVC
       if: matrix.os == 'ubuntu-24.04'
+      env:
+        # The MVC app uses neither Redis nor Azurite; don't start those containers for this run.
+        ORCHARD_TEST_DOCKER_SERVICES: "false"
       run: |
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Mvc*"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -48,6 +48,9 @@ jobs:
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Cms*"
     - name: Functional Tests - MVC
       if: matrix.os == 'ubuntu-24.04'
+      env:
+        # The MVC app uses neither Redis nor Azurite; don't start those containers for this run.
+        ORCHARD_TEST_DOCKER_SERVICES: "false"
       run: |
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Mvc*"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -55,6 +55,9 @@ jobs:
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Cms*"
     - name: Functional Tests - MVC
       if: steps.check-publish.outputs.should-publish == 'true'
+      env:
+        # The MVC app uses neither Redis nor Azurite; don't start those containers for this run.
+        ORCHARD_TEST_DOCKER_SERVICES: "false"
       run: |
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Mvc*"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -58,6 +58,9 @@ jobs:
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Cms*"
     - name: Functional Tests - MVC
       if: matrix.os == 'ubuntu-24.04'
+      env:
+        # The MVC app uses neither Redis nor Azurite; don't start those containers for this run.
+        ORCHARD_TEST_DOCKER_SERVICES: "false"
       run: |
         dotnet test --project test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -c Release --no-build --filter-class "*Mvc*"
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/test/OrchardCore.Tests.Functional/Helpers/DockerHelper.cs
+++ b/test/OrchardCore.Tests.Functional/Helpers/DockerHelper.cs
@@ -13,7 +13,8 @@ public static class DockerHelper
         + "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
         + "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
 
-    private static bool _dockerStarted;
+    private static bool _startAttempted;
+    private static bool _containersStarted;
 
     /// <summary>
     /// Starts Redis and Azurite Docker containers if Docker is available,
@@ -25,12 +26,20 @@ public static class DockerHelper
     /// </summary>
     public static void TryStartDockerServices()
     {
-        if (_dockerStarted)
+        if (_startAttempted)
         {
             return;
         }
 
-        _dockerStarted = true;
+        _startAttempted = true;
+
+        // Runs that exercise no Redis/Azurite-backed test (e.g. the MVC suite) opt out, so the
+        // containers don't compete with the host for runner resources while it boots.
+        if (System.Environment.GetEnvironmentVariable("ORCHARD_TEST_DOCKER_SERVICES") == "false")
+        {
+            Log("Docker services disabled via ORCHARD_TEST_DOCKER_SERVICES — skipping container startup.");
+            return;
+        }
 
         if (!IsDockerAvailable())
         {
@@ -78,6 +87,8 @@ public static class DockerHelper
             Log($"Started Docker container '{_azuriteContainerName}' (Azurite).");
         }
 
+        _containersStarted = true;
+
         // Remove containers when the test process exits.
         AppDomain.CurrentDomain.ProcessExit += (_, _) => StopDockerServices();
     }
@@ -87,7 +98,7 @@ public static class DockerHelper
     /// </summary>
     public static void StopDockerServices()
     {
-        if (!_dockerStarted)
+        if (!_containersStarted)
         {
             return;
         }

--- a/test/OrchardCore.Tests.Functional/Helpers/OrchardTestServer.cs
+++ b/test/OrchardCore.Tests.Functional/Helpers/OrchardTestServer.cs
@@ -109,7 +109,7 @@ public sealed class OrchardTestServer : IAsyncDisposable
 
         // The OrchardCore tenant pipeline initializes lazily on the first request.
         // Warm up the app now so tests don't race against pipeline initialization.
-        await WarmUpAsync(address, timeoutSeconds: 90);
+        await WarmUpAsync(address, loggerProvider.Collector, timeoutSeconds: 90);
 
         return new OrchardTestServer(app, address, loggerProvider.Collector);
     }
@@ -362,32 +362,89 @@ public sealed class OrchardTestServer : IAsyncDisposable
     /// OrchardCore tenant pipeline has finished its lazy first-request initialization
     /// before the Playwright tests begin.
     /// </summary>
-    private static async Task WarmUpAsync(string baseAddress, string healthPath = "/health/live", int timeoutSeconds = 30)
+    private static async Task WarmUpAsync(
+        string baseAddress,
+        FakeLogCollector logCollector,
+        string healthPath = "/health/live",
+        int timeoutSeconds = 30)
     {
-        using var client = new HttpClient();
+        // Each attempt gets a fresh connection: a single connection that the server accepts but
+        // never answers must not consume the whole budget, nor be handed back out of the pool.
+        var handler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.Zero,
+            ConnectTimeout = TimeSpan.FromSeconds(5),
+        };
+
+        using var client = new HttpClient(handler, disposeHandler: true);
+
         var deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        var attempts = 0;
+        var lastFailure = "no attempt completed";
 
         while (DateTime.UtcNow < deadline)
         {
+            attempts++;
+
+            // Bound each attempt so one hung request can't eat the entire timeout, which would
+            // leave us unable to tell a hang apart from a fast, consistently failing response.
+            using var attemptCancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
             try
             {
-                var response = await client.GetAsync($"{baseAddress}{healthPath}");
+                var response = await client.GetAsync($"{baseAddress}{healthPath}", attemptCancellation.Token);
                 if (response.IsSuccessStatusCode)
                 {
                     return;
                 }
+
+                var body = await response.Content.ReadAsStringAsync(attemptCancellation.Token);
+                lastFailure = $"HTTP {(int)response.StatusCode} {response.ReasonPhrase}"
+                    + (string.IsNullOrWhiteSpace(body) ? " (empty body)" : $": {Truncate(body, 500)}");
             }
-            catch
+            catch (OperationCanceledException)
+            {
+                lastFailure = "the request did not complete within 10 seconds";
+            }
+            catch (Exception ex)
             {
                 // Server not yet accepting connections — keep waiting.
+                lastFailure = $"{ex.GetType().Name}: {ex.Message}";
             }
 
             await Task.Delay(500);
         }
 
         throw new TimeoutException(
-            $"The application at '{baseAddress}' did not respond successfully at '{healthPath}' within {timeoutSeconds} seconds.");
+            $"The application at '{baseAddress}' did not respond successfully at '{healthPath}' within "
+            + $"{timeoutSeconds} seconds after {attempts} attempt(s). Last failure: {lastFailure}."
+            + DescribeLoggedIssues(logCollector));
     }
+
+    /// <summary>
+    /// Renders the warnings and errors the host logged during startup, so a warm-up failure
+    /// reports why the app is unhealthy instead of only that it is.
+    /// </summary>
+    private static string DescribeLoggedIssues(FakeLogCollector logCollector)
+    {
+        var issues = logCollector.GetSnapshot()
+            .Where(e => e.Level >= LogLevel.Warning)
+            .ToList();
+
+        if (issues.Count == 0)
+        {
+            return $"{System.Environment.NewLine}The host logged no warnings or errors.";
+        }
+
+        var messages = issues.Select(e =>
+            $"[{e.Level}] {e.Category}: {e.Message}{(e.Exception is not null ? $" -> {e.Exception}" : string.Empty)}");
+
+        return $"{System.Environment.NewLine}The host logged {issues.Count} warning(s)/error(s):"
+            + $"{System.Environment.NewLine}{string.Join(System.Environment.NewLine, messages)}";
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value.Length <= maxLength ? value : value[..maxLength] + "…";
 
     private static string GetListeningAddress(WebApplication app)
     {


### PR DESCRIPTION
The MVC fixture intermittently fails in CI with a 90 second timeout waiting on '/health/live', and the failure carries no evidence: the deadline was only checked at the top of the retry loop and HttpClient's default timeout is 100 seconds, so a single hung request consumed the whole budget in one attempt, while a bare catch swallowed every exception.

Bound each attempt to 10 seconds, disable connection pooling so a retry can't reuse a poisoned connection, and report the attempt count, last status/body, last exception and the host's logged warnings and errors on timeout.

Also skip the Redis and Azurite containers for the MVC runs, which use neither, so they don't compete with the host while it boots.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
