### PR TITLE
Add implicitly enabled feature support

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -8,7 +8,7 @@ using OrchardCore.Modules.Manifest;
 )]
 
 [assembly: Feature(
-    Id = "OrchardCore.Media.Implicit",
+    Id = "OrchardCore.Media.Core",
     Name = "Media Implicit",
     Description = "Provides core media services.",
     Category = "Media",

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -9,7 +9,7 @@ using OrchardCore.Modules.Manifest;
 
 [assembly: Feature(
     Id = "OrchardCore.Media.Core",
-    Name = "Media Implicit",
+    Name = "Media Core",
     Description = "Provides core media services.",
     Category = "Media",
     IsImplicitlyEnabled = true

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -10,7 +10,7 @@ using OrchardCore.Modules.Manifest;
 [assembly: Feature(
     Id = "OrchardCore.Media.Implicit",
     Name = "Media Implicit",
-    Description = "This feature is implicitly enabled and required for the media module to function correctly.",
+    Description = "Provides core media services.",
     Category = "Media",
     IsImplicitlyEnabled = true
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -8,12 +8,20 @@ using OrchardCore.Modules.Manifest;
 )]
 
 [assembly: Feature(
+    Id = "OrchardCore.Media.Implicit",
+    Name = "Media Implicit",
+    Description = "This feature is implicitly enabled and required for the media module to function correctly.",
+    Category = "Media",
+    IsImplicitlyEnabled = true
+)]
+
+[assembly: Feature(
     Id = "OrchardCore.Media",
     Name = "Media",
     Description = "The media module adds media management support.",
     Dependencies =
     [
-        "OrchardCore.ContentTypes"
+        "OrchardCore.ContentTypes",
     ],
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -409,7 +409,7 @@ public sealed class SecureMediaStartup : StartupBase
 }
 
 // This startup is required to ensure that the SecureMediaFeatureEventHandler is registered all the time.
-[RequireFeatures("Application.Default")]
+[Feature("OrchardCore.Media.Implicit")]
 public sealed class FeatureEventHandlerStartup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -409,7 +409,7 @@ public sealed class SecureMediaStartup : StartupBase
 }
 
 // This startup is required to ensure that the SecureMediaFeatureEventHandler is registered all the time.
-[Feature("OrchardCore.Media.Implicit")]
+[Feature("OrchardCore.Media.Core")]
 public sealed class FeatureEventHandlerStartup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
@@ -42,6 +42,7 @@ public class FeatureBuildingContext
 
     public bool DefaultTenantOnly { get; set; }
     public bool IsAlwaysEnabled { get; set; }
+    public bool IsImplicitlyEnabled { get; set; }
     public bool EnabledByDependencyOnly { get; set; }
 }
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
@@ -13,5 +13,6 @@ public interface IFeatureInfo
     string[] After { get; }
     string[] Dependencies { get; }
     bool IsAlwaysEnabled { get; }
+    bool IsImplicitlyEnabled { get; }
     bool EnabledByDependencyOnly { get; }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
@@ -256,6 +256,11 @@ public class FeatureAttribute : Attribute
     public virtual bool IsAlwaysEnabled { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the feature is implicitly enabled for every valid tenant.
+    /// </summary>
+    public virtual bool IsImplicitlyEnabled { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the feature can only be enabled as a dependency of another feature.
     /// </summary>
     public virtual bool EnabledByDependencyOnly { get; set; }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Events/ThemeFeaturesProvider.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Events/ThemeFeaturesProvider.cs
@@ -53,6 +53,7 @@ public sealed class ThemeFeaturesProvider : FeaturesProviderBase
             FeatureAfterDependencyIds = moduleInfo.After,
             DefaultTenantOnly = moduleInfo.DefaultTenantOnly,
             IsAlwaysEnabled = moduleInfo.IsAlwaysEnabled,
+            IsImplicitlyEnabled = moduleInfo.IsImplicitlyEnabled,
             EnabledByDependencyOnly = moduleInfo.EnabledByDependencyOnly,
         };
 
@@ -68,6 +69,7 @@ public sealed class ThemeFeaturesProvider : FeaturesProviderBase
             ctx.FeatureAfterDependencyIds,
             ctx.DefaultTenantOnly,
             ctx.IsAlwaysEnabled,
+            ctx.IsImplicitlyEnabled,
             ctx.EnabledByDependencyOnly));
 
         return [mainFeatureInfo];
@@ -87,6 +89,7 @@ public sealed class ThemeFeaturesProvider : FeaturesProviderBase
             string[] after,
             bool defaultTenantOnly,
             bool isAlwaysEnabled,
+            bool isImplicitlyEnabled,
             bool enabledByDependencyOnly)
         {
             Id = id;
@@ -100,6 +103,7 @@ public sealed class ThemeFeaturesProvider : FeaturesProviderBase
             After = after ?? [];
             DefaultTenantOnly = defaultTenantOnly;
             IsAlwaysEnabled = isAlwaysEnabled;
+            IsImplicitlyEnabled = isImplicitlyEnabled;
             EnabledByDependencyOnly = enabledByDependencyOnly;
         }
 
@@ -114,6 +118,7 @@ public sealed class ThemeFeaturesProvider : FeaturesProviderBase
         public string[] Before { get; }
         public string[] After { get; }
         public bool IsAlwaysEnabled { get; }
+        public bool IsImplicitlyEnabled { get; }
         public bool EnabledByDependencyOnly { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
@@ -71,7 +71,8 @@ public class ShellDescriptorManager : IShellDescriptorManager
         var configuredFeatures = new ConfiguredFeatures();
         _shellConfiguration.Bind(configuredFeatures);
 
-        var features = _alwaysEnabledFeatures
+        var features = GetImplicitlyEnabledShellFeatures()
+            .Concat(_alwaysEnabledFeatures)
             .Concat(configuredFeatures.Features.Select(id => new ShellFeature(id) { AlwaysEnabled = true }))
             .Concat(shellDescriptor.Features)
             .Distinct();
@@ -106,7 +107,10 @@ public class ShellDescriptorManager : IShellDescriptorManager
 
         shellDescriptor.SerialNumber++;
 
-        shellDescriptor.Features = _alwaysEnabledFeatures.Union(enabledFeatures).ToList();
+        shellDescriptor.Features = GetImplicitlyEnabledShellFeatures()
+            .Union(_alwaysEnabledFeatures)
+            .Union(enabledFeatures)
+            .ToList();
         foreach (var feature in shellDescriptor.Features)
         {
             if (shellDescriptor.Installed.Contains(feature))
@@ -134,6 +138,14 @@ public class ShellDescriptorManager : IShellDescriptorManager
         // So, we commit the session earlier to prevent a new shell from being built from an outdated descriptor.
         await _shellDescriptorManagerEventHandlers.InvokeAsync((handler, shellDescriptor, _shellSettings) =>
             handler.ChangedAsync(shellDescriptor, _shellSettings), shellDescriptor, _shellSettings, _logger);
+    }
+
+    private IEnumerable<ShellFeature> GetImplicitlyEnabledShellFeatures()
+    {
+        return _extensionManager
+            .GetFeatures()
+            .Where(feature => feature.IsImplicitlyEnabled)
+            .Select(feature => new ShellFeature(feature.Id, alwaysEnabled: true));
     }
 
     private sealed class ConfiguredFeatures

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
@@ -30,10 +30,38 @@ public class FeatureInfo : IFeatureInfo
             description,
             extension,
             dependencies,
+            defaultTenantOnly,
+            isAlwaysEnabled,
+            isImplicitlyEnabled: false,
+            enabledByDependencyOnly)
+    {
+    }
+
+    public FeatureInfo(
+        string id,
+        string name,
+        int priority,
+        string category,
+        string description,
+        IExtensionInfo extension,
+        string[] dependencies,
+        bool defaultTenantOnly,
+        bool isAlwaysEnabled,
+        bool isImplicitlyEnabled,
+        bool enabledByDependencyOnly)
+        : this(
+            id,
+            name,
+            priority,
+            category,
+            description,
+            extension,
+            dependencies,
             [],
             [],
             defaultTenantOnly,
             isAlwaysEnabled,
+            isImplicitlyEnabled,
             enabledByDependencyOnly)
     {
     }
@@ -50,6 +78,7 @@ public class FeatureInfo : IFeatureInfo
         string[] after,
         bool defaultTenantOnly,
         bool isAlwaysEnabled,
+        bool isImplicitlyEnabled,
         bool enabledByDependencyOnly)
     {
         Id = id;
@@ -63,6 +92,7 @@ public class FeatureInfo : IFeatureInfo
         After = after ?? [];
         DefaultTenantOnly = defaultTenantOnly;
         IsAlwaysEnabled = isAlwaysEnabled;
+        IsImplicitlyEnabled = isImplicitlyEnabled;
         EnabledByDependencyOnly = enabledByDependencyOnly;
     }
 
