### PR TITLE
Make permission templates distinct from permissions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Permissions.cs
@@ -5,10 +5,11 @@ namespace OrchardCore.AdminMenu;
 
 public sealed class Permissions : IPermissionProvider
 {
-    private static readonly Permission s_viewAdminMenu = new("ViewAdminMenu_{0}", "View Admin Menu - {0}", new[] {
+    private static readonly PermissionTemplate s_viewAdminMenu = new(
+        "ViewAdminMenu_{0}",
+        "View Admin Menu - {0}",
         AdminMenuPermissions.ManageAdminMenu,
-        AdminMenuPermissions.ViewAdminMenuAll,
-    });
+        AdminMenuPermissions.ViewAdminMenuAll);
 
     private readonly IEnumerable<Permission> _generalPermissions =
     [
@@ -60,10 +61,6 @@ public sealed class Permissions : IPermissionProvider
         },
     ];
 
-    public static Permission CreatePermissionForAdminMenu(string name)
-        => new(
-            string.Format(s_viewAdminMenu.Name, name),
-            string.Format(s_viewAdminMenu.Description, name),
-            s_viewAdminMenu.ImpliedBy
-        );
+    public static Permission CreatePermissionForAdminMenu(string name) =>
+        s_viewAdminMenu.CreateDynamicPermission(name);
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -99,7 +99,7 @@ public sealed class AdminMenu : AdminNavigationProvider
                         {
                             newMenu.Add(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName), "5", item => item
                                 .Action(cim.CreateRouteValues["Action"] as string, cim.CreateRouteValues["Controller"] as string, cim.CreateRouteValues)
-                                .Permission(ContentTypePermissionsHelper.CreateDynamicPermission(ContentTypePermissionsHelper.PermissionTemplates[CommonPermissions.EditOwnContent.Name], contentTypeDefinition))
+                                .Permission(ContentTypePermissionsHelper.CreateDynamicPermissionOf(CommonPermissions.EditOwnContent, contentTypeDefinition))
                                 );
                         }
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
@@ -62,7 +62,7 @@ public class ContentTypesAdminNodeNavigationBuilder : IAdminNodeNavigationBuilde
                 itemBuilder.Priority(node.Priority);
                 itemBuilder.Position(node.Position);
                 itemBuilder.Permission(
-                    ContentTypePermissionsHelper.CreateDynamicPermission(ContentTypePermissionsHelper.PermissionTemplates[CommonPermissions.ViewContent.Name], ctd));
+                    ContentTypePermissionsHelper.CreateDynamicPermissionOf(CommonPermissions.ViewContent, ctd));
 
                 GetIconClasses(ctd, node).ToList().ForEach(c => itemBuilder.AddClass(c));
             });

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Security/ContentTypeAuthorizationHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Security/ContentTypeAuthorizationHandler.cs
@@ -45,20 +45,17 @@ public sealed class ContentTypeAuthorizationHandler : AuthorizationHandler<Permi
             }
         }
 
-        var contentTypePermission = ContentTypePermissionsHelper.ConvertToDynamicPermission(permission ?? requirement.Permission);
+        // The resource can be a content type name
+        var contentType = contentItem != null
+            ? contentItem.ContentType
+            : context.Resource.ToString()
+            ;
 
-        if (contentTypePermission != null)
+        if (!string.IsNullOrEmpty(contentType) &&
+            (permission ?? requirement.Permission) is { } basePermission &&
+            ContentTypePermissionsHelper.CreateDynamicPermissionOf(basePermission.Name, contentType) is { } dynamicPermission)
         {
-            // The resource can be a content type name
-            var contentType = contentItem != null
-                ? contentItem.ContentType
-                : context.Resource.ToString()
-                ;
-
-            if (!string.IsNullOrEmpty(contentType))
-            {
-                permission = ContentTypePermissionsHelper.CreateDynamicPermission(contentTypePermission, contentType);
-            }
+            permission = dynamicPermission;
         }
 
         if (permission == null)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Security/ContentTypePermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Security/ContentTypePermissions.cs
@@ -23,9 +23,9 @@ public sealed class ContentTypePermissions : IPermissionProvider
 
         foreach (var typeDefinition in securableTypes)
         {
-            foreach (var permissionTemplate in ContentTypePermissionsHelper.PermissionTemplates.Values)
+            foreach (var templateNames in ContentTypePermissionsHelper.PermissionTemplates.Keys)
             {
-                result.Add(ContentTypePermissionsHelper.CreateDynamicPermission(permissionTemplate, typeDefinition));
+                result.Add(ContentTypePermissionsHelper.CreateDynamicPermissionOf(templateNames, typeDefinition));
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/Permissions.cs
@@ -6,7 +6,10 @@ namespace OrchardCore.CustomSettings;
 
 public sealed class Permissions : IPermissionProvider
 {
-    private static readonly Permission s_manageCustomSettings = new("ManageCustomSettings_{0}", "Manage Custom Settings - {0}", new[] { new Permission("ManageResourceSettings") });
+    private static readonly PermissionTemplate s_manageCustomSettings = new(
+        "ManageCustomSettings_{0}",
+        "Manage Custom Settings - {0}",
+        new Permission("ManageResourceSettings"));
 
     private readonly CustomSettingsService _customSettingsService;
 
@@ -31,13 +34,7 @@ public sealed class Permissions : IPermissionProvider
         => string.Format(s_manageCustomSettings.Name, name);
 
     public static Permission CreatePermissionForType(ContentTypeDefinition type)
-    {
-        return new Permission(
-                CreatePermissionName(type.Name),
-                string.Format(s_manageCustomSettings.Description, type.DisplayName),
-                s_manageCustomSettings.ImpliedBy
-            );
-    }
+        => s_manageCustomSettings.CreateDynamicPermission(type.Name, type.DisplayName);
 
     public IEnumerable<PermissionStereotype> GetDefaultStereotypes()
         => [];

--- a/src/OrchardCore.Modules/OrchardCore.Lists/AdminNodes/ListsAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/AdminNodes/ListsAdminNodeNavigationBuilder.cs
@@ -59,8 +59,8 @@ public class ListsAdminNodeNavigationBuilder : IAdminNodeNavigationBuilder
             await builder.AddAsync(new LocalizedString(_contentType.DisplayName, _contentType.DisplayName), async listTypeMenu =>
             {
                 AddPrefixToClasses(_node.IconForParentLink).ForEach(c => listTypeMenu.AddClass(c));
-                listTypeMenu.Permission(ContentTypePermissionsHelper.CreateDynamicPermission(
-                    ContentTypePermissionsHelper.PermissionTemplates[CommonPermissions.EditContent.Name], _contentType));
+                listTypeMenu.Permission(ContentTypePermissionsHelper.CreateDynamicPermissionOf(
+                    CommonPermissions.EditContent, _contentType));
                 await AddContentItemsAsync(listTypeMenu);
             });
         }
@@ -102,8 +102,8 @@ public class ListsAdminNodeNavigationBuilder : IAdminNodeNavigationBuilder
                     itemBuilder.LocalNav();
                     AddPrefixToClasses(_node.IconForContentItems).ToList().ForEach(c => itemBuilder.AddClass(c));
 
-                    itemBuilder.Permission(ContentTypePermissionsHelper.CreateDynamicPermission(
-                    ContentTypePermissionsHelper.PermissionTemplates[CommonPermissions.EditContent.Name], _contentType));
+                    itemBuilder.Permission(ContentTypePermissionsHelper.CreateDynamicPermissionOf(
+                        CommonPermissions.EditContent, _contentType));
                 });
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexPermissionHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexPermissionHelper.cs
@@ -10,7 +10,10 @@ public static class LuceneIndexPermissionHelper
     private const string PermissionNamePrefix = "QueryLucene";
     private const string PermissionNameSuffix = "Index";
 
-    private static readonly Permission s_indexPermissionTemplate = new("QueryLucene{0}Index", "Query Lucene {0} Index", new[] { LuceneSearchPermissions.ManageLuceneIndexes });
+    private static readonly PermissionTemplate s_indexPermissionTemplate = new(
+        "QueryLucene{0}Index",
+        "Query Lucene {0} Index", 
+        LuceneSearchPermissions.ManageLuceneIndexes);
 
     private static readonly ConcurrentDictionary<string, Permission> s_permissions = [];
 
