### PR TITLE
Imply root media access from folder permissions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/ViewMediaFolderAuthorizationHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/ViewMediaFolderAuthorizationHandler.cs
@@ -88,7 +88,7 @@ public sealed class ViewMediaFolderAuthorizationHandler : AuthorizationHandler<P
 
         if (IsAuthorizedFolder("/", path))
         {
-            await AuthorizeAsync(context, requirement, MediaPermissions.ViewRootMedia);
+            await AuthorizeAsync(context, requirement, await GetViewRootMediaPermissionAsync());
 
             return;
         }
@@ -119,6 +119,35 @@ public sealed class ViewMediaFolderAuthorizationHandler : AuthorizationHandler<P
             // Not a secure file
             context.Succeed(requirement);
         }
+    }
+
+    /// <summary>
+    /// Returns the <c>ViewRootMediaContent</c> permission as built by <see cref="SecureMediaPermissions"/>.
+    /// </summary>
+    /// <remarks>
+    /// The provider constructs its own instance whose <c>ImpliedBy</c> list carries every first-level
+    /// folder permission, so that holding <c>ViewMediaContent_Alpha</c> implies root access. The static
+    /// <see cref="MediaPermissions.ViewRootMedia"/> instance is implied only by the global
+    /// <c>ViewMediaContent</c>, so authorizing against it makes a role with folder-scoped grants fail at
+    /// the root while the role editor shows it as allowed. Ask the provider for the instance it published
+    /// rather than assuming the two agree.
+    /// </remarks>
+    private async Task<Permission> GetViewRootMediaPermissionAsync()
+    {
+        var provider = _serviceProvider.GetServices<IPermissionProvider>()
+            .OfType<SecureMediaPermissions>()
+            .FirstOrDefault();
+
+        if (provider is null)
+        {
+            return MediaPermissions.ViewRootMedia;
+        }
+
+        // Cached by the provider, so this does not re-enumerate the media folders on every check.
+        var permissions = await provider.GetPermissionsAsync();
+
+        return permissions.FirstOrDefault(permission => permission.Name == MediaPermissions.ViewRootMedia.Name)
+            ?? MediaPermissions.ViewRootMedia;
     }
 
     private async Task AuthorizeAttachedMediaFieldsFolderAsync(AuthorizationHandlerContext context, PermissionRequirement requirement, string path)

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/SecureMedia/ViewMediaFolderAuthorizationHandlerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/SecureMedia/ViewMediaFolderAuthorizationHandlerTests.cs
@@ -1,9 +1,12 @@
+using Microsoft.Extensions.Caching.Memory;
 using OrchardCore.ContentManagement;
+using OrchardCore.Environment.Cache;
 using OrchardCore.FileStorage;
 using OrchardCore.Media;
 using OrchardCore.Media.Services;
 using OrchardCore.Security;
 using OrchardCore.Security.AuthorizationHandlers;
+using OrchardCore.Security.Permissions;
 using OrchardCore.Tests.Security;
 
 namespace OrchardCore.Tests.Modules.OrchardCore.Media.SecureMedia;
@@ -377,7 +380,71 @@ public class ViewMediaFolderAuthorizationHandlerTests
         Assert.True(context.HasSucceeded);
     }
 
-    private static ViewMediaFolderAuthorizationHandler CreateHandler()
+    [Theory]
+    [InlineData("")]
+    [InlineData("/")]
+    [InlineData("filename.png")]
+    public async Task SecureFolderPermissionGrantsRootViewPermission(string resource)
+    {
+        // Arrange
+        var handler = CreateHandler(withSecureMediaPermissions: true);
+        var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(
+            MediaPermissions.ViewMedia,
+            ["ViewMediaContent_folder"],
+            authenticated: true,
+            resource);
+
+        // Act
+        await handler.HandleAsync(context);
+
+        // Assert
+        // The root must be viewable, otherwise the granted folder cannot be navigated to.
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Theory]
+    [InlineData("otherfolder")]
+    [InlineData("otherfolder/filename.png")]
+    [InlineData(UsersFolder)]
+    [InlineData(MediafieldsFolder)]
+    public async Task SecureFolderPermissionDoesNotGrantOtherFolders(string resource)
+    {
+        // Arrange
+        var handler = CreateHandler(withSecureMediaPermissions: true);
+        var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(
+            MediaPermissions.ViewMedia,
+            ["ViewMediaContent_folder"],
+            authenticated: true,
+            resource);
+
+        // Act
+        await handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("/")]
+    public async Task NoFolderPermissionDoesNotGrantRootViewPermission(string resource)
+    {
+        // Arrange
+        var handler = CreateHandler(withSecureMediaPermissions: true);
+        var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(
+            MediaPermissions.ViewMedia,
+            ["ViewOwnMediaContent"],
+            authenticated: true,
+            resource);
+
+        // Act
+        await handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+
+    private static ViewMediaFolderAuthorizationHandler CreateHandler(bool withSecureMediaPermissions = false)
     {
         var defaultHttpContext = new DefaultHttpContext();
         var httpContextAccessor = Mock.Of<IHttpContextAccessor>(hca => hca.HttpContext == defaultHttpContext);
@@ -472,6 +539,24 @@ public class ViewMediaFolderAuthorizationHandlerTests
 
         var services = new ServiceCollection();
         services.AddTransient(sp => mockAuthorizationService.Object);
+
+        if (withSecureMediaPermissions)
+        {
+            // The root level folders the dynamic 'ViewMediaContent_{folder}' permissions are created from.
+            mockMediaFileStore
+                .Setup(fs => fs.GetDirectoryContentAsync(It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(ToAsyncEnumerable(directoryMap.Keys
+                    .Where(path => !path.Contains('/'))
+                    .Select(path => Mock.Of<IFileStoreEntry>(e => e.Path == path && e.Name == path && e.IsDirectory))));
+
+            services.AddScoped<IPermissionProvider>(sp => new SecureMediaPermissions(
+                mockMediaOptions.Object,
+                mockMediaFileStore.Object,
+                new MemoryCache(new MemoryCacheOptions()),
+                attachedMediaFieldFileService,
+                new Signal()));
+        }
+
         var serviceProvider = services.BuildServiceProvider();
 
         return new ViewMediaFolderAuthorizationHandler(
@@ -483,6 +568,16 @@ public class ViewMediaFolderAuthorizationHandlerTests
             mockUserAssetFolderNameProvider.Object,
             mockContentManager.Object
         );
+    }
+
+    private static async IAsyncEnumerable<IFileStoreEntry> ToAsyncEnumerable(IEnumerable<IFileStoreEntry> entries)
+    {
+        foreach (var entry in entries)
+        {
+            yield return entry;
+        }
+
+        await Task.CompletedTask;
     }
 }
 


### PR DESCRIPTION
SecureMediaPermissions publishes a ViewRootMediaContent permission whose ImpliedBy list carries every first-level folder permission, so that holding ViewMediaContent_Alpha implies root access. ViewMediaFolderAuthorizationHandler authorized against the static MediaPermissions.ViewRootMedia instance instead, which carries no such implication, so a folder-scoped role was denied at the root — it could not open the Media library at all — while the role editor showed the access as granted.

The handler now asks the provider for the instance it published rather than assuming the two agree.

Fixes #19675.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