@@ -77,5 +107,6 @@ public class FeatureInfo : IFeatureInfo
     public string[] Before { get; }
     public string[] After { get; }
     public bool IsAlwaysEnabled { get; }
+    public bool IsImplicitlyEnabled { get; }
     public bool EnabledByDependencyOnly { get; }
 }

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
@@ -44,6 +44,7 @@ public sealed class FeaturesProvider : FeaturesProviderBase
                 var featureDescription = feature.Describe(manifestInfo.ModuleInfo);
                 var featureDefaultTenantOnly = feature.DefaultTenantOnly;
                 var featureIsAlwaysEnabled = feature.IsAlwaysEnabled;
+                var featureIsImplicitlyEnabled = feature.IsImplicitlyEnabled;
                 var featureEnabledByDependencyOnly = feature.EnabledByDependencyOnly;
 
                 var context = new FeatureBuildingContext
@@ -60,6 +61,7 @@ public sealed class FeaturesProvider : FeaturesProviderBase
                     FeatureAfterDependencyIds = featureAfterDependencyIds,
                     DefaultTenantOnly = featureDefaultTenantOnly,
                     IsAlwaysEnabled = featureIsAlwaysEnabled,
+                    IsImplicitlyEnabled = featureIsImplicitlyEnabled,
                     EnabledByDependencyOnly = featureEnabledByDependencyOnly,
                 };
 