@@ -24,10 +27,7 @@ public static class LuceneIndexPermissionHelper
             throw new ArgumentException($"{nameof(indexName)} cannot be null or empty");
         }
 
-        return s_permissions.GetOrAdd(indexName, indexName => new Permission(
-                string.Format(s_indexPermissionTemplate.Name, indexName),
-                string.Format(s_indexPermissionTemplate.Description, indexName),
-                s_indexPermissionTemplate.ImpliedBy));
+        return s_permissions.GetOrAdd(indexName, s_indexPermissionTemplate.CreateDynamicPermission);
     }
 
     internal static bool IsLuceneIndexPermissionClaim(RoleClaim claim) =>

--- a/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
@@ -101,43 +101,6 @@ public sealed class SecureMediaPermissions : IPermissionProvider
     }
 
     /// <summary>
-    /// Returns a dynamic permission for a secure folder, based on a global view media permission template.
-    /// </summary>
-    [Obsolete($"Use {nameof(CreateDynamicPermissionOf)} instead.")]
-    internal static Permission ConvertToDynamicPermission(Permission permission) =>
-        s_permissionTemplates.TryGetValue(permission.Name, out var result) ? result.CreateDynamicPermission("{0}") : null;
-
-    [Obsolete($"Use {nameof(CreateDynamicPermissionOf)} instead.")]
-    internal static Permission CreateDynamicPermission(Permission template, string secureFolder)
-    {
-        ArgumentNullException.ThrowIfNull(template);
-
-        secureFolder = secureFolder?.Trim(s_trimSecurePathChars);
-
-        var key = new ValueTuple<string, string>(template.Name, secureFolder);
-
-        if (s_permissionsByFolder.TryGetValue(key, out var permission))
-        {
-            return permission;
-        }
-
-        permission = new Permission(
-            string.Format(template.Name, secureFolder),
-            string.Format(template.Description, secureFolder),
-            (template.ImpliedBy ?? []).Select(t => CreateDynamicPermission(t, secureFolder))
-        );
-
-        var localPermissions = new Dictionary<ValueTuple<string, string>, Permission>(s_permissionsByFolder)
-        {
-            [key] = permission,
-        };
-
-        s_permissionsByFolder = localPermissions;
-
-        return permission;
-    }
-
-    /// <summary>
     /// Create a dynamic permission specific to the provided <paramref name="secureFolder"/> using internal templates,
     /// based on the permission identified by the <paramref name="basePermissionName"/>.
     /// </summary>

--- a/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
@@ -205,7 +205,7 @@ public sealed class SecureMediaPermissions : IPermissionProvider
 
             var folderPath = entry.Path;
 
