### PR TITLE
Revise release notes for version 4.0.0

### DIFF
--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -6,7 +6,9 @@
 
 ## Breaking Changes
 
--Previously, `bootstrap-select` styles were included automatically in the **TheAdmin** theme. If you use `bootstrap-select` resources in your own project, you must now include the `bootstrap-select` styles explicitly.  This can be done by adding the following to your `Startup.cs`:
+### Admin Theme
+
+Previously, `bootstrap-select` styles were included automatically in the **TheAdmin** theme. If you use `bootstrap-select` resources in your own project, you must now include the `bootstrap-select` styles explicitly. This can be done by adding the following to your Razor view:
 
 ```
 <style asp-name="bootstrap-select" at="Head"></style>
@@ -19,22 +21,6 @@ The former Media admin AJAX endpoints on `AdminController` (`MediaApplication`, 
 ### Queries Module
 
 `QueryApiController`'s `api/queries/{name}` endpoint previously handled both `GET` and `POST` through a single action sharing one `operationId` (`ApiExecuteQuery`), which OpenAPI does not allow to be reused across operations. It is now split into two actions — `ApiExecuteQueryGet` and `ApiExecuteQueryPost` — with no change to the endpoint's route, verbs, or parameters. If you generate an API client (e.g., with NSwag) against this endpoint, the generated method name(s) will change on your next regeneration.
-
-### Media Gallery and Media API
-
-The Media Library admin UI has been rewritten as a **Vue 3 Media Gallery** application, replacing the previous media application. It provides file operations (upload, rename, move, copy, delete, download), folder management with drag-and-drop, search, sorting, pagination, and a storage-information panel.
-
-The gallery is backed by a new **Media API** — minimal-API endpoints under `api/media` — with a selectable authentication scheme (`MediaApiSettings.AuthenticationScheme`):
-
-- **Cookie** (default): the ambient same-origin admin cookie, with antiforgery validation on mutating requests. Works out of the box.
-- **Bearer**: OAuth2 authorization-code + PKCE tokens acquired silently by the gallery (hidden iframe against the tenant's OpenID Connect server) and attached to API calls, uploads, and the SignalR connection. Provisioned by the **`MediaApiPkce` recipe**, which registers a public `media_gallery` client. Additional recipes (`MediaApiStandalone`, plus a localhost-dev variant) configure running the gallery as a standalone external app on its own origin, with interactive login and CORS.
-
-Supporting features:
-
-- **`OrchardCore.Media.Tus`** — resumable uploads via the [TUS protocol](https://tus.io/): chunked, pausable, and recoverable after network interruptions.
-- **`OrchardCore.Media.SignalR`** (with `.Azure` and `.Redis` backplane sub-features) — real-time media updates broadcast to all connected clients, keeping the gallery in sync across tabs, users, and instances.
-
-See the [Media Gallery documentation](../reference/modules/Media/MediaGallery.md) for details, including multi-instance deployment guidance.
 
 ## New features
 
@@ -54,6 +40,21 @@ When the feature is enabled, uploads fail:
 
 This feature integrates with the shared file upload security pipeline through `IFileEventHandler`, so uploads can be rejected before Orchard Core stores them permanently.
 
+### `OrchardCore.OpenApi` Module
+
+This release introduces a new `OrchardCore.OpenApi` module that provides interactive API documentation and OpenAPI/Swagger schema generation for Orchard Core's API endpoints.
+
+The module provides:
+
+- three independently toggleable documentation UIs — Swagger UI, ReDoc, and Scalar — each as its own sub-feature;
+- **zero-configuration silent authentication** for the "Try it out" flows: the Swagger and Scalar pages acquire an OAuth2 authorization-code + PKCE bearer token silently (`prompt=none` in a hidden iframe) using the signed-in admin's cookie session, auto-renew it, and attach it to every API request — no "Authorize" click and no authentication settings to fill in. Tokens are held in memory only, attached exclusively to same-origin `/api/` requests, and a token rejected by the server triggers one silent re-sign-in and retry;
+- an **`OpenApiPkce` recipe** that provisions everything the silent flow needs: the OpenID Server/Validation/Management features, the authorization-code flow with PKCE required, local token validation, and a public secret-less `openapi` client registration;
+- an `AllowAnonymousSchemaAccess` setting, **disabled by default**: the JSON schema endpoints require the `ViewOpenApiContent` permission unless it is enabled, so external tools like NSwag must either authenticate or run against a tenant that has opted into anonymous schema access;
+- a `ViewOpenApiContent`/`ManageOpenApi` permission pair, so a role can be granted read-only access to the documentation UIs without also being able to change the module's settings;
+- an `OpenApiGeneration` recipe that enables every feature exposing an API endpoint (Content, Queries, Tenants, Lucene, Elasticsearch) and turns on anonymous schema access, for generating client SDKs with tools like NSwag — plus a `tools/OpenApiClientGenerator` console tool that runs the whole NSwag regeneration pipeline headlessly and deterministically (operations are sorted by route + verb, so unchanged APIs regenerate byte-identical clients).
+
+For configuration details and client generation steps, see the [OpenApi documentation](../reference/modules/OpenApi/README.md).
+
 ### `OrchardCore.RateLimits` Module
 
 This release introduces a new `OrchardCore.RateLimits` module that centralizes request rate limiting for Orchard Core tenants.
@@ -66,26 +67,27 @@ When enabled, it provides:
 
 Static assets are excluded from the tenant rate limiter because the middleware is ordered after Orchard Core static-file handling. For configuration details, see the [Rate Limits documentation](../reference/modules/RateLimits/README.md).
 
-### `OrchardCore.OpenApi` Module
-
-This release introduces a new `OrchardCore.OpenApi` module that provides interactive API documentation and OpenAPI/Swagger schema generation for Orchard Core's API endpoints.
-
-The module provides:
-
-- three independently toggleable documentation UIs — Swagger UI, ReDoc, and Scalar — each its own sub-feature;
-- **zero-configuration silent authentication** for the "Try it out" flows: the Swagger and Scalar pages acquire an OAuth2 authorization-code + PKCE bearer token silently (`prompt=none` in a hidden iframe) using the signed-in admin's cookie session, auto-renew it, and attach it to every API request — no "Authorize" click and no authentication settings to fill in. Tokens are held in memory only, attached exclusively to same-origin `/api/` requests, and a token rejected by the server triggers one silent re-sign-in and retry;
-- an **`OpenApiPkce` recipe** that provisions everything the silent flow needs: the OpenID Server/Validation/Management features, the authorization-code flow with PKCE required, local token validation, and a public secret-less `openapi` client registration;
-- an `AllowAnonymousSchemaAccess` setting, **disabled by default**: the JSON schema endpoints require the `ViewOpenApiContent` permission unless it is enabled, so external tools like NSwag must either authenticate or run against a tenant that has opted into anonymous schema access;
-- a `ViewOpenApiContent`/`ManageOpenApi` permission pair, so a role can be granted read-only access to the documentation UIs without also being able to change the module's settings;
-- an `OpenApiGeneration` recipe that enables every feature exposing an API endpoint (Content, Queries, Tenants, Lucene, Elasticsearch) and turns on anonymous schema access, for generating client SDKs with tools like NSwag — plus a `tools/OpenApiClientGenerator` console tool that runs the whole NSwag regeneration pipeline headlessly and deterministically (operations are sorted by route + verb, so unchanged APIs regenerate byte-identical clients).
-
-For configuration details and client generation steps, see the [OpenApi documentation](../reference/modules/OpenApi/README.md).
-
 ## Change Logs
 
 ### Content Fields Module
 
 The `TextField` settings now expose optional **Minimum length** and **Maximum length** values. When set to a value greater than `0`, the field's content is validated on save, and the corresponding `minlength`/`maxlength` attributes are rendered on the standard and `TextArea` editors. An empty value (the default) means no limit, so existing content types are unaffected.
+
+### Media Gallery and Media API
+
+The Media Library admin UI has been rewritten as a **Vue 3 Media Gallery** application, replacing the previous media application. It provides file operations (upload, rename, move, copy, delete, download), folder management with drag-and-drop, search, sorting, pagination, and a storage-information panel.
+
+The gallery is backed by a new **Media API** — minimal-API endpoints under `api/media` — with a selectable authentication scheme (`MediaApiSettings.AuthenticationScheme`):
+
+- **Cookie** (default): the ambient same-origin admin cookie, with antiforgery validation on mutating requests. Works out of the box.
+- **Bearer**: OAuth2 authorization-code + PKCE tokens acquired silently by the gallery (hidden iframe against the tenant's OpenID Connect server) and attached to API calls, uploads, and the SignalR connection. Provisioned by the **`MediaApiPkce` recipe**, which registers a public `media_gallery` client. Additional recipes (`MediaApiStandalone`, plus a localhost-dev variant) configure running the gallery as a standalone external app on its own origin, with interactive login and CORS.
+
+Supporting features:
+
+- **`OrchardCore.Media.Tus`** — resumable uploads via the [TUS protocol](https://tus.io/): chunked, pausable, and recoverable after network interruptions.
+- **`OrchardCore.Media.SignalR`** (with `.Azure` and `.Redis` backplane sub-features) — real-time media updates broadcast to all connected clients, keeping the gallery in sync across tabs, users, and instances.
+
+See the [Media Gallery documentation](../reference/modules/Media/MediaGallery.md) for details, including multi-instance deployment guidance.
 
 ### `OrchardCore.Users` Module
 
@@ -106,7 +108,7 @@ See the [Azure Media documentation](../reference/modules/Media.Azure/README.md) 
 
 ### API Error Responses
 
-Error responses that opt out of the HTML error pages — the 401 and 403 responses produced by the shared `Api` authentication scheme, and the responses of endpoints marked with `[SkipStatusCodePages]` — now carry an RFC 9457 Problem Details body (`application/problem+json`), so headless clients get a parseable payload instead of an empty one. Responses that don't opt out are still handled by the status code pages middleware the `OrchardCore.Diagnostics` feature registers.
+Error responses that opt out of the HTML error pages — the 401 and 403 responses produced by the shared `Api` authentication scheme, and the responses of endpoints marked with `[SkipStatusCodePages]` — now carry an RFC 9457 Problem Details body (`application/problem+json`), so headless clients get a parseable payload instead of an empty one. Responses that don't opt out are still handled by the status code pages middleware that the `OrchardCore.Diagnostics` feature registers.
 
 Status codes and headers are left untouched: the `WWW-Authenticate` header of a challenge remains the responsibility of the authentication handler that issued it (e.g. the OpenID Token Validation feature, which emits the RFC 6750 header carrying the OAuth 2.0 error details). The body is written through `IProblemDetailsService`, so an application registering its own Problem Details customizations sees them applied to these responses too.
 


### PR DESCRIPTION
Updated the release notes for version 4.0.0 to address a few minor issues.

@MikeAlhayek, you recently moved the entire Media Gallery change into the `Breaking Changes` section. I think the previous approach of splitting the changes into breaking and non-breaking categories was clearer and easier to follow.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