@@ -75,6 +77,7 @@ public sealed class FeaturesProvider : FeaturesProviderBase
                     ctx.FeatureAfterDependencyIds,
                     ctx.DefaultTenantOnly,
                     ctx.IsAlwaysEnabled,
+                    ctx.IsImplicitlyEnabled,
                     ctx.EnabledByDependencyOnly));
 
                 featuresInfos.Add(featureInfo);
@@ -96,6 +99,7 @@ public sealed class FeaturesProvider : FeaturesProviderBase
             var featureDescription = manifestInfo.ModuleInfo.Describe();
             var featureDefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly;
             var featureIsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled;
+            var featureIsImplicitlyEnabled = manifestInfo.ModuleInfo.IsImplicitlyEnabled;
             var featureEnabledByDependencyOnly = manifestInfo.ModuleInfo.EnabledByDependencyOnly;
 
             var context = new FeatureBuildingContext
@@ -112,6 +116,7 @@ public sealed class FeaturesProvider : FeaturesProviderBase
                 FeatureAfterDependencyIds = featureAfterDependencyIds,
                 DefaultTenantOnly = featureDefaultTenantOnly,
                 IsAlwaysEnabled = featureIsAlwaysEnabled,
+                IsImplicitlyEnabled = featureIsImplicitlyEnabled,
                 EnabledByDependencyOnly = featureEnabledByDependencyOnly,
             };
 
@@ -127,6 +132,7 @@ public sealed class FeaturesProvider : FeaturesProviderBase
                 ctx.FeatureAfterDependencyIds,
                 ctx.DefaultTenantOnly,
                 ctx.IsAlwaysEnabled,
+                ctx.IsImplicitlyEnabled,
                 ctx.EnabledByDependencyOnly));
 
             featuresInfos.Add(featureInfo);