-            foreach (var (templateName, _) in s_permissionTemplates)
+            foreach (var templateName in s_permissionTemplates.Keys)
             {
                 var dynamicPermission = CreateDynamicPermissionOf(templateName, folderPath);
                 result.Add(dynamicPermission);

--- a/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Media;
 
 public sealed class SecureMediaPermissions : IPermissionProvider
 {
-    private static readonly Permission s_viewMediaTemplate = new("ViewMediaContent_{0}", "View media content in folder '{0}'", new[] { MediaPermissions.ViewMedia });
+    private static readonly Permission s_viewMediaTemplate = new("ViewMediaContent_{0}", "View media content in folder '{0}'", [MediaPermissions.ViewMedia]);
 
     private static Dictionary<ValueTuple<string, string>, Permission> s_permissionsByFolder = new();
     private static readonly char[] s_trimSecurePathChars = ['/', '\\', ' '];
@@ -167,11 +167,6 @@ public sealed class SecureMediaPermissions : IPermissionProvider
         {
             return permissionByFolder;
         }
-
-        template = template with
-        {
-            ImpliedBy = template.ImpliedBy.Select(impliedBy => CreateDynamicPermissionOf(impliedBy.Name, secureFolder)),
-        };
 
         var permission = template.CreateDynamicPermission(secureFolder);
         var localPermissions = new Dictionary<ValueTuple<string, string>, Permission>(s_permissionsByFolder)

--- a/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
@@ -118,7 +118,7 @@ public sealed class SecureMediaPermissions : IPermissionProvider
         permission = new Permission(
             string.Format(template.Name, secureFolder),
             string.Format(template.Description, secureFolder),
-            (template.ImpliedBy ?? Array.Empty<Permission>()).Select(t => CreateDynamicPermission(t, secureFolder))
+            (template.ImpliedBy ?? []).Select(t => CreateDynamicPermission(t, secureFolder))
         );
 
         var localPermissions = new Dictionary<ValueTuple<string, string>, Permission>(s_permissionsByFolder)

--- a/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
@@ -100,8 +100,11 @@ public sealed class SecureMediaPermissions : IPermissionProvider
     /// <summary>
     /// Returns a dynamic permission for a secure folder, based on a global view media permission template.
     /// </summary>
-    internal static Permission ConvertToDynamicPermission(Permission permission) => s_permissionTemplates.TryGetValue(permission.Name, out var result) ? result : null;
+    [Obsolete($"Use {nameof(CreatePermissionTemplate)} instead.")]
+    internal static Permission ConvertToDynamicPermission(Permission permission) =>
+        s_permissionTemplates.TryGetValue(permission.Name, out var result) ? result : null;
 
+    [Obsolete($"Use {nameof(CreateDynamicPermissionOf)} instead.")]
     internal static Permission CreateDynamicPermission(Permission template, string secureFolder)
     {
         ArgumentNullException.ThrowIfNull(template);
@@ -128,6 +131,55 @@ public sealed class SecureMediaPermissions : IPermissionProvider
 
         s_permissionsByFolder = localPermissions;
 
+        return permission;
+    }
+
+    /// <summary>
+    /// Create a permission template based on the template identified by the <paramref name="basePermissionName"/>.
+    /// </summary>
+    internal static PermissionTemplate CreatePermissionTemplate(string basePermissionName) =>
+        s_permissionTemplates.TryGetValue(basePermissionName, out var result)
+            ? new PermissionTemplate(
+                result.Name,
+                result.Description,
+                Category: null,
+                result.ImpliedBy ?? [])
+            : null;
+
+    /// <summary>
+    /// Create a dynamic permission specific to the provided <paramref name="secureFolder"/> using internal templates,
+    /// based on the permission identified by the <paramref name="basePermissionName"/>.
+    /// </summary>
+    /// <param name="basePermissionName"></param>
+    /// <param name="secureFolder"></param>
+    /// <returns></returns>
+    internal static Permission CreateDynamicPermissionOf(string basePermissionName, string secureFolder)
+    {
+        if (CreatePermissionTemplate(basePermissionName) is not { } template)
+        {
+            return null;
+        }
+
+        secureFolder = secureFolder?.Trim(s_trimSecurePathChars);
+        var key = new ValueTuple<string, string>(template.Name, secureFolder);
+
+        if (s_permissionsByFolder.TryGetValue(key, out var permissionByFolder))
+        {
+            return permissionByFolder;
+        }
+
+        template = template with
+        {
+            ImpliedBy = template.ImpliedBy.Select(impliedBy => CreateDynamicPermissionOf(impliedBy.Name, secureFolder)),
+        };
+
+        var permission = template.CreateDynamicPermission(secureFolder);
+        var localPermissions = new Dictionary<ValueTuple<string, string>, Permission>(s_permissionsByFolder)
+        {
+            [key] = permission,
+        };
+
+        s_permissionsByFolder = localPermissions;
         return permission;
     }
 
@@ -158,9 +210,9 @@ public sealed class SecureMediaPermissions : IPermissionProvider
 
             var folderPath = entry.Path;
 
-            foreach (var template in s_permissionTemplates)
+            foreach (var (templateName, _) in s_permissionTemplates)
             {
-                var dynamicPermission = CreateDynamicPermission(template.Value, folderPath);
+                var dynamicPermission = CreateDynamicPermissionOf(templateName, folderPath);
                 result.Add(dynamicPermission);
                 viewRootImpliedBy.Add(dynamicPermission);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Cache;
@@ -9,14 +8,17 @@ namespace OrchardCore.Media;
 
 public sealed class SecureMediaPermissions : IPermissionProvider
 {
-    private static readonly Permission s_viewMediaTemplate = new("ViewMediaContent_{0}", "View media content in folder '{0}'", [MediaPermissions.ViewMedia]);
+    private static readonly PermissionTemplate s_viewMediaTemplate = new(
+        "ViewMediaContent_{0}",
+        "View media content in folder '{0}'",
+        MediaPermissions.ViewMedia);
 
     private static Dictionary<ValueTuple<string, string>, Permission> s_permissionsByFolder = new();
     private static readonly char[] s_trimSecurePathChars = ['/', '\\', ' '];
-    private static readonly ReadOnlyDictionary<string, Permission> s_permissionTemplates = new(new Dictionary<string, Permission>()
+    private static readonly IReadOnlyDictionary<string, PermissionTemplate> s_permissionTemplates = new Dictionary<string, PermissionTemplate>()
     {
-        { MediaPermissions.ViewMedia.Name, s_viewMediaTemplate },
-    });
+        [MediaPermissions.ViewMedia.Name] = s_viewMediaTemplate,
+    };
 
     private readonly MediaOptions _mediaOptions;
     private readonly AttachedMediaFieldFileService _attachedMediaFieldFileService;
@@ -100,9 +102,9 @@ public sealed class SecureMediaPermissions : IPermissionProvider
     /// <summary>
     /// Returns a dynamic permission for a secure folder, based on a global view media permission template.
     /// </summary>
-    [Obsolete($"Use {nameof(CreatePermissionTemplate)} instead.")]
+    [Obsolete($"Use {nameof(CreateDynamicPermissionOf)} instead.")]
     internal static Permission ConvertToDynamicPermission(Permission permission) =>
-        s_permissionTemplates.TryGetValue(permission.Name, out var result) ? result : null;
+        s_permissionTemplates.TryGetValue(permission.Name, out var result) ? result.CreateDynamicPermission("{0}") : null;
 
     [Obsolete($"Use {nameof(CreateDynamicPermissionOf)} instead.")]
     internal static Permission CreateDynamicPermission(Permission template, string secureFolder)
@@ -135,18 +137,6 @@ public sealed class SecureMediaPermissions : IPermissionProvider
     }
 
     /// <summary>
-    /// Create a permission template based on the template identified by the <paramref name="basePermissionName"/>.
-    /// </summary>
-    internal static PermissionTemplate CreatePermissionTemplate(string basePermissionName) =>
-        s_permissionTemplates.TryGetValue(basePermissionName, out var result)
-            ? new PermissionTemplate(
-                result.Name,
-                result.Description,
-                Category: null,
-                result.ImpliedBy ?? [])
-            : null;
-
-    /// <summary>
     /// Create a dynamic permission specific to the provided <paramref name="secureFolder"/> using internal templates,
     /// based on the permission identified by the <paramref name="basePermissionName"/>.
     /// </summary>
@@ -155,7 +145,7 @@ public sealed class SecureMediaPermissions : IPermissionProvider
     /// <returns></returns>
     internal static Permission CreateDynamicPermissionOf(string basePermissionName, string secureFolder)
     {
-        if (CreatePermissionTemplate(basePermissionName) is not { } template)
+        if (!s_permissionTemplates.TryGetValue(basePermissionName, out var template))
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/SecureMediaPermissions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Media.Services;
 using OrchardCore.Security.Permissions;
+using System.Collections.ObjectModel;
 
 namespace OrchardCore.Media;
 
@@ -15,10 +16,10 @@ public sealed class SecureMediaPermissions : IPermissionProvider
 
     private static Dictionary<ValueTuple<string, string>, Permission> s_permissionsByFolder = new();
     private static readonly char[] s_trimSecurePathChars = ['/', '\\', ' '];
-    private static readonly IReadOnlyDictionary<string, PermissionTemplate> s_permissionTemplates = new Dictionary<string, PermissionTemplate>()
+    private static readonly ReadOnlyDictionary<string, PermissionTemplate> s_permissionTemplates = new Dictionary<string, PermissionTemplate>()
     {
         [MediaPermissions.ViewMedia.Name] = s_viewMediaTemplate,
-    };
+    }.AsReadOnly();
 
     private readonly MediaOptions _mediaOptions;
     private readonly AttachedMediaFieldFileService _attachedMediaFieldFileService;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/ViewMediaFolderAuthorizationHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/ViewMediaFolderAuthorizationHandler.cs
@@ -108,11 +108,9 @@ public sealed class ViewMediaFolderAuthorizationHandler : AuthorizationHandler<P
         }
 
         // Create a dynamic permission for the folder path. This allows to give access to a specific folders only.
-        var template = SecureMediaPermissions.ConvertToDynamicPermission(MediaPermissions.ViewMedia);
-        if (template != null)
+        if (SecureMediaPermissions.CreateDynamicPermissionOf(MediaPermissions.ViewMedia.Name, folderPath) is { } dynamicPermission)
         {
-            var permission = SecureMediaPermissions.CreateDynamicPermission(template, folderPath);
-            await AuthorizeAsync(context, requirement, permission);
+            await AuthorizeAsync(context, requirement, dynamicPermission);
         }
         else
         {

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Permissions.cs
@@ -7,7 +7,11 @@ public sealed class Permissions : IPermissionProvider
     public static readonly Permission ManageQueries = new("ManageQueries", "Manage queries");
     public static readonly Permission ExecuteApiAll = new("ExecuteApiAll", "Execute Api - All queries", [ManageQueries]);
 
-    private static readonly Permission s_executeApi = new("ExecuteApi_{0}", "Execute Api - {0}", [ManageQueries, ExecuteApiAll]);
+    private static readonly PermissionTemplate s_executeApi = new(
+        "ExecuteApi_{0}",
+        "Execute Api - {0}", 
+        ManageQueries,
+        ExecuteApiAll);
 
     private readonly IQueryManager _queryManager;
     private readonly IEnumerable<Permission> _generalPermissions =
@@ -52,10 +56,6 @@ public sealed class Permissions : IPermissionProvider
         },
     ];
 
-    public static Permission CreatePermissionForQuery(string name)
-        => new(
-                string.Format(s_executeApi.Name, name),
-                string.Format(s_executeApi.Description, name),
-                s_executeApi.ImpliedBy
-            );
+    public static Permission CreatePermissionForQuery(string name) =>
+        s_executeApi.CreateDynamicPermission(name);
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/CustomUserSettingsPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/CustomUserSettingsPermissions.cs
@@ -7,7 +7,10 @@ namespace OrchardCore.Users;
 public sealed class CustomUserSettingsPermissions : IPermissionProvider
 {
     // This permission is never checked it is only used as a template.
-    private static readonly Permission s_manageOwnCustomUserSettings = new("ManageOwnCustomUserSettings_{0}", "Manage Own Custom User Settings - {0}", new[] { Permissions.ManageUsers });
+    private static readonly PermissionTemplate s_manageOwnCustomUserSettings = new(
+        "ManageOwnCustomUserSettings_{0}",
+        "Manage Own Custom User Settings - {0}",
+        Permissions.ManageUsers);
 
     private readonly IContentDefinitionManager _contentDefinitionManager;
 
@@ -25,9 +28,5 @@ public sealed class CustomUserSettingsPermissions : IPermissionProvider
         => [];
 
     public static Permission CreatePermissionForType(ContentTypeDefinition type) =>
-        new(
-            string.Format(s_manageOwnCustomUserSettings.Name, type.Name),
-            string.Format(s_manageOwnCustomUserSettings.Description, type.DisplayName),
-            s_manageOwnCustomUserSettings.ImpliedBy
-        );
+        s_manageOwnCustomUserSettings.CreateDynamicPermission(type.Name, type.DisplayName);
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemFilters.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemFilters.cs
@@ -38,8 +38,7 @@ public sealed class ContentItemFilters : GraphQLFilter<ContentItem>
         }
 
         var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentType);
