### PR TITLE
Add "and new" option for publish and save draft

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -402,6 +402,12 @@ public sealed class AdminController : Controller, IUpdateModel
         string returnUrl)
     {
         var stayOnSamePage = submitSave == "submit.SaveAndContinue";
+
+        if (submitSave == "submit.SaveAndCreate")
+        {
+            returnUrl = Url.Action(nameof(Create), new { returnUrl });
+        }
+
         return CreateInternalAsync(id, returnUrl, stayOnSamePage, async contentItem =>
         {
             await _contentManager.SaveDraftAsync(contentItem);
@@ -434,6 +440,11 @@ public sealed class AdminController : Controller, IUpdateModel
         if (!await _authorizationService.AuthorizeContentTypeAsync(User, CommonPermissions.PublishContent, id, CurrentUserId()))
         {
             return Forbid();
+        }
+
+        if (submitPublish == "submit.PublishAndCreate")
+        {
+            returnUrl = Url.Action(nameof(Create), new { returnUrl });
         }
 
         return await CreateInternalAsync(id, returnUrl, stayOnSamePage, async contentItem =>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -403,7 +403,7 @@ public sealed class AdminController : Controller, IUpdateModel
     {
         var stayOnSamePage = submitSave == "submit.SaveAndContinue";
 
-        if (submitSave == "submit.SaveAndCreate")
+        if (submitSave == "submit.SaveAndNew")
         {
             returnUrl = Url.Action(nameof(Create), new { returnUrl });
         }
@@ -442,7 +442,7 @@ public sealed class AdminController : Controller, IUpdateModel
             return Forbid();
         }
 
-        if (submitPublish == "submit.PublishAndCreate")
+        if (submitPublish == "submit.PublishAndNew")
         {
             returnUrl = Url.Action(nameof(Create), new { returnUrl });
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
@@ -1,6 +1,5 @@
 @{
     var returnUrl = Context.Request.Query["returnUrl"];
-    var contentItemId = Context.Request.RouteValues["contentItemId"]?.ToString();
 }
 
 @if (string.IsNullOrWhiteSpace(returnUrl))
@@ -15,10 +14,7 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
-            @if (string.IsNullOrEmpty(contentItemId))
-            {
-                <button class="dropdown-item publish-new" type="submit" name="submit.Publish" value="submit.PublishAndNew">@T["and new"]</button>
-            }
+            <button class="dropdown-item publish-new" type="submit" name="submit.Publish" value="submit.PublishAndNew">@T["and new"]</button>
             <button class="dropdown-item publish-continue" type="submit" name="submit.Publish" value="submit.PublishAndContinue">@T["and continue"]</button>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
@@ -1,5 +1,6 @@
 @{
     var returnUrl = Context.Request.Query["returnUrl"];
+    var contentItemId = Context.Request.RouteValues["contentItemId"]?.ToString();
 }
 
 @if (string.IsNullOrWhiteSpace(returnUrl))
@@ -14,6 +15,10 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
+            @if (string.IsNullOrEmpty(contentItemId))
+            {
+                <button class="dropdown-item publish-create" type="submit" name="submit.Publish" value="submit.PublishAndCreate">@T["and create"]</button>
+            }
             <button class="dropdown-item publish-continue" type="submit" name="submit.Publish" value="submit.PublishAndContinue">@T["and continue"]</button>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
@@ -17,7 +17,7 @@ else
         <div class="dropdown-menu">
             @if (string.IsNullOrEmpty(contentItemId))
             {
-                <button class="dropdown-item publish-create" type="submit" name="submit.Publish" value="submit.PublishAndCreate">@T["and create"]</button>
+                <button class="dropdown-item publish-new" type="submit" name="submit.Publish" value="submit.PublishAndNew">@T["and new"]</button>
             }
             <button class="dropdown-item publish-continue" type="submit" name="submit.Publish" value="submit.PublishAndContinue">@T["and continue"]</button>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
@@ -1,6 +1,5 @@
 @{
     var returnUrl = Context.Request.Query["returnUrl"];
-    var contentItemId = Context.Request.RouteValues["contentItemId"]?.ToString();
 }
 
 @if (string.IsNullOrWhiteSpace(returnUrl))
@@ -15,10 +14,7 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
-            @if (string.IsNullOrEmpty(contentItemId))
-            {
-                <button class="dropdown-item draft-new" type="submit" name="submit.Save" value="submit.SaveAndNew">@T["and new"]</button>
-            }
+            <button class="dropdown-item draft-new" type="submit" name="submit.Save" value="submit.SaveAndNew">@T["and new"]</button>
             <button class="dropdown-item draft-continue" type="submit" name="submit.Save" value="submit.SaveAndContinue">@T["and continue"]</button>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
@@ -1,5 +1,6 @@
 @{
     var returnUrl = Context.Request.Query["returnUrl"];
+    var contentItemId = Context.Request.RouteValues["contentItemId"]?.ToString();
 }
 
 @if (string.IsNullOrWhiteSpace(returnUrl))
@@ -14,6 +15,10 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
+            @if (string.IsNullOrEmpty(contentItemId))
+            {
+                <button class="dropdown-item draft-create" type="submit" name="submit.Save" value="submit.SaveAndCreate">@T["and create"]</button>
+            }
             <button class="dropdown-item draft-continue" type="submit" name="submit.Save" value="submit.SaveAndContinue">@T["and continue"]</button>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
@@ -17,7 +17,7 @@ else
         <div class="dropdown-menu">
             @if (string.IsNullOrEmpty(contentItemId))
             {
-                <button class="dropdown-item draft-create" type="submit" name="submit.Save" value="submit.SaveAndCreate">@T["and create"]</button>
+                <button class="dropdown-item draft-new" type="submit" name="submit.Save" value="submit.SaveAndNew">@T["and new"]</button>
             }
             <button class="dropdown-item draft-continue" type="submit" name="submit.Save" value="submit.SaveAndContinue">@T["and continue"]</button>
         </div>


### PR DESCRIPTION
This is a small and handy addition that allows the editor to **Save / Publish**, then **Create**, instead of doing two clicks: **Publish / Save** + **New**

<img width="541" height="157" alt="Screenshot 2026-08-16 090258" src="https://github.com/user-attachments/assets/5996a8f8-e392-4d5e-b2cf-aac7266fb39c" />

<img width="482" height="147" alt="Screenshot 2026-08-16 090318" src="https://github.com/user-attachments/assets/db088a7b-e1f7-414f-b1ba-d5b35eedd745" />
