### PR TITLE
Fix menu authorization semantics

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
@@ -1,11 +1,18 @@
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
+using OrchardCore.Contents;
+using OrchardCore.Contents.Security;
 using OrchardCore.Navigation;
+using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Menu;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
+    private static readonly Permission s_listMenuContent = ContentTypePermissionsHelper.CreateDynamicPermission(
+        ContentTypePermissionsHelper.PermissionTemplates[CommonPermissions.ListContent.Name],
+        "Menu");
+
     private static readonly RouteValueDictionary s_routeValues = new()
     {
         { "contentTypeId", "Menu" },
@@ -26,7 +33,8 @@ public sealed class AdminMenu : AdminNavigationProvider
         builder
             .Add(S["Content"], design => design
                 .Add(S["Menus"], S["Menus"].PrefixPosition(), menus => menus
-                    .Permission(Permissions.ManageMenu)
+                    .Permission(s_listMenuContent)
+                    .Resource("Menu")
                     .Action("List", "Admin", s_routeValues)
                     .LocalNav()
                 )

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Permissions.cs
@@ -1,10 +1,16 @@
+using OrchardCore.Contents;
+using OrchardCore.Contents.Security;
 using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Menu;
 
 public sealed class Permissions : IPermissionProvider
 {
-    public static readonly Permission ManageMenu = new("ManageMenu", "Manage menus");
+    private static readonly Permission s_editMenuContent = ContentTypePermissionsHelper.CreateDynamicPermission(
+        ContentTypePermissionsHelper.PermissionTemplates[CommonPermissions.EditContent.Name],
+        "Menu");
+
+    public static readonly Permission ManageMenu = new("ManageMenu", "Manage menus", [s_editMenuContent]);
 
     private readonly IEnumerable<Permission> _allPermissions =
     [

--- a/src/docs/reference/modules/Menu/README.md
+++ b/src/docs/reference/modules/Menu/README.md
@@ -1,5 +1,7 @@
 # Menu (`OrchardCore.Menu`)
 
+The **Menus** admin navigation item is available to users who can list `Menu` content items. The `Edit_Menu` content-type permission also grants `ManageMenu`, allowing users who can edit menus to manage their menu items.
+
 ## Rendering Menus
 
 Menus can be rendered in your theme using either Razor tag helpers or Liquid. This section describes how to render a menu on the frontend of your site.

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/AdminNavigationTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/AdminNavigationTests.cs
@@ -5,6 +5,8 @@ namespace OrchardCore.Tests.Functional.Tests.Cms;
 
 public sealed class AdminNavigationTests : CmsTestBase<BlogFixture>, IClassFixture<BlogFixture>
 {
+    private const string Password = "Orchard1!";
+
     public AdminNavigationTests(BlogFixture fixture) : base(fixture) { }
 
     [Fact]
@@ -173,5 +175,133 @@ public sealed class AdminNavigationTests : CmsTestBase<BlogFixture>, IClassFixtu
         await Assertions.Expect(activeMenusItem).ToHaveCountAsync(0);
 
         await page.CloseAsync();
+    }
+
+    [Fact]
+    public async Task MenuPermissions_EditorCanManageMenuItemsWithoutPublishing()
+    {
+        const string menuEditorRole = "MenuEditor";
+        const string noMenuAccessRole = "NoMenuAccess";
+        const string menuEditorUser = "menu-editor";
+        const string noMenuAccessUser = "no-menu-access";
+
+        var page = await Fixture.CreatePageAsync();
+        await page.LoginAsync();
+
+        await page.GotoAndAssertOkAsync("/Admin/ContentTypes/Edit/Menu");
+        await page.Locator("#ContentTypeDefinition_Securable").CheckAsync();
+        await page.ClickSaveAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await CreateRoleWithPermissionsAsync(
+            page,
+            menuEditorRole,
+            "AccessAdminPanel",
+            "ListContent_Menu",
+            "Edit_Menu");
+        await CreateRoleWithPermissionsAsync(page, noMenuAccessRole, "AccessAdminPanel");
+
+        await UserHelper.CreateUserAsync(page, string.Empty, menuEditorUser, "menu-editor@test.com", Password, menuEditorRole);
+        await UserHelper.CreateUserAsync(page, string.Empty, noMenuAccessUser, "no-menu-access@test.com", Password, noMenuAccessRole);
+
+        await UserHelper.LoginAsAsync(page, string.Empty, menuEditorUser, Password);
+        await page.GotoAndAssertOkAsync("/Admin");
+
+        var menusLink = page.Locator("#adminMenu a[href^=\"/Admin/Contents/ContentItems/Menu\"]");
+        await Assertions.Expect(menusLink).ToHaveCountAsync(1);
+
+        await page.GetByRole(AriaRole.Button, new() { Name = "Content", Exact = true }).ClickAsync();
+        await Assertions.Expect(menusLink).ToBeVisibleAsync();
+
+        await page.GotoAndAssertOkAsync("/Admin/Contents/ContentItems/Menu");
+        await Assertions.Expect(page.GetByRole(AriaRole.Heading, new() { Name = "Manage Content" })).ToBeVisibleAsync();
+
+        var editUrl = await page.GetByRole(AriaRole.Link, new() { Name = "Edit", Exact = true })
+            .First
+            .GetAttributeAsync("href");
+
+        Assert.NotNull(editUrl);
+        await page.GotoAndAssertOkAsync(editUrl);
+
+        var addMenuItemUrl = await page.Locator("a[href*='/Admin/Menu/Create/LinkMenuItem']")
+            .First
+            .GetAttributeAsync("href");
+
+        Assert.NotNull(addMenuItemUrl);
+        await page.GotoAndAssertOkAsync(addMenuItemUrl);
+        await Assertions.Expect(page.GetByRole(AriaRole.Heading, new() { Name = "New Link Menu Item" })).ToBeVisibleAsync();
+
+        await page.GotoAndAssertOkAsync("/Admin/Contents/ContentItems/Menu");
+        await Assertions.Expect(page.Locator("form[action*='/Publish']")).ToHaveCountAsync(0);
+        await Assertions.Expect(page.Locator("form[action*='/Delete']")).ToHaveCountAsync(0);
+
+        var contentItemId = new Uri(new Uri(Fixture.BaseUrl), editUrl)
+            .Segments
+            .SkipWhile(segment => !string.Equals(segment, "ContentItems/", StringComparison.Ordinal))
+            .Skip(1)
+            .First()
+            .TrimEnd('/');
+
+        await SubmitContentActionAsync(page, $"/Admin/Contents/ContentItems/{contentItemId}/Publish");
+        Assert.Contains("/Error/403", page.Url, StringComparison.OrdinalIgnoreCase);
+
+        await UserHelper.LoginAsAsync(page, string.Empty, noMenuAccessUser, Password);
+        await page.GotoAndAssertOkAsync("/Admin");
+        await Assertions.Expect(page.Locator("#adminMenu a[href^=\"/Admin/Contents/ContentItems/Menu\"]")).ToHaveCountAsync(0);
+
+        await page.GotoAsync("/Admin/Contents/ContentItems/Menu");
+        Assert.Contains("/Error/403", page.Url, StringComparison.OrdinalIgnoreCase);
+
+        await page.CloseAsync();
+    }
+
+    private static async Task CreateRoleWithPermissionsAsync(
+        IPage page,
+        string roleName,
+        params string[] permissionNames)
+    {
+        await page.GotoAndAssertOkAsync("/Admin/Roles/Create");
+        await page.Locator("input[name='RoleName']").FillAsync(roleName);
+        await page.ClickCreateAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+        await page.GotoAndAssertOkAsync($"/Admin/Roles/Edit/{Uri.EscapeDataString(roleName)}");
+
+        foreach (var permissionName in permissionNames)
+        {
+            var permission = page.Locator($"input[id='Checkbox.{permissionName}']");
+            await permission.WaitForAsync(new() { State = WaitForSelectorState.Attached });
+            await permission.CheckAsync();
+        }
+
+        await page.ClickSaveAsync();
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    private static async Task SubmitContentActionAsync(IPage page, string action)
+    {
+        await Task.WhenAll(
+            page.WaitForURLAsync("**/Error/403**"),
+            page.EvaluateAsync(
+                """
+                action => {
+                    const token = document.querySelector('input[name="__RequestVerificationToken"]').value;
+                    const form = document.createElement("form");
+                    form.method = "post";
+                    form.action = action;
+
+                    const tokenInput = document.createElement("input");
+                    tokenInput.type = "hidden";
+                    tokenInput.name = "__RequestVerificationToken";
+                    tokenInput.value = token;
+
+                    form.appendChild(tokenInput);
+                    document.body.appendChild(form);
+                    form.submit();
+                }
+                """,
+                action));
+
+        await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Menu/MenuPermissionsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Menu/MenuPermissionsTests.cs
@@ -1,0 +1,79 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Localization;
+using Moq;
+using OrchardCore.Contents;
+using OrchardCore.Contents.Security;
+using OrchardCore.Menu;
+using OrchardCore.Navigation;
+using OrchardCore.Security;
+using OrchardCore.Security.Permissions;
+using MenuAdminMenu = OrchardCore.Menu.AdminMenu;
+using MenuPermissions = OrchardCore.Menu.Permissions;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Menu;
+
+public class MenuPermissionsTests
+{
+    [Fact]
+    public async Task BuildNavigationAsync_ListMenuPermission_UsesMenuResource()
+    {
+        var localizer = new Mock<IStringLocalizer<MenuAdminMenu>>();
+        localizer
+            .Setup(x => x[It.IsAny<string>()])
+            .Returns((string name) => new LocalizedString(name, name));
+
+        var builder = new NavigationBuilder();
+
+        await new MenuAdminMenu(localizer.Object).BuildNavigationAsync(NavigationConstants.AdminId, builder);
+
+        var contentMenu = Assert.Single(builder.Build());
+        var menusItem = Assert.Single(contentMenu.Items);
+        var permission = Assert.Single(menusItem.Permissions);
+
+        Assert.Equal("ListContent_Menu", permission.Name);
+        Assert.Equal("Menu", menusItem.Resource);
+    }
+
+    [Theory]
+    [InlineData(nameof(CommonPermissions.EditContent))]
+    [InlineData("Edit_Menu")]
+    public void ManageMenu_EditPermission_GrantsManageMenu(string grantedPermission)
+    {
+        var claims = new[]
+        {
+            new Claim(Permission.ClaimType, grantedPermission),
+        };
+
+        var permissionGrantingService = new DefaultPermissionGrantingService();
+
+        Assert.True(permissionGrantingService.IsGranted(
+            new PermissionRequirement(MenuPermissions.ManageMenu),
+            claims));
+    }
+
+    [Theory]
+    [InlineData(nameof(CommonPermissions.DeleteContent))]
+    [InlineData(nameof(CommonPermissions.PublishContent))]
+    [InlineData(nameof(CommonPermissions.EditContentOwner))]
+    public void EditMenuPermission_UnrelatedOperation_RemainsDenied(string permissionName)
+    {
+        var editMenu = CreateMenuPermission(CommonPermissions.EditContent);
+        var claims = new[]
+        {
+            new Claim(Permission.ClaimType, editMenu.Name),
+        };
+
+        var permissionGrantingService = new DefaultPermissionGrantingService();
+        var requiredPermission = CreateMenuPermission(
+            ContentTypePermissionsHelper.PermissionTemplates[permissionName]);
+
+        Assert.False(permissionGrantingService.IsGranted(
+            new PermissionRequirement(requiredPermission),
+            claims));
+    }
+
+    private static Permission CreateMenuPermission(Permission permission)
+        => ContentTypePermissionsHelper.CreateDynamicPermission(
+            ContentTypePermissionsHelper.ConvertToDynamicPermission(permission) ?? permission,
+            "Menu");
+}


### PR DESCRIPTION
Fixes #19737

## Summary

- authorize the **Content → Menus** navigation item with `ListContent_Menu` against the `Menu` resource, matching the generic Contents route
- make `Edit_Menu` and generic `EditContent` imply `ManageMenu` through the existing permission graph
- preserve independent publish, delete, and owner-change permissions
- add focused unit and browser-functional tests and document the behavior

## Verification

- `dotnet build src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj -c Debug -f net10.0 --no-restore -p:NuGetAudit=false --nologo -v:minimal`
- `dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj -f net10.0 --no-restore -p:NuGetAudit=false --filter-class OrchardCore.Tests.Modules.OrchardCore.Menu.MenuPermissionsTests` (6 passed)
- `dotnet test test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj -f net10.0 --no-build --no-restore -p:NuGetAudit=false --filter-method '*MenuPermissions_EditorCanManageMenuItemsWithoutPublishing'` (1 passed)

The functional test provisions editor and unauthorized roles and verifies the Menus navigation, generic Menu list/editor, specialized menu-item editor, forbidden publish action, and denied navigation/direct access for the unauthorized user.