-        var contentTypePermission = ContentTypePermissionsHelper.ConvertToDynamicPermission(CommonPermissions.ViewContent);
-        var dynamicPermission = ContentTypePermissionsHelper.CreateDynamicPermission(contentTypePermission, contentTypeDefinition);
+        var dynamicPermission = ContentTypePermissionsHelper.CreateDynamicPermissionOf(CommonPermissions.ViewContent, contentTypeDefinition);
 
         if (await _authorizationService.AuthorizeContentTypeAsync(_httpContextAccessor.HttpContext.User, dynamicPermission, contentTypeDefinition))
         {

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemFilters.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemFilters.cs
@@ -47,8 +47,7 @@ public sealed class ContentItemFilters : GraphQLFilter<ContentItem>
         }
 
         var userId = _httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        var contentTypeOwnPermission = ContentTypePermissionsHelper.ConvertToDynamicPermission(CommonPermissions.ViewOwnContent);
+        var contentTypeOwnPermission = ContentTypePermissionsHelper.CreateDynamicPermissionOf(CommonPermissions.ViewOwnContent, contentTypeDefinition);
 
         if (await _authorizationService.AuthorizeContentTypeAsync(_httpContextAccessor.HttpContext.User, contentTypeOwnPermission, contentTypeDefinition, userId))
         {

--- a/src/OrchardCore/OrchardCore.Contents.Core/AuthorizationServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/AuthorizationServiceExtensions.cs
@@ -44,11 +44,9 @@ public static class AuthorizationServiceExtensions
 
         var permission = GetOwnerVariation(requiredPermission) ?? requiredPermission;
 
-        var contentTypePermission = ContentTypePermissionsHelper.ConvertToDynamicPermission(permission);
-
         foreach (var contentTypeDefinition in contentTypeDefinitions)
         {
-            var dynamicPermission = ContentTypePermissionsHelper.CreateDynamicPermission(contentTypePermission, contentTypeDefinition);
+            var dynamicPermission = ContentTypePermissionsHelper.CreateDynamicPermissionOf(permission, contentTypeDefinition);
 
             if (await service.AuthorizeContentTypeAsync(user, dynamicPermission, contentTypeDefinition.Name, user.FindFirstValue(ClaimTypes.NameIdentifier)))
             {

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -60,6 +60,7 @@ public static class ContentTypePermissionsHelper
     /// <summary>
     /// Generates a permission dynamically for a content type.
     /// </summary>
+    [Obsolete($"Use {nameof(CreateDynamicPermissionOf)} instead.")]
     public static Permission CreateDynamicPermission(Permission template, ContentTypeDefinition typeDefinition)
     {
         ArgumentNullException.ThrowIfNull(template);
@@ -74,6 +75,25 @@ public static class ContentTypePermissionsHelper
         {
             Category = $"{typeDefinition.DisplayName} Content Type - {typeDefinition.Name}",
         };
+    }
+
+    public static Permission CreateDynamicPermissionOf(Permission basePermission, ContentTypeDefinition typeDefinition) =>
+        CreateDynamicPermissionOf(basePermission.Name, typeDefinition);
+
+    public static Permission CreateDynamicPermissionOf(string basePermissionName, ContentTypeDefinition typeDefinition)
+    {
+        if (!PermissionTemplates.TryGetValue(basePermissionName, out var result))
+        {
+            return null;
+        }
+
+        var template = new PermissionTemplate(
+            result.Name,
+            result.Description,
+            $"{typeDefinition.DisplayName} Content Type - {typeDefinition.Name}",
+            result.ImpliedBy?.Select(item => CreateDynamicPermissionOf(item.Name, typeDefinition)) ?? []);
+
+        return template.CreateDynamicPermission(typeDefinition.Name, typeDefinition.DisplayName);
     }
 
     /// <summary>

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -47,6 +47,7 @@ public static class ContentTypePermissionsHelper
     /// <summary>
     /// Returns a dynamic permission for a content type, based on a global content permission template.
     /// </summary>
+    [Obsolete($"Use {nameof(CreatePermissionTemplate)} instead.")]
     public static Permission ConvertToDynamicPermission(Permission permission)
     {
         if (PermissionTemplates.TryGetValue(permission.Name, out var result))
@@ -77,28 +78,10 @@ public static class ContentTypePermissionsHelper
         };
     }
 
-    public static Permission CreateDynamicPermissionOf(Permission basePermission, ContentTypeDefinition typeDefinition) =>
-        CreateDynamicPermissionOf(basePermission.Name, typeDefinition);
-
-    public static Permission CreateDynamicPermissionOf(string basePermissionName, ContentTypeDefinition typeDefinition)
-    {
-        if (!PermissionTemplates.TryGetValue(basePermissionName, out var result))
-        {
-            return null;
-        }
-
-        var template = new PermissionTemplate(
-            result.Name,
-            result.Description,
-            $"{typeDefinition.DisplayName} Content Type - {typeDefinition.Name}",
-            result.ImpliedBy?.Select(item => CreateDynamicPermissionOf(item.Name, typeDefinition)) ?? []);
-
-        return template.CreateDynamicPermission(typeDefinition.Name, typeDefinition.DisplayName);
-    }
-
     /// <summary>
     /// Generates a permission dynamically for a content type, without a display name or category.
     /// </summary>
+    [Obsolete($"Use {nameof(CreateDynamicPermissionOf)} instead.")]
     public static Permission CreateDynamicPermission(Permission template, string contentType)
     {
         ArgumentNullException.ThrowIfNull(template);
@@ -124,5 +107,60 @@ public static class ContentTypePermissionsHelper
         s_permissionsByType = localPermissions;
 
         return permission;
+    }
+
+    /// <summary>
+    /// Returns a permission template for content types, based on a global content permission with the name of <paramref
+    /// name="basePermissionName"/>.
+    /// </summary>
+    public static PermissionTemplate CreatePermissionTemplate(string basePermissionName) =>
+        PermissionTemplates.TryGetValue(basePermissionName, out var result)
+            ? new PermissionTemplate(
+                result.Name,
+                result.Description,
+                "{1} Content Type - {0}",
+                result.ImpliedBy ?? [])
+            : null;
+
+    /// <summary>
+    /// Generates a dynamic version of the provided <paramref name="basePermission"/>, that is specific to content type
+    /// indicated by the <paramref name="typeDefinition"/>.
+    /// </summary>
+    public static Permission CreateDynamicPermissionOf(Permission basePermission, ContentTypeDefinition typeDefinition) =>
+        CreateDynamicPermissionOf(basePermission.Name, typeDefinition);
+
+    /// <summary>
+    /// Generates a permission dynamically for a content type, without a display name or category.
+    /// </summary>
+    public static Permission CreateDynamicPermissionOf(string basePermissionName, string contentType) =>
+        CreateDynamicPermissionOf(basePermissionName, contentType, contentType);
+
+    /// <summary>
+    /// Generates a dynamic version of the provided permission with the name <paramref name="basePermissionName"/>,
+    /// that is specific to a content type indicated by the <paramref name="typeDefinition"/>.
+    /// </summary>
+    public static Permission CreateDynamicPermissionOf(string basePermissionName, ContentTypeDefinition typeDefinition) =>
+        CreateDynamicPermissionOf(basePermissionName, typeDefinition.Name, typeDefinition.DisplayName);
+    
+    /// <summary>
+    /// Generates a dynamic version of the provided permission with the name <paramref name="basePermissionName"/>,
+    /// that is specific to a <paramref name="contentType"/>.
+    /// </summary>
+    private static Permission CreateDynamicPermissionOf(string basePermissionName, string contentType, string contentTypeDisplayName)
+    {
+        if (CreatePermissionTemplate(basePermissionName) is not { } template)
+        {
+            return null;
+        }
+
+        template = template with
+        {
+            ImpliedBy = template
+                .ImpliedBy
+                .Select(item => CreateDynamicPermissionOf(item.Name, contentType, contentTypeDisplayName))
+                .Where(item => item != null),
+        };
+
+        return template.CreateDynamicPermission(contentType, contentTypeDisplayName);
     }
 }

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -142,11 +142,14 @@ public static class ContentTypePermissionsHelper
 
         return template.CreateDynamicPermission(contentType, contentTypeDisplayName);
     }
