### PR TITLE
Support always-composed startup types

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/RequireFeaturesAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/RequireFeaturesAttribute.cs
@@ -3,8 +3,8 @@ using System.Reflection;
 namespace OrchardCore.Modules;
 
 /// <summary>
-/// When used on a class, it will include the service only
-/// if the specific features are enabled.
+/// When used on a class, it includes the service only if the specified features are enabled.
+/// An explicitly empty declaration, <c>[RequireFeatures()]</c>, composes the service for every tenant.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public class RequireFeaturesAttribute : Attribute
@@ -19,6 +19,25 @@ public class RequireFeaturesAttribute : Attribute
     /// </summary>
     public IList<string> RequiredFeatureNames { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the attributed type is composed for every tenant.
+    /// </summary>
+    public bool IsAlwaysComposed => RequiredFeatureNames.Count == 0;
+
+    /// <summary>
+    /// Gets a value indicating whether the specified type explicitly declares an empty
+    /// <see cref="RequireFeaturesAttribute"/> and is therefore composed for every tenant.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    public static bool IsAlwaysComposedForType(Type type)
+    {
+        return type.GetCustomAttributes<RequireFeaturesAttribute>(false).FirstOrDefault()?.IsAlwaysComposed ?? false;
+    }
+
+    /// <summary>
+    /// Gets the feature names required by the specified type.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
     public static IList<string> GetRequiredFeatureNamesForType(Type type)
     {
         var attribute = type.GetCustomAttributes<RequireFeaturesAttribute>(false).FirstOrDefault();

--- a/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
@@ -50,7 +50,6 @@ public class CompositionStrategy : ICompositionStrategy
             {
                 if (RequireFeaturesAttribute.IsAlwaysComposedForType(exportedType))
                 {
-                    alwaysComposedTypes.Add(exportedType);
                     continue;
                 }
 
@@ -68,7 +67,7 @@ public class CompositionStrategy : ICompositionStrategy
             }
         }
 
-        var allFeatures = _extensionManager.GetFeatures().ToArray();
+        var allFeatures = _extensionManager.GetFeatures();
         foreach (var feature in allFeatures)
         {
             foreach (var exportedType in _typeFeatureProvider.GetTypesForFeature(feature))

--- a/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
@@ -35,6 +35,7 @@ public class CompositionStrategy : ICompositionStrategy
         var features = await _extensionManager.LoadFeaturesAsync(featureNames);
 
         var entries = new Dictionary<Type, IEnumerable<IFeatureInfo>>();
+        var alwaysComposedTypes = new HashSet<Type>();
 
         foreach (var feature in features)
         {
@@ -47,6 +48,12 @@ public class CompositionStrategy : ICompositionStrategy
 
             foreach (var exportedType in _typeFeatureProvider.GetTypesForFeature(feature))
             {
+                if (RequireFeaturesAttribute.IsAlwaysComposedForType(exportedType))
+                {
+                    alwaysComposedTypes.Add(exportedType);
+                    continue;
+                }
+
                 var requiredFeatures = RequireFeaturesAttribute.GetRequiredFeatureNamesForType(exportedType);
 
                 if (!requiredFeatures.All(x => featureNames.Contains(x)))
@@ -58,6 +65,29 @@ public class CompositionStrategy : ICompositionStrategy
                     ? featureDependencies.Append(feature).ToArray()
                     : [feature];
 
+            }
+        }
+
+        var allFeatures = _extensionManager.GetFeatures().ToArray();
+        foreach (var feature in allFeatures)
+        {
+            foreach (var exportedType in _typeFeatureProvider.GetTypesForFeature(feature))
+            {
+                if (RequireFeaturesAttribute.IsAlwaysComposedForType(exportedType))
+                {
+                    alwaysComposedTypes.Add(exportedType);
+                }
+            }
+        }
+
+        if (alwaysComposedTypes.Count > 0)
+        {
+            var applicationFeature = allFeatures.FirstOrDefault(feature => feature.Id == Application.DefaultFeatureId)
+                ?? throw new InvalidOperationException($"The '{Application.DefaultFeatureId}' feature is not registered.");
+
+            foreach (var exportedType in alwaysComposedTypes)
+            {
+                entries[exportedType] = [applicationFeature];
             }
         }
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -236,6 +236,10 @@ features now appear correctly with their category and Enable button in the Featu
 service, allowing subsystems such as `OrchardCore.DisplayManagement` to contribute their own feature providers without introducing theme-awareness into
 core (`OrchardCore.Extensions.ExtensionManager`).
 
+### Always-Composed Components
+
+An explicitly empty `[RequireFeatures()]` attribute now composes a public component type for every tenant, even when the feature that contains it is disabled. These components and the services their startup classes register are attributed to `Application.DefaultFeatureId`, rather than to the disabled feature. Omitting `[RequireFeatures]` retains the existing behavior, and named feature requirements remain conditional on every named feature being enabled.
+
 ### File Upload Security
 
 Orchard Core now provides a file upload event pipeline for securing user-uploaded files before they are stored:

--- a/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
+++ b/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
@@ -120,6 +120,83 @@ public class CompositionStrategyTests
     }
 
     [Fact]
+    public void RequireFeatures_AbsentEmptyAndNamedAttributes_HaveExpectedCompositionSemantics()
+    {
+        Assert.Empty(RequireFeaturesAttribute.GetRequiredFeatureNamesForType(typeof(DummyType)));
+        Assert.False(RequireFeaturesAttribute.IsAlwaysComposedForType(typeof(DummyType)));
+
+        Assert.Empty(RequireFeaturesAttribute.GetRequiredFeatureNamesForType(typeof(AlwaysComposedType)));
+        Assert.True(RequireFeaturesAttribute.IsAlwaysComposedForType(typeof(AlwaysComposedType)));
+
+        Assert.Equal(["FeatureA", "FeatureB"], RequireFeaturesAttribute.GetRequiredFeatureNamesForType(typeof(TypeWithMultipleRequiredFeatures)));
+        Assert.False(RequireFeaturesAttribute.IsAlwaysComposedForType(typeof(TypeWithMultipleRequiredFeatures)));
+    }
+
+    [Fact]
+    public async Task ComposeAsync_ExplicitEmptyRequiredFeaturesAndOwningFeatureDisabled_ComposesAsApplicationFeature()
+    {
+        // Arrange
+        var moduleFeature = CreateFeature("FeatureA");
+        var applicationFeature = CreateFeature(Application.DefaultFeatureId);
+
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(m => m.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([]);
+        extensionManager.Setup(m => m.GetFeatures())
+            .Returns([moduleFeature, applicationFeature]);
+
+        var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
+            .Returns([typeof(AlwaysComposedType)]);
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(applicationFeature))
+            .Returns([]);
+
+        var strategy = new CompositionStrategy(extensionManager.Object, typeFeatureProvider.Object, Mock.Of<ILogger<CompositionStrategy>>());
+
+        // Act
+        var blueprint = await strategy.ComposeAsync(new ShellSettings { Name = "Test" }, new ShellDescriptor());
+
+        // Assert
+        var dependency = Assert.Single(blueprint.Dependencies);
+        Assert.Equal(typeof(AlwaysComposedType), dependency.Key);
+        Assert.Equal(applicationFeature, Assert.Single(dependency.Value));
+    }
+
+    [Fact]
+    public async Task ComposeAsync_ExplicitEmptyRequiredFeaturesAndOwningFeatureEnabled_ComposesOnceAsApplicationFeature()
+    {
+        // Arrange
+        var moduleFeature = CreateFeature("FeatureA");
+        var applicationFeature = CreateFeature(Application.DefaultFeatureId);
+
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(m => m.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([moduleFeature]);
+        extensionManager.Setup(m => m.GetFeatures())
+            .Returns([moduleFeature, applicationFeature]);
+
+        var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
+            .Returns([typeof(AlwaysComposedType)]);
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(applicationFeature))
+            .Returns([]);
+
+        var strategy = new CompositionStrategy(extensionManager.Object, typeFeatureProvider.Object, Mock.Of<ILogger<CompositionStrategy>>());
+        var descriptor = new ShellDescriptor
+        {
+            Features = [new ShellFeature { Id = moduleFeature.Id }],
+        };
+
+        // Act
+        var blueprint = await strategy.ComposeAsync(new ShellSettings { Name = "Test" }, descriptor);
+
+        // Assert
+        var dependency = Assert.Single(blueprint.Dependencies);
+        Assert.Equal(typeof(AlwaysComposedType), dependency.Key);
+        Assert.Equal(applicationFeature, Assert.Single(dependency.Value));
+    }
+
+    [Fact]
     public async Task ComposeAsyncIncludedType_AllRequiredFeaturesAreEnabled_Succeeds()
     {
         // Arrange
@@ -316,9 +393,19 @@ public class CompositionStrategyTests
 
     public class DummyType;
 
+    [RequireFeatures()]
+    public class AlwaysComposedType;
+
     [RequireFeatures("MissingFeature")] // This feature will not be present in descriptor
     public class TypeWithRequiredFeature;
 
     [RequireFeatures("FeatureA", "FeatureB")]
     public class TypeWithMultipleRequiredFeatures;
+
+    private static IFeatureInfo CreateFeature(string id)
+    {
+        var feature = new Mock<IFeatureInfo>();
+        feature.Setup(f => f.Id).Returns(id);
+        return feature.Object;
+    }
 }

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -4,6 +4,7 @@ using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Builders.Models;
 using OrchardCore.Environment.Shell.Descriptor.Models;
+using OrchardCore.Modules;
 using OrchardCore.Tests.Stubs;
 using StartupBase = OrchardCore.Modules.StartupBase;
 
@@ -190,6 +191,27 @@ public class ShellContainerFactoryTests
         Assert.Same(expectedFeatureInfo, typeFeatureProvider.GetFeatureForDependency(typeof(TestService)));
     }
 