--- a/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/AllFeaturesShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/AllFeaturesShellDescriptorManager.cs
@@ -21,7 +21,10 @@ public class AllFeaturesShellDescriptorManager : IShellDescriptorManager
     {
         _shellDescriptor ??= new ShellDescriptor
         {
-            Features = _extensionManager.GetFeatures().Select(x => new ShellFeature { Id = x.Id }).ToList(),
+            Features = _extensionManager
+                .GetFeatures()
+                .Select(feature => new ShellFeature(feature.Id, alwaysEnabled: feature.IsImplicitlyEnabled))
+                .ToList(),
         };
 
         return Task.FromResult(_shellDescriptor);

--- a/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
@@ -33,7 +33,8 @@ public class ConfiguredFeaturesShellDescriptorManager : IShellDescriptorManager
             var configuredFeatures = new ConfiguredFeatures();
             _shellConfiguration.Bind(configuredFeatures);
 
-            var features = _alwaysEnabledFeatures
+            var features = GetImplicitlyEnabledShellFeatures()
+                .Concat(_alwaysEnabledFeatures)
                 .Concat(configuredFeatures.Features.Select(id => new ShellFeature(id) { AlwaysEnabled = true }))
                 .Distinct();
 
@@ -58,6 +59,14 @@ public class ConfiguredFeaturesShellDescriptorManager : IShellDescriptorManager
     public Task UpdateShellDescriptorAsync(int priorSerialNumber, IEnumerable<ShellFeature> enabledFeatures)
     {
         return Task.CompletedTask;
+    }
+
+    private IEnumerable<ShellFeature> GetImplicitlyEnabledShellFeatures()
+    {
+        return _extensionManager
+            .GetFeatures()
+            .Where(feature => feature.IsImplicitlyEnabled)
+            .Select(feature => new ShellFeature(feature.Id, alwaysEnabled: true));
     }
 
     private sealed class ConfiguredFeatures

--- a/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/SetFeaturesShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/SetFeaturesShellDescriptorManager.cs
@@ -24,7 +24,11 @@ public class SetFeaturesShellDescriptorManager : IShellDescriptorManager
     {
         if (_shellDescriptor == null)
         {
-            var featureIds = _shellFeatures.Distinct().Select(sf => sf.Id);
+            var features = GetImplicitlyEnabledShellFeatures()
+                .Concat(_shellFeatures)
+                .Distinct()
+                .ToArray();
+            var featureIds = features.Select(sf => sf.Id);
 
             var missingDependencies = (await _extensionManager.LoadFeaturesAsync(featureIds))
                 .Select(entry => entry.Id)
@@ -33,7 +37,7 @@ public class SetFeaturesShellDescriptorManager : IShellDescriptorManager
 
             _shellDescriptor = new ShellDescriptor
             {
-                Features = _shellFeatures
+                Features = features
                     .Concat(missingDependencies)
                     .ToList(),
             };
@@ -45,5 +49,13 @@ public class SetFeaturesShellDescriptorManager : IShellDescriptorManager
     public Task UpdateShellDescriptorAsync(int priorSerialNumber, IEnumerable<ShellFeature> enabledFeatures)
     {
         return Task.CompletedTask;
+    }
+
+    private IEnumerable<ShellFeature> GetImplicitlyEnabledShellFeatures()
+    {
+        return _extensionManager
+            .GetFeatures()
+            .Where(feature => feature.IsImplicitlyEnabled)
+            .Select(feature => new ShellFeature(feature.Id, alwaysEnabled: true));
     }
 }

--- a/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
@@ -45,10 +45,15 @@ public class ShellDescriptorFeaturesManager : IShellDescriptorFeaturesManager
             .Concat(shellDescriptor.Installed.Select(shellFeature => shellFeature.Id))
             .ToHashSet();
 
-        var alwaysEnabledIds = _alwaysEnabledFeatures.Select(shellFeature => shellFeature.Id).ToArray();
+        var alwaysEnabledIds = shellDescriptor.Features
+            .Where(shellFeature => shellFeature.AlwaysEnabled)
+            .Select(shellFeature => shellFeature.Id)
+            .Concat(enabledFeatures.Where(feature => feature.IsImplicitlyEnabled).Select(feature => feature.Id))
+            .Concat(_alwaysEnabledFeatures.Select(shellFeature => shellFeature.Id))
+            .ToHashSet();
 
         var byDependencyOnlyFeaturesToDisable = enabledFeatures
-            .Where(feature => feature.EnabledByDependencyOnly);
+            .Where(feature => feature.EnabledByDependencyOnly && !alwaysEnabledIds.Contains(feature.Id));
 
         var allFeaturesToDisable = featuresToDisable
             .Where(feature => !feature.EnabledByDependencyOnly && !alwaysEnabledIds.Contains(feature.Id))

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -183,6 +183,18 @@ features now appear correctly with their category and Enable button in the Featu
 service, allowing subsystems such as `OrchardCore.DisplayManagement` to contribute their own feature providers without introducing theme-awareness into
 core (`OrchardCore.Extensions.ExtensionManager`).
 
+### Implicitly Enabled Features
+
+Manifest-defined features can now opt into implicit tenant activation with `IsImplicitlyEnabled = true` on `[Feature]`.
+
+When a feature is marked as implicitly enabled:
+
+- it is added automatically to the tenant's effective feature set during shell descriptor construction;
+- its startup runs as part of normal feature activation, even if the feature was not explicitly enabled by the tenant;
+- it is treated as non-disableable by feature management, including the automatic cleanup of dependency-only features.
+
+This is intended for small infrastructure features that must always participate in tenant startup or feature lifecycle observation without changing the semantics of `IsAlwaysEnabled`.
+
 ### File Upload Security
 
 Orchard Core now provides a file upload event pipeline for securing user-uploaded files before they are stored:

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
@@ -301,6 +301,7 @@ public abstract class FeatureAttributeTests<TAttribute>
         Assert.False(feature.Dependencies.Length > 0);
         Assert.False(feature.DefaultTenantOnly);
         Assert.False(feature.IsAlwaysEnabled);
+        Assert.False(feature.IsImplicitlyEnabled);
         Assert.False(feature.Exists);
         // Indeed the default-default Id is 'null' however in more of a context I think we would actually expect a value there
         Assert.Null(feature.Id);

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
@@ -69,6 +69,7 @@ public class FeatureAttributeTests : FeatureAttributeTests<FeatureAttribute>
 
         Assert.Equal(defaultTenant, feature.DefaultTenantOnly);
         Assert.Equal(alwaysEnabled, feature.IsAlwaysEnabled);
+        Assert.False(feature.IsImplicitlyEnabled);
     }
 
     /// <summary>
@@ -118,6 +119,7 @@ public class FeatureAttributeTests : FeatureAttributeTests<FeatureAttribute>
 
         Assert.Equal(defaultTenant, feature.DefaultTenantOnly);
         Assert.Equal(alwaysEnabled, feature.IsAlwaysEnabled);
+        Assert.False(feature.IsImplicitlyEnabled);
     }
 
     /// <summary>