-    
+
     private static PermissionTemplate CreateTemplate(
         string nameBase,
         string description,
         Permission impliedBy,
-        params PermissionTemplate[] impliedByTemplate) =>
-        new(nameBase + "_{0}", description, Category: "{1} Content Type - {0}", [impliedBy], impliedByTemplate);
+        params PermissionTemplate[] impliedByTemplates) =>
+        new(nameBase + "_{0}", description, "{1} Content Type - {0}", impliedBy)
+        {
+            ImpliedByTemplates = impliedByTemplates,
+        };
 }

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -140,17 +140,6 @@ public static class ContentTypePermissionsHelper
             return null;
         }
 
-        template = template with
-        {
-            ImpliedBy = template
-                .ImpliedBy
-                .Select(item => item.Name.Contains("{0}")
-                    ? item
-                    : CreateDynamicPermissionOf(item.Name, contentType, contentTypeDisplayName))
-                .Where(item => item != null)
-                .ToArray(),
-        };
-
         return template.CreateDynamicPermission(contentType, contentTypeDisplayName);
     }
     

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -9,22 +9,22 @@ namespace OrchardCore.Contents.Security;
 /// </summary>
 public static class ContentTypePermissionsHelper
 {
-    private static readonly Permission s_publishContent = new("Publish_{0}", "Publish or unpublish {0} for others", [CommonPermissions.PublishContent]);
-    private static readonly Permission s_publishOwnContent = new("PublishOwn_{0}", "Publish or unpublish {0}", [s_publishContent, CommonPermissions.PublishOwnContent]);
-    private static readonly Permission s_editContent = new("Edit_{0}", "Edit {0} for others", [s_publishContent, CommonPermissions.EditContent]);
-    private static readonly Permission s_editOwnContent = new("EditOwn_{0}", "Edit {0}", [s_editContent, s_publishOwnContent, CommonPermissions.EditOwnContent]);
-    private static readonly Permission s_deleteContent = new("Delete_{0}", "Delete {0} for others", [CommonPermissions.DeleteContent]);
-    private static readonly Permission s_deleteOwnContent = new("DeleteOwn_{0}", "Delete {0}", [s_deleteContent, CommonPermissions.DeleteOwnContent]);
-    private static readonly Permission s_viewContent = new("View_{0}", "View {0} by others", [s_editContent, CommonPermissions.ViewContent]);
-    private static readonly Permission s_viewOwnContent = new("ViewOwn_{0}", "View own {0}", [s_viewContent, CommonPermissions.ViewOwnContent]);
-    private static readonly Permission s_previewContent = new("Preview_{0}", "Preview {0} by others", [s_editContent, CommonPermissions.PreviewContent]);
-    private static readonly Permission s_previewOwnContent = new("PreviewOwn_{0}", "Preview own {0}", [s_previewContent, CommonPermissions.PreviewOwnContent]);
-    private static readonly Permission s_cloneContent = new("Clone_{0}", "Clone {0} by others", [s_editContent, CommonPermissions.CloneContent]);
-    private static readonly Permission s_cloneOwnContent = new("CloneOwn_{0}", "Clone own {0}", [s_cloneContent, CommonPermissions.CloneOwnContent]);
-    private static readonly Permission s_listContent = new("ListContent_{0}", "List {0} content items", [CommonPermissions.ListContent]);
-    private static readonly Permission s_editContentOwner = new("EditContentOwner_{0}", "Edit the owner of a {0} content item", [CommonPermissions.EditContentOwner]);
+    private static readonly PermissionTemplate s_publishContent = CreateTemplate("Publish", "Publish or unpublish {0} for others", CommonPermissions.PublishContent);
+    private static readonly PermissionTemplate s_publishOwnContent = CreateTemplate("PublishOwn", "Publish or unpublish {0}", CommonPermissions.PublishOwnContent, s_publishContent);
+    private static readonly PermissionTemplate s_editContent = CreateTemplate("Edit", "Edit {0} for others", CommonPermissions.EditContent, s_publishContent);
+    private static readonly PermissionTemplate s_editOwnContent = CreateTemplate("EditOwn", "Edit {0}", CommonPermissions.EditOwnContent, s_editContent, s_publishOwnContent);
+    private static readonly PermissionTemplate s_deleteContent = CreateTemplate("Delete", "Delete {0} for others", CommonPermissions.DeleteContent);
+    private static readonly PermissionTemplate s_deleteOwnContent = CreateTemplate("DeleteOwn", "Delete {0}", CommonPermissions.DeleteOwnContent, s_deleteContent);
+    private static readonly PermissionTemplate s_viewContent = CreateTemplate("View", "View {0} by others", CommonPermissions.ViewContent, s_editContent);
+    private static readonly PermissionTemplate s_viewOwnContent = CreateTemplate("ViewOwn", "View own {0}", CommonPermissions.ViewOwnContent, s_viewContent);
+    private static readonly PermissionTemplate s_previewContent = CreateTemplate("Preview", "Preview {0} by others", CommonPermissions.PreviewContent, s_editContent);
+    private static readonly PermissionTemplate s_previewOwnContent = CreateTemplate("PreviewOwn", "Preview own {0}", CommonPermissions.PreviewOwnContent, s_previewContent);
+    private static readonly PermissionTemplate s_cloneContent = CreateTemplate("Clone", "Clone {0} by others", CommonPermissions.CloneContent, s_editContent);
+    private static readonly PermissionTemplate s_cloneOwnContent = CreateTemplate("CloneOwn", "Clone own {0}", CommonPermissions.CloneOwnContent, s_cloneContent);
+    private static readonly PermissionTemplate s_listContent = CreateTemplate("ListContent", "List {0} content items", CommonPermissions.ListContent);
+    private static readonly PermissionTemplate s_editContentOwner = CreateTemplate("EditContentOwner", "Edit the owner of a {0} content item", CommonPermissions.EditContentOwner);
 
-    public static readonly Dictionary<string, Permission> PermissionTemplates = new()
+    public static readonly Dictionary<string, PermissionTemplate> PermissionTemplates = new()
     {
         { CommonPermissions.PublishContent.Name, s_publishContent },
         { CommonPermissions.PublishOwnContent.Name, s_publishOwnContent },
@@ -48,15 +48,8 @@ public static class ContentTypePermissionsHelper
     /// Returns a dynamic permission for a content type, based on a global content permission template.
     /// </summary>
     [Obsolete($"Use {nameof(CreatePermissionTemplate)} instead.")]
-    public static Permission ConvertToDynamicPermission(Permission permission)
-    {
-        if (PermissionTemplates.TryGetValue(permission.Name, out var result))
-        {
-            return result;
-        }
-
-        return null;
-    }
+    public static Permission ConvertToDynamicPermission(Permission permission) =>
+        PermissionTemplates.TryGetValue(permission.Name, out var result) ? result.CreateDynamicPermission("{0}") : null;
 
     /// <summary>
     /// Generates a permission dynamically for a content type.
@@ -114,13 +107,7 @@ public static class ContentTypePermissionsHelper
     /// name="basePermissionName"/>.
     /// </summary>
     public static PermissionTemplate CreatePermissionTemplate(string basePermissionName) =>
-        PermissionTemplates.TryGetValue(basePermissionName, out var result)
-            ? new PermissionTemplate(
-                result.Name,
-                result.Description,
-                "{1} Content Type - {0}",
-                result.ImpliedBy ?? [])
-            : null;
+        PermissionTemplates.TryGetValue(basePermissionName, out var result) ? result : null;
 
     /// <summary>
     /// Generates a dynamic version of the provided <paramref name="basePermission"/>, that is specific to content type
@@ -157,11 +144,20 @@ public static class ContentTypePermissionsHelper
         {
             ImpliedBy = template
                 .ImpliedBy
-                .Select(item => CreateDynamicPermissionOf(item.Name, contentType, contentTypeDisplayName))
+                .Select(item => item.Name.Contains("{0}")
+                    ? item
+                    : CreateDynamicPermissionOf(item.Name, contentType, contentTypeDisplayName))
                 .Where(item => item != null)
                 .ToArray(),
         };
 
         return template.CreateDynamicPermission(contentType, contentTypeDisplayName);
     }
+    
+    public static PermissionTemplate CreateTemplate(
+        string nameBase,
+        string description,
+        Permission impliedBy,
+        params PermissionTemplate[] impliedByTemplate) =>
+        new(nameBase + "_{0}", description, Category: "{1} Content Type - {0}", [impliedBy], impliedByTemplate);
 }

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -143,7 +143,7 @@ public static class ContentTypePermissionsHelper
         return template.CreateDynamicPermission(contentType, contentTypeDisplayName);
     }
     