+    [Fact]
+    public async Task AlwaysComposedStartupIsAssignedToApplicationDefaultFeature_Default_Succeeds()
+    {
+        var shellBlueprint = CreateBlueprint();
+        var applicationDefaultFeature = new FeatureInfo(
+            Application.DefaultFeatureId,
+            new ExtensionInfo(Application.DefaultFeatureId));
+
+        shellBlueprint.Dependencies.Add(typeof(AlwaysComposedStartup), [applicationDefaultFeature]);
+
+        var container = (await _shellContainerFactory
+            .CreateContainerAsync(_uninitializedDefaultShell, shellBlueprint))
+            .CreateScope()
+            .ServiceProvider;
+
+        var typeFeatureProvider = _applicationServiceProvider.GetRequiredService<ITypeFeatureProvider>();
+
+        Assert.Single(container.GetServices<IAlwaysComposedService>());
+        Assert.Same(applicationDefaultFeature, typeFeatureProvider.GetFeatureForDependency(typeof(AlwaysComposedService)));
+    }
+
     private static ShellBlueprint CreateBlueprint()
     {
         return new ShellBlueprint
@@ -257,6 +279,18 @@ public class ShellContainerFactoryTests
         public override void ConfigureServices(IServiceCollection services)
         {
             services.Replace(ServiceDescriptor.Scoped(typeof(ITestService), typeof(CustomTestService)));
+        }
+    }
+
+    private interface IAlwaysComposedService { }
+
+    private sealed class AlwaysComposedService : IAlwaysComposedService { }
+
+    private sealed class AlwaysComposedStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<IAlwaysComposedService, AlwaysComposedService>();
         }
     }
 


### PR DESCRIPTION
## Summary
- make an explicit empty `[RequireFeatures()]` opt a component into composition for every tenant
- attribute always-composed components and their registrations to `Application.DefaultFeatureId`
- cover disabled owning features, named and absent requirements, default attribution, and duplicate prevention

This is a standalone composition capability and currently has no in-tree consumer.

## Testing
- `dotnet test test\OrchardCore.Tests\OrchardCore.Tests.csproj --filter-class OrchardCore.Tests.Shell.CompositionStrategyTests --filter-class OrchardCore.Tests.Shell.ShellContainerFactoryTests`


Possible replacement for #19701.