@@ -172,6 +174,17 @@ public class FeatureAttributeTests : FeatureAttributeTests<FeatureAttribute>
 
         Assert.Equal(defaultTenant, feature.DefaultTenantOnly);
         Assert.Equal(alwaysEnabled, feature.IsAlwaysEnabled);
+        Assert.False(feature.IsImplicitlyEnabled);
+    }
+
+    [Fact]
+    public void ImplicitlyEnabled_PropertyInitializer_Succeeds()
+    {
+        var feature = CreateFromFactory();
+
+        feature.IsImplicitlyEnabled = true;
+
+        Assert.True(feature.IsImplicitlyEnabled);
     }
 
     // OrchardCore.Manifest.Features

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -213,6 +213,55 @@ public class ExtensionManagerTests
         Assert.Equal("BaseThemeSample", themeFeature.Id);
     }
 
+    [Fact]
+    public void GetFeatures_ExplicitFeature_PreservesImplicitEnablementFlag()
+    {
+        var module = new global::OrchardCore.Modules.Module("ModuleSample");
+        module.ModuleInfo.Features.Add(
+            new global::OrchardCore.Modules.Manifest.FeatureAttribute
+            {
+                Id = "SampleImplicit",
+                Name = "Implicit Sample Feature",
+                IsImplicitlyEnabled = true,
+            });
+
+        var applicationContext = new TestApplicationContext(new Application(s_hostingEnvironment, [module]));
+        var featureBuilderEvents = new[] { new ThemeFeatureBuilderEvents() };
+        var extensionManager = CreateExtensionManager(
+            applicationContext,
+            [new ExtensionDependencyStrategy()],
+            [new ExtensionPriorityStrategy()],
+            new TypeFeatureProvider(),
+            new FeaturesProvider(featureBuilderEvents));
+
+        var feature = Assert.Single(extensionManager.GetFeatures(), feature => feature.Id == "SampleImplicit");
+
+        Assert.True(feature.IsImplicitlyEnabled);
+    }
+
+    [Fact]
+    public void GetFeatures_ThemeWithAdditionalFeature_PreservesImplicitEnablementFlagOnSynthesizedThemeFeature()
+    {
+        var themeModule = new global::OrchardCore.Modules.Module("BaseThemeSample");
+        themeModule.ModuleInfo.IsImplicitlyEnabled = true;
+        themeModule.ModuleInfo.Features.Add(
+            new global::OrchardCore.Modules.Manifest.FeatureAttribute { Id = "BaseThemeSample.Additional" });
+
+        var applicationContext = new TestApplicationContext(new Application(s_hostingEnvironment, [themeModule]));
+        var featureBuilderEvents = new[] { new ThemeFeatureBuilderEvents() };
+        var extensionManager = CreateExtensionManager(
+            applicationContext,
+            [new ExtensionDependencyStrategy(), new ThemeExtensionDependencyStrategy()],
+            [new ExtensionPriorityStrategy()],
+            new TypeFeatureProvider(),
+            new FeaturesProvider(featureBuilderEvents),
+            new ThemeFeaturesProvider(featureBuilderEvents));
+
+        var themeFeature = Assert.Single(extensionManager.GetFeatures(), feature => feature.Extension.Id == "BaseThemeSample" && feature.IsTheme());
+
+        Assert.True(themeFeature.IsImplicitlyEnabled);
+    }
+
     /* Theme and Module Dependencies */
 
     [Fact]

