### PR TITLE
#19664: Fix: rename static field to follow naming convention.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationSettings.cs
@@ -30,7 +30,7 @@ public class OpenIdApplicationSettings
 
 internal static class OpenIdApplicationExtensions
 {
-    internal static readonly string[] _separator = [" ", ","];
+    internal static readonly string[] s_separator = [" ", ","];
 
     public static async Task UpdateDescriptorFromSettings(this IOpenIdApplicationManager _applicationManager, OpenIdApplicationSettings model, object application = null)
     {
@@ -236,7 +236,7 @@ internal static class OpenIdApplicationExtensions
 
         descriptor.PostLogoutRedirectUris.Clear();
         foreach (var uri in
-            (from uri in model.PostLogoutRedirectUris?.Split(_separator, StringSplitOptions.RemoveEmptyEntries) ?? []
+            (from uri in model.PostLogoutRedirectUris?.Split(s_separator, StringSplitOptions.RemoveEmptyEntries) ?? []
              select new Uri(uri, UriKind.Absolute)))
         {
             descriptor.PostLogoutRedirectUris.Add(uri);
@@ -244,7 +244,7 @@ internal static class OpenIdApplicationExtensions
 
         descriptor.RedirectUris.Clear();
         foreach (var uri in
-           (from uri in model.RedirectUris?.Split(_separator, StringSplitOptions.RemoveEmptyEntries) ?? []
+           (from uri in model.RedirectUris?.Split(s_separator, StringSplitOptions.RemoveEmptyEntries) ?? []
             select new Uri(uri, UriKind.Absolute)))
         {
             descriptor.RedirectUris.Add(uri);


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

Asked Copilot to take a look and see if it could find any other fields that needed to be renamed. I didn't think renaming things like `public static TypeHere XYZ => { ... }` was worth renaming, since that seems more like a method posing as a property than an actual field.

That only left this one thing, so here's a PR for it.