-    public static PermissionTemplate CreateTemplate(
+    private static PermissionTemplate CreateTemplate(
         string nameBase,
         string description,
         Permission impliedBy,

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -158,7 +158,8 @@ public static class ContentTypePermissionsHelper
             ImpliedBy = template
                 .ImpliedBy
                 .Select(item => CreateDynamicPermissionOf(item.Name, contentType, contentTypeDisplayName))
-                .Where(item => item != null),
+                .Where(item => item != null)
+                .ToArray(),
         };
 
         return template.CreateDynamicPermission(contentType, contentTypeDisplayName);

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -47,7 +47,7 @@ public static class ContentTypePermissionsHelper
     /// <summary>
     /// Returns a dynamic permission for a content type, based on a global content permission template.
     /// </summary>
-    [Obsolete($"Use {nameof(CreatePermissionTemplate)} instead.")]
+    [Obsolete($"Use {nameof(GetPermissionTemplate)} instead.")]
     public static Permission ConvertToDynamicPermission(Permission permission) =>
         PermissionTemplates.TryGetValue(permission.Name, out var result) ? result.CreateDynamicPermission("{0}") : null;
 
@@ -106,7 +106,7 @@ public static class ContentTypePermissionsHelper
     /// Returns a permission template for content types, based on a global content permission with the name of <paramref
     /// name="basePermissionName"/>.
     /// </summary>
-    public static PermissionTemplate CreatePermissionTemplate(string basePermissionName) =>
+    public static PermissionTemplate GetPermissionTemplate(string basePermissionName) =>
         PermissionTemplates.TryGetValue(basePermissionName, out var result) ? result : null;
 
     /// <summary>
@@ -135,7 +135,7 @@ public static class ContentTypePermissionsHelper
     /// </summary>
     private static Permission CreateDynamicPermissionOf(string basePermissionName, string contentType, string contentTypeDisplayName)
     {
-        if (CreatePermissionTemplate(basePermissionName) is not { } template)
+        if (GetPermissionTemplate(basePermissionName) is not { } template)
         {
             return null;
         }

--- a/src/OrchardCore/OrchardCore.Elasticsearch.Core/ElasticsearchIndexPermissionHelper.cs
+++ b/src/OrchardCore/OrchardCore.Elasticsearch.Core/ElasticsearchIndexPermissionHelper.cs
@@ -11,8 +11,10 @@ public static class ElasticsearchIndexPermissionHelper
     private const string PermissionNamePrefix = "QueryElasticsearch";
     private const string PermissionNameSuffix = "Index";
 
-    private static readonly Permission s_indexPermissionTemplate =
-        new(PermissionNamePrefix + "{0}" + PermissionNameSuffix, "Query Elasticsearch {0} Index", [Permissions.ManageElasticIndexes]);
+    private static readonly PermissionTemplate s_indexPermissionTemplate = new(
+        $"{PermissionNamePrefix}{{0}}{PermissionNameSuffix}",
+        "Query Elasticsearch {0} Index",
+        Permissions.ManageElasticIndexes);
 
     private static readonly ConcurrentDictionary<string, Permission> s_permissions = [];
 
@@ -21,10 +23,7 @@ public static class ElasticsearchIndexPermissionHelper
     {
         ArgumentException.ThrowIfNullOrEmpty(indexName);
 
-        return s_permissions.GetOrAdd(indexName, indexName => new Permission(
-                string.Format(s_indexPermissionTemplate.Name, indexName),
-                string.Format(s_indexPermissionTemplate.Description, indexName),
-                s_indexPermissionTemplate.ImpliedBy));
+        return s_permissions.GetOrAdd(indexName, s_indexPermissionTemplate.CreateDynamicPermission);
     }
 
     internal static bool IsElasticsearchIndexPermissionClaim(RoleClaim claim) =>

--- a/src/OrchardCore/OrchardCore.Indexing.Core/IndexingPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/IndexingPermissions.cs
@@ -10,8 +10,8 @@ public static class IndexingPermissions
 
     public static readonly Permission ManageIndexes = new("ManageIndexes", "Manage Indexes");
 
-    private static readonly Permission s_indexPermissionTemplate =
-        new("QueryIndex_{0}", "Query '{0}' Index", [ManageIndexes, QuerySearchIndex]);
+    private static readonly PermissionTemplate s_indexPermissionTemplate =
+        new("QueryIndex_{0}", "Query '{0}' Index", ManageIndexes, QuerySearchIndex);
 
     private static readonly ConcurrentDictionary<string, Permission> s_permissions = [];
 
@@ -19,9 +19,6 @@ public static class IndexingPermissions
     {
         ArgumentNullException.ThrowIfNull(indexProfile);
 
-        return s_permissions.GetOrAdd(indexProfile.Id, indexId => new Permission(
-            string.Format(s_indexPermissionTemplate.Name, indexProfile.Name),
-            string.Format(s_indexPermissionTemplate.Description, indexProfile.Name),
-            s_indexPermissionTemplate.ImpliedBy));
+        return s_permissions.GetOrAdd(indexProfile.Id, s_indexPermissionTemplate.CreateDynamicPermission);
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
@@ -26,6 +26,6 @@ public record PermissionTemplate(
         ImpliedBy ?? [],
         IsSecurityCritical)
     {
-        Category = Category,
+        Category = string.IsNullOrEmpty(Category) ? null : string.Format(Category, nameValue, descriptionValue),
     };
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
@@ -16,8 +16,11 @@ public record PermissionTemplate(
         : this(name, description, category: null, impliedBy)
     {
     }
-    
-    public Permission CreateDynamicPermission(string nameValue, string descriptionValue =  null) => new(
+
+    public Permission CreateDynamicPermission(string nameValue) =>
+        CreateDynamicPermission(nameValue, nameValue);
+
+    public Permission CreateDynamicPermission(string nameValue, string descriptionValue) => new(
         string.Format(Name, nameValue),
         string.Format(Description, descriptionValue ?? nameValue),
         ImpliedBy ?? [],

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
@@ -5,10 +5,11 @@ public record PermissionTemplate(
     string Description,
     string Category,
     IEnumerable<Permission> ImpliedBy,
+    IEnumerable<PermissionTemplate> ImpliedByTemplates,
     bool IsSecurityCritical = false)
 {
     public PermissionTemplate(string name, string description, string category = null, params Permission[] impliedBy)
-        : this(name, description, category, impliedBy, IsSecurityCritical: false)
+        : this(name, description, category, impliedBy, ImpliedByTemplates: [], IsSecurityCritical: false)
     {
     }
 
@@ -23,7 +24,7 @@ public record PermissionTemplate(
     public Permission CreateDynamicPermission(string nameValue, string descriptionValue) => new(
         string.Format(Name, nameValue),
         string.Format(Description, descriptionValue ?? nameValue),
-        ImpliedBy ?? [],
+        [.. ImpliedBy, .. ImpliedByTemplates.Select(template => template.CreateDynamicPermission(nameValue, descriptionValue))],
         IsSecurityCritical)
     {
         Category = string.IsNullOrEmpty(Category) ? null : string.Format(Category, nameValue, descriptionValue),

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
@@ -1,0 +1,28 @@
+namespace OrchardCore.Security.Permissions;
+
+public record PermissionTemplate(
+    string Name,
+    string Description,
+    string Category,
+    IEnumerable<Permission> ImpliedBy,
+    bool IsSecurityCritical = false)
+{
+    public PermissionTemplate(string name, string description, string category = null, params Permission[] impliedBy)
+        : this(name, description, category, impliedBy, IsSecurityCritical: false)
+    {
+    }
+
+    public PermissionTemplate(string name, string description, params Permission[] impliedBy)
+        : this(name, description, category: null, impliedBy)
+    {
+    }
+    
+    public Permission CreateDynamicPermission(string nameValue, string descriptionValue =  null) => new(
+        string.Format(Name, nameValue),
+        string.Format(Description, descriptionValue ?? nameValue),
+        ImpliedBy ?? [],
+        IsSecurityCritical)
+    {
+        Category = Category,
+    };
+}

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
@@ -1,16 +1,20 @@
 namespace OrchardCore.Security.Permissions;
 
-public sealed record PermissionTemplate(
-    string Name,
-    string Description,
-    string Category,
-    IEnumerable<Permission> ImpliedBy,
-    IEnumerable<PermissionTemplate> ImpliedByTemplates,
-    bool IsSecurityCritical = false)
+public sealed record PermissionTemplate
 {
-    public PermissionTemplate(string name, string description, string category = null, params Permission[] impliedBy)
-        : this(name, description, category, impliedBy, ImpliedByTemplates: [], IsSecurityCritical: false)
+    public string Name { get; init; }
+    public string Description { get; init; }
+    public string Category { get; init; }
+    public IEnumerable<Permission> ImpliedBy { get; init; } = [];
+    public IEnumerable<PermissionTemplate> ImpliedByTemplates { get; init; } = [];
+    public bool IsSecurityCritical { get; init; }
+    
+    public PermissionTemplate(string name, string description = null, string category = null, params Permission[] impliedBy)
     {
+        Name = name;
+        Description = description;
+        Category = category;
+        ImpliedBy = impliedBy ?? [];
     }
 
     public PermissionTemplate(string name, string description, params Permission[] impliedBy)

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/PermissionTemplate.cs
@@ -1,6 +1,6 @@
 namespace OrchardCore.Security.Permissions;
 
-public record PermissionTemplate(
+public sealed record PermissionTemplate(
     string Name,
     string Description,
     string Category,

--- a/src/OrchardCore/OrchardCore.Localization.Core/Data/DataLocalizationPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/Data/DataLocalizationPermissions.cs
@@ -29,8 +29,8 @@ public class DataLocalizationPermissions
     // Declared after ManageTranslations so its ImpliedBy list captures the real instance
     // rather than the default null a forward reference would read from a static field
     // initializer that hasn't run yet.
-    private static readonly Permission s_manageTranslationsForCulture =
-        new("ManageTranslations_{0}", "Manage {0} translations", [ManageTranslations]);
+    private static readonly PermissionTemplate s_manageTranslationsForCulture =
+        new("ManageTranslations_{0}", "Manage {0} translations", "Data Localization", ManageTranslations);
 
     /// <summary>
     /// Creates a dynamic permission for managing translations in a specific culture.
@@ -47,14 +47,7 @@ public class DataLocalizationPermissions
             return existingPermission;
         }
 
-        var permission = new Permission(
-            string.Format(s_manageTranslationsForCulture.Name, cultureName),
-            string.Format(s_manageTranslationsForCulture.Description, cultureDisplayName),
-            s_manageTranslationsForCulture.ImpliedBy)
-        {
-            Category = "Data Localization",
-        };
-
+        var permission = s_manageTranslationsForCulture.CreateDynamicPermission(cultureName, cultureDisplayName);
         s_culturePermissions[cultureName] = permission;
 
         return permission;

--- a/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
@@ -28,26 +28,23 @@ public static class UsersPermissions
     public static readonly Permission EditOwnUser = new("ManageOwnUserInformation", "Edit own user information", [EditUsers]);
 
     public static Permission CreateEditUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("EditUsersInRole_{0}", "Edit users in {0} role", [EditUsers], true));
+        CreateDynamicPermission(roleName, "EditUsersInRole_{0}", "Edit users in {0} role", EditUsers);
 
     public static Permission CreateDeleteUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("DeleteUsersInRole_{0}", "Delete users in {0} role", [DeleteUsers], true));
+        CreateDynamicPermission(roleName, "DeleteUsersInRole_{0}", "Delete users in {0} role", DeleteUsers);
 
     public static Permission CreateListUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("ListUsersInRole_{0}", "List users in {0} role", [ListUsers]));
+        CreateDynamicPermission(roleName, "ListUsersInRole_{0}", "List users in {0} role", ListUsers, isSecurityCritical: false);
 
     public static Permission CreateAssignRoleToUsersPermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("AssignRoleToUsers_{0}", "Assign {0} role to users", [AssignRoleToUsers], true));
+        CreateDynamicPermission(roleName, "AssignRoleToUsers_{0}", "Assign {0} role to users", AssignRoleToUsers);
 
     public static Permission CreatePermissionForManageUsersInRole(string name) =>
-        CreateDynamicPermission(name, new Permission("ManageUsersInRole_{0}", "Manage users in {0} role", [ManageUsers], true));
+        CreateDynamicPermission(name, "ManageUsersInRole_{0}", "Manage users in {0} role", ManageUsers);
 
     // Dynamic permission template.
-    private static Permission CreateDynamicPermission(string roleName, Permission permission)
-        => new(
-            string.Format(permission.Name, roleName),
-            string.Format(permission.Description, roleName),
-            permission.ImpliedBy,
-            permission.IsSecurityCritical
-        );
+    private static Permission CreateDynamicPermission(
+        string roleName, string name, string description, Permission impliedBy, bool isSecurityCritical = true) =>
+        new PermissionTemplate(name, description, Category: null, [impliedBy], isSecurityCritical)
+            .CreateDynamicPermission(roleName);
 }

--- a/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
@@ -4,7 +4,7 @@ namespace OrchardCore.Users;
 
 public static class UsersPermissions
 {
-    private static readonly IReadOnlyDictionary<string, PermissionTemplate> s_userPermissionTemplates;
+    private static readonly Dictionary<string, PermissionTemplate> s_userPermissionTemplates;
     
     /// <summary>
     /// When authorizing request ManageUsers and pass an <see cref="IUser"/>

--- a/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
@@ -4,6 +4,8 @@ namespace OrchardCore.Users;
 
 public static class UsersPermissions
 {
+    private static readonly IReadOnlyDictionary<string, PermissionTemplate> s_userPermissionTemplates;
+    
     /// <summary>
     /// When authorizing request ManageUsers and pass an <see cref="IUser"/>
     /// Do not request a dynamic permission unless you are checking if the user can manage a specific role.
@@ -28,26 +30,29 @@ public static class UsersPermissions
     public static readonly Permission EditOwnUser = new("ManageOwnUserInformation", "Edit own user information", [EditUsers]);
 
     public static Permission CreateEditUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("EditUsersInRole_{0}", "Edit users in {0} role", [EditUsers], true));
+        s_userPermissionTemplates[EditUsers.Name].CreateDynamicPermission(roleName);
 
     public static Permission CreateDeleteUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("DeleteUsersInRole_{0}", "Delete users in {0} role", [DeleteUsers], true));
+        s_userPermissionTemplates[DeleteUsers.Name].CreateDynamicPermission(roleName);
 
     public static Permission CreateListUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("ListUsersInRole_{0}", "List users in {0} role", [ListUsers]));
+        s_userPermissionTemplates[ListUsers.Name].CreateDynamicPermission(roleName);
 
     public static Permission CreateAssignRoleToUsersPermission(string roleName) =>
-        CreateDynamicPermission(roleName, new Permission("AssignRoleToUsers_{0}", "Assign {0} role to users", [AssignRoleToUsers], true));
+        s_userPermissionTemplates[AssignRoleToUsers.Name].CreateDynamicPermission(roleName);
 
     public static Permission CreatePermissionForManageUsersInRole(string name) =>
-        CreateDynamicPermission(name, new Permission("ManageUsersInRole_{0}", "Manage users in {0} role", [ManageUsers], true));
+        s_userPermissionTemplates[ManageUsers.Name].CreateDynamicPermission(name);
 
-    // Dynamic permission template.
-    private static Permission CreateDynamicPermission(string roleName, Permission permission)
-        => new(
-            string.Format(permission.Name, roleName),
-            string.Format(permission.Description, roleName),
-            permission.ImpliedBy,
-            permission.IsSecurityCritical
-        );
+    static UsersPermissions()
+    {
+        s_userPermissionTemplates = new Dictionary<string, PermissionTemplate>
+        {
+            [EditUsers.Name] = new("EditUsersInRole_{0}", "Edit users in {0} role", null, [EditUsers], true),
+            [DeleteUsers.Name] = new("DeleteUsersInRole_{0}", "Delete users in {0} role", null, [DeleteUsers], true),
+            [ListUsers.Name] = new("ListUsersInRole_{0}", "List users in {0} role", null, [ListUsers]),
+            [AssignRoleToUsers.Name] = new("AssignRoleToUsers_{0}", "Assign {0} role to users", null, [AssignRoleToUsers], true),
+            [ManageUsers.Name] = new("ManageUsersInRole_{0}", "Manage users in {0} role", null, [ManageUsers], true),
+        };
+    }
 }

--- a/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
@@ -28,23 +28,26 @@ public static class UsersPermissions
     public static readonly Permission EditOwnUser = new("ManageOwnUserInformation", "Edit own user information", [EditUsers]);
 
     public static Permission CreateEditUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, "EditUsersInRole_{0}", "Edit users in {0} role", EditUsers);
+        CreateDynamicPermission(roleName, new Permission("EditUsersInRole_{0}", "Edit users in {0} role", [EditUsers], true));
 
     public static Permission CreateDeleteUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, "DeleteUsersInRole_{0}", "Delete users in {0} role", DeleteUsers);
+        CreateDynamicPermission(roleName, new Permission("DeleteUsersInRole_{0}", "Delete users in {0} role", [DeleteUsers], true));
 
     public static Permission CreateListUsersInRolePermission(string roleName) =>
-        CreateDynamicPermission(roleName, "ListUsersInRole_{0}", "List users in {0} role", ListUsers, isSecurityCritical: false);
+        CreateDynamicPermission(roleName, new Permission("ListUsersInRole_{0}", "List users in {0} role", [ListUsers]));
 
     public static Permission CreateAssignRoleToUsersPermission(string roleName) =>
-        CreateDynamicPermission(roleName, "AssignRoleToUsers_{0}", "Assign {0} role to users", AssignRoleToUsers);
+        CreateDynamicPermission(roleName, new Permission("AssignRoleToUsers_{0}", "Assign {0} role to users", [AssignRoleToUsers], true));
 
     public static Permission CreatePermissionForManageUsersInRole(string name) =>
-        CreateDynamicPermission(name, "ManageUsersInRole_{0}", "Manage users in {0} role", ManageUsers);
+        CreateDynamicPermission(name, new Permission("ManageUsersInRole_{0}", "Manage users in {0} role", [ManageUsers], true));
 
     // Dynamic permission template.
-    private static Permission CreateDynamicPermission(
-        string roleName, string name, string description, Permission impliedBy, bool isSecurityCritical = true) =>
-        new PermissionTemplate(name, description, Category: null, [impliedBy], isSecurityCritical)
-            .CreateDynamicPermission(roleName);
+    private static Permission CreateDynamicPermission(string roleName, Permission permission)
+        => new(
+            string.Format(permission.Name, roleName),
+            string.Format(permission.Description, roleName),
+            permission.ImpliedBy,
+            permission.IsSecurityCritical
+        );
 }

--- a/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
@@ -59,5 +59,8 @@ public static class UsersPermissions
     }
 
     private static PermissionTemplate CreateTemplate(string nameBase, string description, Permission impliedBy) =>