--- a/test/OrchardCore.Tests/Shell/ImplicitFeatureShellBehaviorTests.cs
+++ b/test/OrchardCore.Tests/Shell/ImplicitFeatureShellBehaviorTests.cs
@@ -1,0 +1,250 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OrchardCore.Data.Documents;
+using OrchardCore.Environment.Extensions;
+using OrchardCore.Environment.Extensions.Features;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Builders;
+using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Environment.Shell.Data.Descriptors;
+using OrchardCore.Environment.Shell.Descriptor;
+using OrchardCore.Environment.Shell.Descriptor.Models;
+using OrchardCore.Environment.Shell.Descriptor.Settings;
+using OrchardCore.Environment.Shell.Scope;
+
+namespace OrchardCore.Tests.Shell;
+
+public class ImplicitFeatureShellBehaviorTests
+{
+    [Fact]
+    public async Task ConfiguredFeaturesShellDescriptorManager_IncludesImplicitlyEnabledFeatures()
+    {
+        var implicitFeature = CreateFeatureInfo("Implicit.Feature", isImplicitlyEnabled: true);
+        var extensionManager = CreateExtensionManager([implicitFeature], [implicitFeature]);
+        var manager = new ConfiguredFeaturesShellDescriptorManager(
+            CreateShellConfiguration(),
+            [],
+            extensionManager.Object);
+
+        var descriptor = await manager.GetShellDescriptorAsync();
+
+        Assert.Contains(descriptor.Features, feature => feature.Id == "Implicit.Feature" && feature.AlwaysEnabled);
+    }
+
+    [Fact]
+    public async Task SetFeaturesShellDescriptorManager_IncludesImplicitlyEnabledFeatures()
+    {
+        var implicitFeature = CreateFeatureInfo("Implicit.Feature", isImplicitlyEnabled: true);
+        var explicitFeature = CreateFeatureInfo("Explicit.Feature");
+        var extensionManager = CreateExtensionManager([implicitFeature, explicitFeature], [implicitFeature, explicitFeature]);
+        var manager = new SetFeaturesShellDescriptorManager(
+            [new ShellFeature("Explicit.Feature")],
+            extensionManager.Object);
+
+        var descriptor = await manager.GetShellDescriptorAsync();
+
+        Assert.Contains(descriptor.Features, feature => feature.Id == "Implicit.Feature" && feature.AlwaysEnabled);
+        Assert.Contains(descriptor.Features, feature => feature.Id == "Explicit.Feature");
+    }
+
+    [Fact]
+    public async Task AllFeaturesShellDescriptorManager_MarksImplicitlyEnabledFeaturesAsAlwaysEnabled()
+    {
+        var implicitFeature = CreateFeatureInfo("Implicit.Feature", isImplicitlyEnabled: true);
+        var explicitFeature = CreateFeatureInfo("Explicit.Feature");
+        var extensionManager = CreateExtensionManager([implicitFeature, explicitFeature], [implicitFeature, explicitFeature]);
+        var manager = new AllFeaturesShellDescriptorManager(extensionManager.Object);
+
+        var descriptor = await manager.GetShellDescriptorAsync();
+
+        Assert.Contains(descriptor.Features, feature => feature.Id == "Implicit.Feature" && feature.AlwaysEnabled);
+        Assert.Contains(descriptor.Features, feature => feature.Id == "Explicit.Feature" && !feature.AlwaysEnabled);
+    }
+
+    [Fact]
+    public async Task ShellDescriptorManager_GetShellDescriptorAsync_IncludesImplicitlyEnabledFeatures()
+    {
+        var persistedDescriptor = new ShellDescriptor
+        {
+            SerialNumber = 1,
+            Features = [new ShellFeature("Explicit.Feature")],
+        };
+        var implicitFeature = CreateFeatureInfo("Implicit.Feature", isImplicitlyEnabled: true);
+        var explicitFeature = CreateFeatureInfo("Explicit.Feature");
+        var extensionManager = CreateExtensionManager(
+            [implicitFeature, explicitFeature],
+            [implicitFeature, explicitFeature]);
+        var documentStore = new Mock<IDocumentStore>();
+        documentStore
+            .Setup(store => store.GetOrCreateImmutableAsync<ShellDescriptor>(It.IsAny<Func<Task<ShellDescriptor>>>() ))
+            .ReturnsAsync((true, persistedDescriptor));
+        var manager = new ShellDescriptorManager(
+            new ShellSettings { Name = "Test" },
+            CreateShellConfiguration(),
+            [],
+            [],
+            extensionManager.Object,
+            documentStore.Object,
+            NullLogger<ShellDescriptorManager>.Instance);
+
+        var descriptor = await manager.GetShellDescriptorAsync();
+
+        Assert.Contains(descriptor.Features, feature => feature.Id == "Implicit.Feature" && feature.AlwaysEnabled);
+        Assert.Contains(descriptor.Features, feature => feature.Id == "Explicit.Feature");
+    }
+
+    [Fact]
+    public async Task ShellDescriptorManager_UpdateShellDescriptorAsync_PersistsImplicitlyEnabledFeaturesAsAlwaysEnabled()
+    {
+        var mutableDescriptor = new ShellDescriptor
+        {
+            SerialNumber = 1,
+            Features = [],
+            Installed = [],
+        };
+        var implicitFeature = CreateFeatureInfo("Implicit.Feature", isImplicitlyEnabled: true);
+        var explicitFeature = CreateFeatureInfo("Explicit.Feature");
+        var extensionManager = CreateExtensionManager([implicitFeature, explicitFeature], [implicitFeature, explicitFeature]);
+        var documentStore = new Mock<IDocumentStore>();
+        documentStore
+            .Setup(store => store.GetOrCreateMutableAsync<ShellDescriptor>(It.IsAny<Func<Task<ShellDescriptor>>>() ))
+            .ReturnsAsync(mutableDescriptor);
+        documentStore
+            .Setup(store => store.UpdateAsync(It.IsAny<ShellDescriptor>(), It.IsAny<Func<ShellDescriptor, Task>>(), It.IsAny<bool>()))
+            .Returns(Task.CompletedTask);
+        documentStore
+            .Setup(store => store.CommitAsync())
+            .Returns(Task.CompletedTask);
+        var manager = new ShellDescriptorManager(
+            new ShellSettings { Name = "Test" },
+            CreateShellConfiguration(),
+            [],
+            [],
+            extensionManager.Object,
+            documentStore.Object,
+            NullLogger<ShellDescriptorManager>.Instance);
+
+        await manager.UpdateShellDescriptorAsync(1, [new ShellFeature("Explicit.Feature")]);
+
+        Assert.Contains(mutableDescriptor.Features, feature => feature.Id == "Implicit.Feature" && feature.AlwaysEnabled);
+        Assert.Contains(mutableDescriptor.Features, feature => feature.Id == "Explicit.Feature");
+        Assert.Contains(mutableDescriptor.Installed, feature => feature.Id == "Implicit.Feature" && feature.AlwaysEnabled);
+    }
+
+    [Fact]
+    public async Task ShellDescriptorFeaturesManager_UpdateFeaturesAsync_DoesNotDisableImplicitlyEnabledFeature()
+    {
+        var implicitFeature = CreateFeatureInfo("Implicit.Feature", isImplicitlyEnabled: true);
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(manager => manager.GetFeatures()).Returns([implicitFeature]);
+        var descriptorManager = new Mock<IShellDescriptorManager>(MockBehavior.Strict);
+        var manager = new ShellDescriptorFeaturesManager(
+            extensionManager.Object,
+            [],
+            descriptorManager.Object,
+            NullLogger<ShellFeaturesManager>.Instance);
+        var shellDescriptor = new ShellDescriptor
+        {
+            SerialNumber = 1,
+            Features = [new ShellFeature("Implicit.Feature", alwaysEnabled: true)],
+            Installed = [new InstalledShellFeature(new ShellFeature("Implicit.Feature", alwaysEnabled: true))],
+        };
+
+        await RunInShellScopeAsync(async () =>
+        {
+            var (disabledFeatures, enabledFeatures) = await manager.UpdateFeaturesAsync(shellDescriptor, [implicitFeature], [], force: false);
+
+            Assert.Empty(disabledFeatures);
+            Assert.Empty(enabledFeatures);
+        });
+
+        descriptorManager.Verify(
+            descriptor => descriptor.UpdateShellDescriptorAsync(It.IsAny<int>(), It.IsAny<IEnumerable<ShellFeature>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ShellDescriptorFeaturesManager_UpdateFeaturesAsync_DoesNotAutoDisableImplicitDependencyOnlyFeature()
+    {
+        var implicitFeature = CreateFeatureInfo(
+            "Implicit.Feature",
+            isImplicitlyEnabled: true,
+            enabledByDependencyOnly: true);
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(manager => manager.GetFeatures()).Returns([implicitFeature]);
+        var descriptorManager = new Mock<IShellDescriptorManager>(MockBehavior.Strict);
+        var manager = new ShellDescriptorFeaturesManager(
+            extensionManager.Object,
+            [],
+            descriptorManager.Object,
+            NullLogger<ShellFeaturesManager>.Instance);
+        var shellDescriptor = new ShellDescriptor
+        {
+            SerialNumber = 1,
+            Features = [new ShellFeature("Implicit.Feature", alwaysEnabled: true)],
+            Installed = [new InstalledShellFeature(new ShellFeature("Implicit.Feature", alwaysEnabled: true))],
+        };
+
+        await RunInShellScopeAsync(async () =>
+        {
+            var (disabledFeatures, enabledFeatures) = await manager.UpdateFeaturesAsync(shellDescriptor, [], [], force: false);
+
+            Assert.Empty(disabledFeatures);
+            Assert.Empty(enabledFeatures);
+        });
+
+        descriptorManager.Verify(
+            descriptor => descriptor.UpdateShellDescriptorAsync(It.IsAny<int>(), It.IsAny<IEnumerable<ShellFeature>>()),
+            Times.Never);
+    }
+
+    private static Mock<IExtensionManager> CreateExtensionManager(
+        IEnumerable<IFeatureInfo> discoveredFeatures,
+        IEnumerable<IFeatureInfo> loadedFeatures)
+    {
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(manager => manager.GetFeatures()).Returns(discoveredFeatures);
+        extensionManager.Setup(manager => manager.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync(loadedFeatures);
+
+        return extensionManager;
+    }
+
+    private static FeatureInfo CreateFeatureInfo(
+        string id,
+        bool isImplicitlyEnabled = false,
+        bool enabledByDependencyOnly = false)
+    {
+        return new FeatureInfo(
+            id,
+            id,
+            0,
+            "Test",
+            string.Empty,
+            new ExtensionInfo("TestExtension"),
+            [],
+            defaultTenantOnly: false,
+            isAlwaysEnabled: false,
+            isImplicitlyEnabled,
+            enabledByDependencyOnly);
+    }
+
+    private static ShellConfiguration CreateShellConfiguration()
+    {
+        return new ShellConfiguration(new ConfigurationBuilder().Build());
+    }
+
+    private static async Task RunInShellScopeAsync(Func<Task> execute)
+    {
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var shellContext = new ShellContext
+        {
+            ServiceProvider = serviceProvider,
+            Settings = new ShellSettings { Name = "Test" },
+        };
+
+        var shellScope = new ShellScope(shellContext);
+        await shellScope.UsingServiceScopeAsync(_ => execute());
+    }
+}


### PR DESCRIPTION
## Summary
- add IsImplicitlyEnabled feature metadata and propagate it through feature discovery
- auto-include implicitly enabled features in shell descriptors and prevent them from being disabled
- mark OrchardCore.Media.Core as implicitly enabled, add unit tests, and document the change in the 4.0.0 release notes

## Validation
- dotnet build
- targeted unit tests for FeatureAttributeTests, ExtensionManagerTests, and ImplicitFeatureShellBehaviorTests