-        new(nameBase + "_{0}", description, Category: null, [impliedBy], [], impliedBy.IsSecurityCritical);
+        new(nameBase + "_{0}", description, impliedBy)
+        {
+            IsSecurityCritical = impliedBy.IsSecurityCritical,
+        };
 }

--- a/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/UsersPermissions.cs
@@ -15,19 +15,13 @@ public static class UsersPermissions
     /// <summary>
     /// Allows viewing user profiles.
     /// </summary>
-    public static readonly Permission ViewUsers = new("View Users", "View user profiles", [ManageUsers]);
-
-    public static readonly Permission EditUsers = new("EditUsers", "Edit any user", [ManageUsers], true);
-
-    public static readonly Permission DeleteUsers = new("DeleteUsers", "Delete any user", [ManageUsers], true);
-
-    public static readonly Permission ListUsers = new("ListUsers", "List all users", [EditUsers, DeleteUsers]);
-
-    public static readonly Permission AssignRoleToUsers = new("AssignRoleToUsers", "Assign any role to users", true);
-
-    public static readonly Permission DisableTwoFactorAuthenticationForUsers = new("DisableTwoFactorAuthenticationForUsers", "Disable two-factor authentication for any user", [ManageUsers], true);
-
-    public static readonly Permission EditOwnUser = new("ManageOwnUserInformation", "Edit own user information", [EditUsers]);
+    public static readonly Permission ViewUsers;
+    public static readonly Permission EditUsers;
+    public static readonly Permission DeleteUsers;
+    public static readonly Permission ListUsers;
+    public static readonly Permission AssignRoleToUsers;
+    public static readonly Permission DisableTwoFactorAuthenticationForUsers;
+    public static readonly Permission EditOwnUser;
 
     public static Permission CreateEditUsersInRolePermission(string roleName) =>
         s_userPermissionTemplates[EditUsers.Name].CreateDynamicPermission(roleName);
@@ -46,13 +40,24 @@ public static class UsersPermissions
 
     static UsersPermissions()
     {
+        ViewUsers = new("View Users", "View user profiles", [ManageUsers]);
+        EditUsers = new("EditUsers", "Edit any user", [ManageUsers], true);
+        DeleteUsers = new("DeleteUsers", "Delete any user", [ManageUsers], true);
+        ListUsers = new("ListUsers", "List all users", [EditUsers, DeleteUsers]);
+        AssignRoleToUsers = new("AssignRoleToUsers", "Assign any role to users", true);
+        DisableTwoFactorAuthenticationForUsers = new("DisableTwoFactorAuthenticationForUsers", "Disable two-factor authentication for any user", [ManageUsers], true);
+        EditOwnUser = new("ManageOwnUserInformation", "Edit own user information", [EditUsers]);
+        
         s_userPermissionTemplates = new Dictionary<string, PermissionTemplate>
         {
-            [EditUsers.Name] = new("EditUsersInRole_{0}", "Edit users in {0} role", null, [EditUsers], true),
-            [DeleteUsers.Name] = new("DeleteUsersInRole_{0}", "Delete users in {0} role", null, [DeleteUsers], true),
-            [ListUsers.Name] = new("ListUsersInRole_{0}", "List users in {0} role", null, [ListUsers]),
-            [AssignRoleToUsers.Name] = new("AssignRoleToUsers_{0}", "Assign {0} role to users", null, [AssignRoleToUsers], true),
-            [ManageUsers.Name] = new("ManageUsersInRole_{0}", "Manage users in {0} role", null, [ManageUsers], true),
+            [EditUsers.Name] = CreateTemplate("EditUsersInRole", "Edit users in {0} role", EditUsers),
+            [DeleteUsers.Name] = CreateTemplate("DeleteUsersInRole", "Delete users in {0} role", DeleteUsers),
+            [ListUsers.Name] = CreateTemplate("ListUsersInRole", "List users in {0} role", ListUsers),
+            [AssignRoleToUsers.Name] = CreateTemplate("AssignRoleToUsers", "Assign {0} role to users", AssignRoleToUsers),
+            [ManageUsers.Name] = CreateTemplate("ManageUsersInRole", "Manage users in {0} role", ManageUsers),
         };
     }
+
+    private static PermissionTemplate CreateTemplate(string nameBase, string description, Permission impliedBy) =>
+        new(nameBase + "_{0}", description, Category: null, [impliedBy], [], impliedBy.IsSecurityCritical);
 }


### PR DESCRIPTION
Currently a lot of dynamic permission generation code uses `Permission` instances as templates. This is problematic, because the there is no internal way to distinguish a template (which is useless for authorization) from a dynamic permission, causing mistakes [such as this](https://github.com/Lombiq/OrchardCore/blob/5dc244bf64afb2056939b617885fceb7a0da3607/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemFilters.cs#L52) (note how the permission template was acquired and used directly instead of turning it into a dynamic permission).

The main thing to avoid was the pattern of separate `ConvertToDynamicPermission(basePermission)` and `CreateDynamicPermission(templatePermission, value)` which is pretty dangerous. If they are not used together the logic would break and the authorization always fail.

To remedy this, I've created a `PermissionTemplate` class that intentionally doesn't inherit from `Permission`, but can be used to create new `Permission` instances in a unified way. I've also moved all code I could find to use `PermissionTemplate`, which also removes some simple but error-prone and non-uniform duplicate code.