### PR TITLE
Use IOptionsMonitor<> for Email Options

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Drivers/AzureEmailSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Drivers/AzureEmailSettingsDisplayDriver.cs
@@ -8,11 +8,12 @@ using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Email;
 using OrchardCore.Email.Azure;
+using OrchardCore.Email.Azure.Models;
 using OrchardCore.Email.Azure.Services;
 using OrchardCore.Email.Azure.ViewModels;
 using OrchardCore.Email.Services;
 using OrchardCore.Entities;
-using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Options;
 using OrchardCore.Mvc.ModelBinding;
 using OrchardCore.Settings;
 
@@ -20,7 +21,7 @@ namespace OrchardCore.Azure.Email.Drivers;
 
 public sealed class AzureEmailSettingsDisplayDriver : SiteDisplayDriver<AzureEmailSettings>
 {
-    private readonly IShellReleaseManager _shellReleaseManager;
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
     private readonly IDataProtectionProvider _dataProtectionProvider;
@@ -29,14 +30,14 @@ public sealed class AzureEmailSettingsDisplayDriver : SiteDisplayDriver<AzureEma
     internal readonly IStringLocalizer S;
 
     public AzureEmailSettingsDisplayDriver(
-        IShellReleaseManager shellReleaseManager,
+        IOptionsUpdateNotifier optionsUpdateNotifier,
         IHttpContextAccessor httpContextAccessor,
         IAuthorizationService authorizationService,
         IDataProtectionProvider dataProtectionProvider,
         IEmailAddressValidator emailValidator,
         IStringLocalizer<AzureEmailSettingsDisplayDriver> stringLocalizer)
     {
-        _shellReleaseManager = shellReleaseManager;
+        _optionsUpdateNotifier = optionsUpdateNotifier;
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
         _dataProtectionProvider = dataProtectionProvider;
@@ -138,7 +139,10 @@ public sealed class AzureEmailSettingsDisplayDriver : SiteDisplayDriver<AzureEma
 
             if (hasChanges)
             {
-                _shellReleaseManager.RequestRelease();
+                _optionsUpdateNotifier
+                    .RequestUpdate<AzureEmailOptions>()
+                    .RequestUpdate<EmailProviderOptions>()
+                    .RequestUpdate<EmailOptions>();
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProvider.cs
@@ -10,10 +10,10 @@ public class AzureEmailProvider : AzureEmailProviderBase
     public const string TechnicalName = "Azure";
 
     public AzureEmailProvider(
-        IOptions<AzureEmailOptions> options,
+        IOptionsMonitor<AzureEmailOptions> options,
         ILogger<AzureEmailProvider> logger,
         IStringLocalizer<AzureEmailProvider> stringLocalizer)
-        : base(options.Value, logger, stringLocalizer)
+        : base(() => options.CurrentValue, logger, stringLocalizer)
     {
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProvider.cs
@@ -5,7 +5,7 @@ using OrchardCore.Email.Azure.Models;
 
 namespace OrchardCore.Email.Azure.Services;
 
-public class AzureEmailProvider : AzureEmailProviderBase
+public class AzureEmailProvider : AzureEmailProviderBase<AzureEmailOptions>
 {
     public const string TechnicalName = "Azure";
 
@@ -13,7 +13,7 @@ public class AzureEmailProvider : AzureEmailProviderBase
         IOptionsMonitor<AzureEmailOptions> options,
         ILogger<AzureEmailProvider> logger,
         IStringLocalizer<AzureEmailProvider> stringLocalizer)
-        : base(() => options.CurrentValue, logger, stringLocalizer)
+        : base(options, logger, stringLocalizer)
     {
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProviderBase.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProviderBase.cs
@@ -3,12 +3,14 @@ using Azure;
 using Azure.Communication.Email;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OrchardCore.Email.Azure.Models;
 using OrchardCore.Infrastructure;
 
 namespace OrchardCore.Email.Azure.Services;
 
-public abstract class AzureEmailProviderBase : IEmailProvider
+public abstract class AzureEmailProviderBase<TOptions> : IEmailProvider
+    where TOptions : AzureEmailOptions
 {
     // Common supported file extensions and their corresponding MIME types for email attachments
     // using Azure Communication Services Email.
@@ -79,8 +81,9 @@ public abstract class AzureEmailProviderBase : IEmailProvider
         { ".zip", "application/zip" },
     };
 
-    private readonly Func<AzureEmailOptions> _optionsAccessor;
+    private readonly IOptionsMonitor<TOptions> _optionsMonitor;
     private readonly ILogger _logger;
+    private readonly Lock _emailClientLock = new();
 
     private EmailClient _emailClient;
     private string _emailClientConnectionString;
@@ -88,11 +91,11 @@ public abstract class AzureEmailProviderBase : IEmailProvider
     protected readonly IStringLocalizer S;
 
     public AzureEmailProviderBase(
-        Func<AzureEmailOptions> optionsAccessor,
+        IOptionsMonitor<TOptions> optionsMonitor,
         ILogger logger,
         IStringLocalizer stringLocalizer)
     {
-        _optionsAccessor = optionsAccessor;
+        _optionsMonitor = optionsMonitor;
         _logger = logger;
         S = stringLocalizer;
     }
@@ -109,7 +112,7 @@ public abstract class AzureEmailProviderBase : IEmailProvider
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var providerOptions = _optionsAccessor();
+        var providerOptions = _optionsMonitor.CurrentValue;
 
         if (!providerOptions.IsEnabled)
         {
@@ -158,15 +161,8 @@ public abstract class AzureEmailProviderBase : IEmailProvider
 
         try
         {
-            if (!string.Equals(_emailClientConnectionString, providerOptions.ConnectionString, StringComparison.Ordinal))
-            {
-                _emailClient = null;
-                _emailClientConnectionString = providerOptions.ConnectionString;
-            }
-
-            _emailClient ??= new EmailClient(providerOptions.ConnectionString);
-
-            var result = await _emailClient.SendAsync(WaitUntil.Completed, emailMessage, cancellationToken);
+            var emailClient = GetOrCreateEmailClient(providerOptions.ConnectionString);
+            var result = await emailClient.SendAsync(WaitUntil.Completed, emailMessage, cancellationToken);
 
             if (result.HasValue)
             {
@@ -181,6 +177,23 @@ public abstract class AzureEmailProviderBase : IEmailProvider
 
             // IMPORTANT: Do not expose ex.Message as it could contain the connection string in a raw format!
             return Result.Failed(S["An error occurred while sending an email."]);
+        }
+    }
+
+    protected virtual EmailClient CreateEmailClient(string connectionString) => new(connectionString);
+
+    protected EmailClient GetOrCreateEmailClient(string connectionString)
+    {
+        lock (_emailClientLock)
+        {
+            if (!string.Equals(_emailClientConnectionString, connectionString, StringComparison.Ordinal))
+            {
+                // Recreate the client so it uses the latest connection string after options change.
+                _emailClient = CreateEmailClient(connectionString);
+                _emailClientConnectionString = connectionString;
+            }
+
+            return _emailClient;
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProviderBase.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProviderBase.cs
@@ -79,19 +79,20 @@ public abstract class AzureEmailProviderBase : IEmailProvider
         { ".zip", "application/zip" },
     };
 
-    private readonly AzureEmailOptions _providerOptions;
+    private readonly Func<AzureEmailOptions> _optionsAccessor;
     private readonly ILogger _logger;
 
     private EmailClient _emailClient;
+    private string _emailClientConnectionString;
 
     protected readonly IStringLocalizer S;
 
     public AzureEmailProviderBase(
-        AzureEmailOptions options,
+        Func<AzureEmailOptions> optionsAccessor,
         ILogger logger,
         IStringLocalizer stringLocalizer)
     {
-        _providerOptions = options;
+        _optionsAccessor = optionsAccessor;
         _logger = logger;
         S = stringLocalizer;
     }
@@ -108,13 +109,15 @@ public abstract class AzureEmailProviderBase : IEmailProvider
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        if (!_providerOptions.IsEnabled)
+        var providerOptions = _optionsAccessor();
+
+        if (!providerOptions.IsEnabled)
         {
             return Result.Failed(S["The Azure Email Provider is disabled."]);
         }
 
         var senderAddress = string.IsNullOrWhiteSpace(message.From)
-            ? _providerOptions.DefaultSender
+            ? providerOptions.DefaultSender
             : message.From;
 
         if (_logger.IsEnabled(LogLevel.Debug))
@@ -155,7 +158,13 @@ public abstract class AzureEmailProviderBase : IEmailProvider
 
         try
         {
-            _emailClient ??= new EmailClient(_providerOptions.ConnectionString);
+            if (!string.Equals(_emailClientConnectionString, providerOptions.ConnectionString, StringComparison.Ordinal))
+            {
+                _emailClient = null;
+                _emailClientConnectionString = providerOptions.ConnectionString;
+            }
+
+            _emailClient ??= new EmailClient(providerOptions.ConnectionString);
 
             var result = await _emailClient.SendAsync(WaitUntil.Completed, emailMessage, cancellationToken);
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProviderOptionsConfigurations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/AzureEmailProviderOptionsConfigurations.cs
@@ -6,22 +6,22 @@ namespace OrchardCore.Email.Azure.Services;
 
 public sealed class AzureEmailProviderOptionsConfigurations : IConfigureOptions<EmailProviderOptions>
 {
-    private readonly AzureEmailOptions _azureOptions;
-    private readonly DefaultAzureEmailOptions _defaultAzureOptions;
+    private readonly IOptionsMonitor<AzureEmailOptions> _azureOptions;
+    private readonly IOptionsMonitor<DefaultAzureEmailOptions> _defaultAzureOptions;
 
     public AzureEmailProviderOptionsConfigurations(
-        IOptions<AzureEmailOptions> azureOptions,
-        IOptions<DefaultAzureEmailOptions> defaultAzureOptions)
+        IOptionsMonitor<AzureEmailOptions> azureOptions,
+        IOptionsMonitor<DefaultAzureEmailOptions> defaultAzureOptions)
     {
-        _azureOptions = azureOptions.Value;
-        _defaultAzureOptions = defaultAzureOptions.Value;
+        _azureOptions = azureOptions;
+        _defaultAzureOptions = defaultAzureOptions;
     }
 
     public void Configure(EmailProviderOptions options)
     {
         ConfigureTenantProvider(options);
 
-        if (_defaultAzureOptions.IsEnabled)
+        if (_defaultAzureOptions.CurrentValue.IsEnabled)
         {
             // Only configure the default provider, if settings are provided by the configuration provider.
             ConfigureDefaultProvider(options);
@@ -32,7 +32,7 @@ public sealed class AzureEmailProviderOptionsConfigurations : IConfigureOptions<
     {
         var typeOptions = new EmailProviderTypeOptions(typeof(AzureEmailProvider))
         {
-            IsEnabled = _azureOptions.IsEnabled,
+            IsEnabled = _azureOptions.CurrentValue.IsEnabled,
         };
 
         options.TryAddProvider(AzureEmailProvider.TechnicalName, typeOptions);

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/DefaultAzureEmailProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/DefaultAzureEmailProvider.cs
@@ -5,15 +5,15 @@ using OrchardCore.Email.Azure.Models;
 
 namespace OrchardCore.Email.Azure.Services;
 
-public class DefaultAzureEmailProvider : AzureEmailProviderBase
+public class DefaultAzureEmailProvider : AzureEmailProviderBase<DefaultAzureEmailOptions>
 {
     public const string TechnicalName = "DefaultAzure";
 
     public DefaultAzureEmailProvider(
-        IOptions<DefaultAzureEmailOptions> options,
+        IOptionsMonitor<DefaultAzureEmailOptions> options,
         ILogger<DefaultAzureEmailProvider> logger,
         IStringLocalizer<DefaultAzureEmailProvider> stringLocalizer)
-        : base(() => options.Value, logger, stringLocalizer)
+        : base(options, logger, stringLocalizer)
     {
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/DefaultAzureEmailProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Services/DefaultAzureEmailProvider.cs
@@ -13,7 +13,7 @@ public class DefaultAzureEmailProvider : AzureEmailProviderBase
         IOptions<DefaultAzureEmailOptions> options,
         ILogger<DefaultAzureEmailProvider> logger,
         IStringLocalizer<DefaultAzureEmailProvider> stringLocalizer)
-        : base(options.Value, logger, stringLocalizer)
+        : base(() => options.Value, logger, stringLocalizer)
     {
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Startup.cs
@@ -21,6 +21,8 @@ public sealed class Startup
 
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddSignalOptionsChangeTokenSource<AzureEmailOptions>();
+
         services.AddTransient<IConfigureOptions<AzureEmailOptions>, AzureEmailOptionsConfiguration>();
 
         services.AddEmailProviderOptionsConfiguration<AzureEmailProviderOptionsConfigurations>()

--- a/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
@@ -15,8 +15,8 @@ public sealed class AdminController : Controller
 {
     private readonly IAuthorizationService _authorizationService;
     private readonly INotifier _notifier;
-    private readonly EmailOptions _emailOptions;
-    private readonly EmailProviderOptions _providerOptions;
+    private readonly IOptionsMonitor<EmailOptions> _emailOptions;
+    private readonly IOptionsMonitor<EmailProviderOptions> _providerOptions;
     private readonly IEmailService _emailService;
     private readonly IEmailProviderResolver _emailProviderResolver;
 
@@ -26,8 +26,8 @@ public sealed class AdminController : Controller
     public AdminController(
         IAuthorizationService authorizationService,
         INotifier notifier,
-        IOptions<EmailProviderOptions> providerOptions,
-        IOptions<EmailOptions> emailOptions,
+        IOptionsMonitor<EmailProviderOptions> providerOptions,
+        IOptionsMonitor<EmailOptions> emailOptions,
         IEmailService emailService,
         IEmailProviderResolver emailProviderResolver,
         IHtmlLocalizer<AdminController> htmlLocalizer,
@@ -35,8 +35,8 @@ public sealed class AdminController : Controller
     {
         _authorizationService = authorizationService;
         _notifier = notifier;
-        _emailOptions = emailOptions.Value;
-        _providerOptions = providerOptions.Value;
+        _emailOptions = emailOptions;
+        _providerOptions = providerOptions;
         _emailService = emailService;
         _emailProviderResolver = emailProviderResolver;
         H = htmlLocalizer;
@@ -53,7 +53,7 @@ public sealed class AdminController : Controller
 
         var model = new EmailTestViewModel()
         {
-            Provider = _emailOptions.DefaultProviderName,
+            Provider = _emailOptions.CurrentValue.DefaultProviderName,
         };
 
         await PopulateModelAsync(model);
@@ -136,7 +136,7 @@ public sealed class AdminController : Controller
     {
         var options = new List<SelectListItem>();
 
-        foreach (var entry in _providerOptions.Providers)
+        foreach (var entry in _providerOptions.CurrentValue.Providers)
         {
             if (!entry.Value.IsEnabled)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Email/Drivers/EmailSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Drivers/EmailSettingsDisplayDriver.cs
@@ -8,7 +8,7 @@ using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Email.Services;
 using OrchardCore.Email.ViewModels;
-using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Options;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Email.Drivers;
@@ -17,10 +17,10 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
-    private readonly EmailOptions _emailOptions;
+    private readonly IOptionsMonitor<EmailOptions> _emailOptions;
     private readonly IEmailProviderResolver _emailProviderResolver;
-    private readonly IShellReleaseManager _shellReleaseManager;
-    private readonly EmailProviderOptions _emailProviders;
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
+    private readonly IOptionsMonitor<EmailProviderOptions> _emailProviders;
 
     internal readonly IStringLocalizer S;
 
@@ -30,20 +30,21 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
     public EmailSettingsDisplayDriver(
         IHttpContextAccessor httpContextAccessor,
         IAuthorizationService authorizationService,
-        IOptions<EmailProviderOptions> emailProviders,
-        IOptions<EmailOptions> emailOptions,
+        IOptionsMonitor<EmailProviderOptions> emailProviders,
+        IOptionsMonitor<EmailOptions> emailOptions,
         IEmailProviderResolver emailProviderResolver,
-        IShellReleaseManager shellReleaseManager,
+        IOptionsUpdateNotifier optionsUpdateNotifier,
         IStringLocalizer<EmailSettingsDisplayDriver> stringLocalizer)
     {
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
-        _emailOptions = emailOptions.Value;
+        _emailOptions = emailOptions;
         _emailProviderResolver = emailProviderResolver;
-        _emailProviders = emailProviders.Value;
-        _shellReleaseManager = shellReleaseManager;
+        _emailProviders = emailProviders;
+        _optionsUpdateNotifier = optionsUpdateNotifier;
         S = stringLocalizer;
     }
+
     public override async Task<IDisplayResult> EditAsync(ISite site, EmailSettings settings, BuildEditorContext context)
     {
         if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext?.User, EmailPermissions.ManageEmailSettings))
@@ -51,11 +52,9 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
             return null;
         }
 
-        context.AddTenantReloadWarningWrapper();
-
         return Initialize<EmailSettingsViewModel>("EmailSettings_Edit", async model =>
         {
-            model.DefaultProvider = settings.DefaultProviderName ?? _emailOptions.DefaultProviderName;
+            model.DefaultProvider = settings.DefaultProviderName ?? _emailOptions.CurrentValue.DefaultProviderName;
             model.Providers = await GetProviderOptionsAsync();
         }).Location("Content:1#Providers")
         .OnGroup(SettingsGroupId);
@@ -76,7 +75,7 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
         {
             settings.DefaultProviderName = model.DefaultProvider;
 
-            _shellReleaseManager.RequestRelease();
+            _optionsUpdateNotifier.RequestUpdate<EmailOptions>();
         }
 
         return await EditAsync(site, settings, context);
@@ -86,7 +85,7 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
     {
         var options = new List<SelectListItem>();
 
-        foreach (var entry in _emailProviders.Providers)
+        foreach (var entry in _emailProviders.CurrentValue.Providers)
         {
             if (!entry.Value.IsEnabled)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Email/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Startup.cs
@@ -3,6 +3,7 @@ using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Email.Drivers;
 using OrchardCore.Email.Migrations;
+using OrchardCore.Email.Services;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
@@ -14,6 +15,8 @@ public sealed class Startup : StartupBase
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddEmailServices()
+            .AddSignalOptionsChangeTokenSource<EmailOptions>()
+            .AddSignalOptionsChangeTokenSource<EmailProviderOptions>()
             .AddSiteDisplayDriver<EmailSettingsDisplayDriver>()
             .AddSiteSettingsPermission(EmailSettings.GroupId, EmailPermissions.ManageEmailSettings)
             .AddPermissionProvider<Permissions>()

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/EmailSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/EmailSettings.Edit.cshtml
@@ -1,10 +1,7 @@
-@using Microsoft.Extensions.Options
 @using OrchardCore.Email.Services
 @using OrchardCore.Email.ViewModels
 
 @model EmailSettingsViewModel
-
-@inject IOptions<EmailProviderOptions> EmailProviderOptions
 
 @if (Model.Providers.Count == 0)
 {

--- a/src/OrchardCore/OrchardCore.Abstractions/Options/IOptionsUpdateNotifier.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Options/IOptionsUpdateNotifier.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Options;
+
+namespace OrchardCore.Environment.Options;
+
+/// <summary>
+/// Queues an options invalidation request so <see cref="IOptionsMonitor{TOptions}"/>
+/// instances that are wired to Orchard Core's signal-backed change tokens are refreshed
+/// after the current shell scope commits successfully.
+/// </summary>
+public interface IOptionsUpdateNotifier
+{
+    /// <summary>
+    /// Queues an update notification for the specified options instance.
+    /// The options type must have a corresponding <see cref="IOptionsChangeTokenSource{TOptions}"/>
+    /// registration that listens to Orchard Core's update signal for the invalidation to be observed.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type to invalidate.</typeparam>
+    /// <param name="name">The named options instance to invalidate.</param>
+    IOptionsUpdateNotifier RequestUpdate<TOptions>(string name = "") where TOptions : class;
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Options/OptionsServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Options/OptionsServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Options;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class OptionsServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers Orchard Core's signal-backed <see cref="IOptionsChangeTokenSource{TOptions}"/>
+    /// for the default named options instance so the standard <see cref="IOptionsMonitor{TOptions}"/>
+    /// observes post-commit update notifications.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type to observe.</typeparam>
+    public static IServiceCollection AddSignalOptionsChangeTokenSource<TOptions>(this IServiceCollection services)
+        where TOptions : class
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<TOptions>, SignalOptionsChangeTokenSource<TOptions>>());
+
+        return services;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Options/OptionsUpdateSignal.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Options/OptionsUpdateSignal.cs
@@ -1,0 +1,25 @@
+namespace OrchardCore.Environment.Options;
+
+/// <summary>
+/// Builds the distributed signal key used to invalidate a specific options type and name.
+/// </summary>
+public static class OptionsUpdateSignal
+{
+    private const string Prefix = "OrchardCore.Environment.Options.Update:";
+
+    /// <summary>
+    /// Gets the distributed signal key for the specified options type and name.
+    /// </summary>
+    /// <param name="optionsType">The options type to invalidate.</param>
+    /// <param name="name">The named options instance to invalidate.</param>
+    public static string GetKey(Type optionsType, string name)
+    {
+        ArgumentNullException.ThrowIfNull(optionsType);
+
+        name ??= Microsoft.Extensions.Options.Options.DefaultName;
+
+        var typeName = optionsType.AssemblyQualifiedName ?? optionsType.FullName ?? optionsType.Name;
+
+        return $"{Prefix}{typeName.Length}:{typeName}:{name.Length}:{name}";
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Options/SignalOptionsChangeTokenSource.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Options/SignalOptionsChangeTokenSource.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.Environment.Cache;
+
+namespace OrchardCore.Environment.Options;
+
+/// <summary>
+/// Provides an Orchard Core distributed signal-backed <see cref="IOptionsChangeTokenSource{TOptions}"/>
+/// so the default <see cref="IOptionsMonitor{TOptions}"/> can refresh options after an update notification.
+/// </summary>
+/// <typeparam name="TOptions">The options type to observe.</typeparam>
+public sealed class SignalOptionsChangeTokenSource<TOptions> : IOptionsChangeTokenSource<TOptions>
+    where TOptions : class
+{
+    private readonly ISignal _signal;
+
+    /// <summary>
+    /// Creates a change-token source for the default options name.
+    /// </summary>
+    /// <param name="signal">The Orchard Core signal service.</param>
+    public SignalOptionsChangeTokenSource(ISignal signal)
+        : this(signal, Microsoft.Extensions.Options.Options.DefaultName)
+    {
+    }
+
+    /// <summary>
+    /// Creates a change-token source for the specified named options instance.
+    /// </summary>
+    /// <param name="signal">The Orchard Core signal service.</param>
+    /// <param name="name">The named options instance to observe.</param>
+    public SignalOptionsChangeTokenSource(ISignal signal, string name)
+    {
+        _signal = signal;
+        Name = name ?? Microsoft.Extensions.Options.Options.DefaultName;
+    }
+
+    /// <summary>
+    /// Gets the named options instance observed by this token source.
+    /// </summary>
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public IChangeToken GetChangeToken()
+        => _signal.GetToken(OptionsUpdateSignal.GetKey(typeof(TOptions), Name));
+}

--- a/src/OrchardCore/OrchardCore.Email.Core/Services/DefaultEmailProviderResolver.cs
+++ b/src/OrchardCore/OrchardCore.Email.Core/Services/DefaultEmailProviderResolver.cs
@@ -5,30 +5,33 @@ namespace OrchardCore.Email.Services;
 
 public class DefaultEmailProviderResolver : IEmailProviderResolver
 {
-    private readonly EmailOptions _emailOptions;
+    private readonly IOptionsMonitor<EmailOptions> _emailOptions;
     private readonly IServiceProvider _serviceProvider;
-    private readonly EmailProviderOptions _providerOptions;
+    private readonly IOptionsMonitor<EmailProviderOptions> _providerOptions;
 
     public DefaultEmailProviderResolver(
-        IOptions<EmailOptions> emailOptions,
-        IOptions<EmailProviderOptions> providerOptions,
+        IOptionsMonitor<EmailOptions> emailOptions,
+        IOptionsMonitor<EmailProviderOptions> providerOptions,
         IServiceProvider serviceProvider)
     {
-        _emailOptions = emailOptions.Value;
+        _emailOptions = emailOptions;
         _serviceProvider = serviceProvider;
-        _providerOptions = providerOptions.Value;
+        _providerOptions = providerOptions;
     }
 
     public ValueTask<IEmailProvider> GetAsync(string name = null)
     {
+        var emailOptions = _emailOptions.CurrentValue;
+        var providerOptions = _providerOptions.CurrentValue;
+
         if (string.IsNullOrEmpty(name))
         {
-            name = _emailOptions.DefaultProviderName;
+            name = emailOptions.DefaultProviderName;
         }
 
         if (!string.IsNullOrEmpty(name))
         {
-            if (_providerOptions.Providers.TryGetValue(name, out var providerType))
+            if (providerOptions.Providers.TryGetValue(name, out var providerType))
             {
                 return ValueTask.FromResult(_serviceProvider.CreateInstance<IEmailProvider>(providerType.Type));
             }

--- a/src/OrchardCore/OrchardCore.Email.Core/Services/EmailOptionsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.Email.Core/Services/EmailOptionsConfiguration.cs
@@ -6,22 +6,23 @@ namespace OrchardCore.Email.Services;
 public sealed class EmailOptionsConfiguration : IConfigureOptions<EmailOptions>
 {
     private readonly ISiteService _siteService;
-    private readonly EmailProviderOptions _emailProviderOptions;
+    private readonly IOptionsMonitor<EmailProviderOptions> _emailProviderOptions;
 
     public EmailOptionsConfiguration(
         ISiteService siteService,
-        IOptions<EmailProviderOptions> emailProviderOptions)
+        IOptionsMonitor<EmailProviderOptions> emailProviderOptions)
     {
         _siteService = siteService;
-        _emailProviderOptions = emailProviderOptions.Value;
+        _emailProviderOptions = emailProviderOptions;
     }
 
     public void Configure(EmailOptions options)
     {
         var emailSettings = _siteService.GetSettings<EmailSettings>();
+        var emailProviderOptions = _emailProviderOptions.CurrentValue;
 
         if (!string.IsNullOrEmpty(emailSettings.DefaultProviderName)
-            && _emailProviderOptions.Providers.TryGetValue(emailSettings.DefaultProviderName, out var provider)
+            && emailProviderOptions.Providers.TryGetValue(emailSettings.DefaultProviderName, out var provider)
             && provider.IsEnabled)
         {
             options.DefaultProviderName = emailSettings.DefaultProviderName;
@@ -29,13 +30,13 @@ public sealed class EmailOptionsConfiguration : IConfigureOptions<EmailOptions>
             return;
         }
 
-        if (_emailProviderOptions.Providers.Count > 0)
+        if (emailProviderOptions.Providers.Count > 0)
         {
-            options.DefaultProviderName = _emailProviderOptions.Providers
+            options.DefaultProviderName = emailProviderOptions.Providers
                 .Where(x => x.Value.IsEnabled)
                 .Select(x => x.Key)
                 .LastOrDefault()
-                ?? _emailProviderOptions.Providers.Keys.Last();
+                ?? emailProviderOptions.Providers.Keys.Last();
         }
     }
 }

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Environment.Shell.Descriptor.Models;
+using OrchardCore.Environment.Options;
 using OrchardCore.Extensions;
 using OrchardCore.Json;
 using OrchardCore.Localization;
@@ -204,6 +205,7 @@ public static class ServiceCollectionExtensions
 
         builder.ConfigureServices(shellServices =>
         {
+            shellServices.AddScoped<IOptionsUpdateNotifier, DefaultOptionsUpdateNotifier>();
             shellServices.AddScoped<IShellReleaseManager, DefaultShellReleaseManager>();
             shellServices.AddTransient<IConfigureOptions<ShellContextOptions>, ShellContextOptionsSetup>();
             shellServices.AddNullFeatureProfilesService();

--- a/src/OrchardCore/OrchardCore/Options/DefaultOptionsUpdateNotifier.cs
+++ b/src/OrchardCore/OrchardCore/Options/DefaultOptionsUpdateNotifier.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Data.Documents;
+using OrchardCore.Environment.Cache;
+using OrchardCore.Environment.Shell.Scope;
+
+namespace OrchardCore.Environment.Options;
+
+/// <summary>
+/// Defers distributed options invalidation until the current shell scope has committed successfully.
+/// </summary>
+public sealed class DefaultOptionsUpdateNotifier : IOptionsUpdateNotifier
+{
+    private readonly IDocumentStore _documentStore;
+    private readonly HashSet<OptionsUpdateRequest> _pendingUpdates = [];
+
+    private bool _commitRegistered;
+    private bool _commitSucceeded;
+    private bool _deferredTaskAdded;
+
+    public DefaultOptionsUpdateNotifier(IDocumentStore documentStore) => _documentStore = documentStore;
+
+    public IOptionsUpdateNotifier RequestUpdate<TOptions>(string name = "") where TOptions : class
+    {
+        if (ShellScope.Current is null)
+        {
+            throw new InvalidOperationException($"'{nameof(IOptionsUpdateNotifier)}' can only be used from an active shell scope.");
+        }
+
+        _pendingUpdates.Add(new(typeof(TOptions), name ?? Microsoft.Extensions.Options.Options.DefaultName));
+
+        if (!_commitRegistered)
+        {
+            _commitRegistered = true;
+
+            _documentStore.AfterCommitSuccess<DefaultOptionsUpdateNotifier>(() =>
+            {
+                _commitSucceeded = true;
+                return Task.CompletedTask;
+            });
+        }
+
+        if (_deferredTaskAdded)
+        {
+            return this;
+        }
+
+        _deferredTaskAdded = true;
+
+        ShellScope.AddDeferredTask(async scope =>
+        {
+            try
+            {
+                if (!_commitSucceeded || _pendingUpdates.Count == 0)
+                {
+                    return;
+                }
+
+                var signal = scope.ServiceProvider.GetRequiredService<ISignal>();
+
+                foreach (var update in _pendingUpdates)
+                {
+                    await signal.SignalTokenAsync(OptionsUpdateSignal.GetKey(update.OptionsType, update.Name));
+                }
+            }
+            finally
+            {
+                _pendingUpdates.Clear();
+                _commitRegistered = false;
+                _commitSucceeded = false;
+                _deferredTaskAdded = false;
+            }
+        });
+
+        return this;
+    }
+
+    private readonly record struct OptionsUpdateRequest(Type OptionsType, string Name);
+}

--- a/src/OrchardCore/OrchardCore/Options/DefaultOptionsUpdateNotifier.cs
+++ b/src/OrchardCore/OrchardCore/Options/DefaultOptionsUpdateNotifier.cs
@@ -17,7 +17,10 @@ public sealed class DefaultOptionsUpdateNotifier : IOptionsUpdateNotifier
     private bool _commitSucceeded;
     private bool _deferredTaskAdded;
 
-    public DefaultOptionsUpdateNotifier(IDocumentStore documentStore) => _documentStore = documentStore;
+    public DefaultOptionsUpdateNotifier(IDocumentStore documentStore)
+    {
+        _documentStore = documentStore;
+    }
 
     public IOptionsUpdateNotifier RequestUpdate<TOptions>(string name = "") where TOptions : class
     {

--- a/src/docs/reference/modules/Configuration/README.md
+++ b/src/docs/reference/modules/Configuration/README.md
@@ -161,6 +161,64 @@ services
 !!! note
     On the admin there will be no indication that this override happened, and the value displayed there will still be the one configured in site settings, so if you choose to do this you'll need to let your users know.
 
+#### Live tenant options with `IOptionsMonitor`
+
+Orchard Core keeps the standard `IOptionsMonitor<TOptions>` implementation. To make a specific options type refresh after tenant data changes, opt it in by registering Orchard Core's signal-backed `IOptionsChangeTokenSource<TOptions>`.
+
+Use `IOptionsMonitor<TOptions>` when an options type is built from mutable tenant state such as site settings, documents, or other values that can change from the admin UI without restarting the application. Continue to use `IOptions<TOptions>` for values that are effectively immutable for the lifetime of the tenant shell, such as options coming only from startup code or static configuration.
+
+When a settings editor updates data that feeds an options type, request an invalidation through `IOptionsUpdateNotifier`. Orchard Core defers the notification until the current document session commits successfully, so failed or rolled-back updates do not refresh the options cache.
+
+```csharp
+public sealed class Startup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSignalOptionsChangeTokenSource<MyOptions>();
+    }
+}
+
+public sealed class MySettingsDisplayDriver : SiteDisplayDriver<MySettings>
+{
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
+
+    public MySettingsDisplayDriver(IOptionsUpdateNotifier optionsUpdateNotifier)
+    {
+        _optionsUpdateNotifier = optionsUpdateNotifier;
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(ISite site, MySettings settings, UpdateEditorContext context)
+    {
+        await context.Updater.TryUpdateModelAsync(settings, Prefix);
+
+        if (context.Updater.ModelState.IsValid)
+        {
+            _optionsUpdateNotifier.RequestUpdate<MyOptions>();
+        }
+
+        return await EditAsync(site, settings, context);
+    }
+}
+
+public sealed class MyService
+{
+    private readonly IOptionsMonitor<MyOptions> _options;
+
+    public MyService(IOptionsMonitor<MyOptions> options)
+    {
+        _options = options;
+    }
+
+    public string GetValue() => _options.CurrentValue.SomeSetting;
+}
+```
+
+Queue update requests only after validation succeeds and only for the options types affected by the change. The notifier is intentionally one-way: Orchard Core coalesces requests per shell scope and dispatches them after commit, so there is no `RemoveUpdateRequest()` API to cancel earlier requests.
+
+For named options, register `IOptionsChangeTokenSource<TOptions>` manually with `SignalOptionsChangeTokenSource<TOptions>` for the matching name and call `RequestUpdate<TOptions>(name)` with the same value.
+
+In multi-node environments, use a distributed `ISignal` implementation such as the Redis Bus feature from [`OrchardCore.Redis`](../Redis/README.md). This ensures every node invalidates its local `IOptionsMonitor<TOptions>` cache and rebuilds the updated options from the committed tenant state.
+
 ### `ORCHARD_APP_DATA` Environment Variable
 
 The location of the `App_Data` folder can be configured by setting the `ORCHARD_APP_DATA` environment variable.

--- a/src/docs/reference/modules/Email.Azure/README.md
+++ b/src/docs/reference/modules/Email.Azure/README.md
@@ -29,6 +29,10 @@ For more information about configurations, please refer to [Configuration](../Co
 !!! note
     Configuration of the **Default Azure Communication Services** provider is not possible through Admin Settings. Utilize the configuration provider for the necessary setup. The provider will appear only if the configuration exists.
 
+## Runtime updates
+
+`AzureEmailOptions` is populated from tenant site settings, so custom services that need to observe admin changes without reloading the tenant should inject `IOptionsMonitor<AzureEmailOptions>` instead of `IOptions<AzureEmailOptions>`. The module registers a signal-backed `IOptionsChangeTokenSource<AzureEmailOptions>`, and when the Azure email settings are updated Orchard Core invalidates the relevant option monitors after the YesSql session commits successfully, allowing running nodes to rebuild the provider options from the committed settings.
+
 ## Recipe Configuration
 
 Azure email settings can be configured using the `Settings` recipe step:

--- a/src/docs/reference/modules/Email/README.md
+++ b/src/docs/reference/modules/Email/README.md
@@ -56,6 +56,10 @@ public class SmtpProviderOptionsConfigurations : IConfigureOptions<EmailProvider
 }
 ```
 
+If your provider options are built from site settings or other tenant data that can change at runtime, consume them through `IOptionsMonitor<TOptions>` in the provider and any `IConfigureOptions<EmailProviderOptions>` implementation that depends on them. Register `AddSignalOptionsChangeTokenSource<TOptions>()` for any options type that should participate in post-commit refresh, then request invalidation for the affected options types with `IOptionsUpdateNotifier` when the settings editor saves changes.
+
+For example, Orchard Core now refreshes the Azure email provider in-place by invalidating `AzureEmailOptions`, `EmailProviderOptions`, and `EmailOptions`, and the built-in email modules register signal-backed change token sources for those options types so the standard `IOptionsMonitor<TOptions>` can rebuild them from committed tenant state.
+
 ## Sending Email Messages
 
 An Email message can be sent by injecting `IEmailService` and invoking the `SendAsync` method. For instance:

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -28,6 +28,8 @@ Custom code that previously injected `IOptions<EmailOptions>`, `IOptions<EmailPr
 
 If your own settings UI updates values that feed those options, register Orchard Core's signal-backed `IOptionsChangeTokenSource<TOptions>` for the affected options types and request invalidation with `IOptionsUpdateNotifier` after the settings update succeeds so Orchard Core refreshes the monitor cache after the underlying YesSql session commits.
 
+`AzureEmailProviderBase` also changed accordingly. It is now generic (`AzureEmailProviderBase<TOptions> where TOptions : AzureEmailOptions`), its constructor takes `IOptionsMonitor<TOptions>` instead of a `Func<AzureEmailOptions>`, and it reuses the `EmailClient` instance until the current connection string changes. Custom Azure email providers derived from the old non-generic base class must update their inheritance and constructor calls.
+
 ### Media Module
 
 The former Media admin AJAX endpoints on `AdminController` (`MediaApplication`, `Upload`, `DeleteMedia`, `DeleteMediaList`, `MoveMedia`, `MoveMediaList`, `DeleteFolder`, …) have been removed and replaced by the `api/media` minimal-API endpoints described above. Custom code or themes calling those admin routes directly must migrate to the Media API (and account for its authentication scheme — cookie with antiforgery by default).

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -20,6 +20,14 @@ Previously, `bootstrap-select` styles were included automatically in the **TheAd
 
 `DisplayDriverBase.Shape()` is now obsolete because it allocates an `IShape` immediately, even when the shape is later hidden. Use `DisplayDriverBase.Factory()` instead to defer shape creation until the shape is actually displayed.
 
+### Email options that follow site settings
+
+`EmailOptions`, `EmailProviderOptions`, and `AzureEmailOptions` now participate in Orchard Core's post-commit `IOptionsMonitor<TOptions>` refresh pipeline so admin settings changes can update the running tenant without forcing a shell release.
+
+Custom code that previously injected `IOptions<EmailOptions>`, `IOptions<EmailProviderOptions>`, or `IOptions<AzureEmailOptions>` and expected those values to track settings changes must switch to `IOptionsMonitor<...>` and read `CurrentValue` (or `Get(name)` for named options) instead.
+
+If your own settings UI updates values that feed those options, register Orchard Core's signal-backed `IOptionsChangeTokenSource<TOptions>` for the affected options types and request invalidation with `IOptionsUpdateNotifier` after the settings update succeeds so Orchard Core refreshes the monitor cache after the underlying YesSql session commits.
+
 ### Media Module
 
 The former Media admin AJAX endpoints on `AdminController` (`MediaApplication`, `Upload`, `DeleteMedia`, `DeleteMediaList`, `MoveMedia`, `MoveMediaList`, `DeleteFolder`, …) have been removed and replaced by the `api/media` minimal-API endpoints described above. Custom code or themes calling those admin routes directly must migrate to the Media API (and account for its authentication scheme — cookie with antiforgery by default).

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email.Azure/AzureEmailOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email.Azure/AzureEmailOptionsMonitorTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Email;
+using OrchardCore.Email.Azure;
+using OrchardCore.Email.Azure.Models;
+using OrchardCore.Email.Azure.Services;
+using OrchardCore.Email.Services;
+using OrchardCore.Entities;
+using OrchardCore.Environment.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Settings;
+using OrchardCore.Tests.Apis.Context;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Email.Azure;
+
+public class AzureEmailOptionsMonitorTests
+{
+    [Fact]
+    public async Task RequestUpdate_ShouldRefreshAzureEmailOptionsWithoutReleasingTenant()
+    {
+        using var context = new SiteContext()
+            .WithRecipe("SaaS");
+
+        await context.InitializeAsync();
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var shellFeaturesManager = scope.ServiceProvider.GetRequiredService<IShellFeaturesManager>();
+
+            await shellFeaturesManager.EnableFeaturesAsync("OrchardCore.Email.Azure");
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        long shellContextTicks = 0;
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            shellContextTicks = scope.ShellContext.UtcTicks;
+
+            Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<AzureEmailOptions>>().CurrentValue.IsEnabled);
+            Assert.Null(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailOptions>>().CurrentValue.DefaultProviderName);
+            Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailProviderOptions>>().CurrentValue.Providers[AzureEmailProvider.TechnicalName].IsEnabled);
+
+            return Task.CompletedTask;
+        });
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
+            var notifier = scope.ServiceProvider.GetRequiredService<IOptionsUpdateNotifier>();
+            var dataProtectionProvider = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
+            var protector = dataProtectionProvider.CreateProtector(AzureEmailOptionsConfiguration.ProtectorName);
+
+            var site = await siteService.LoadSiteSettingsAsync();
+
+            var azureEmailSettings = site.GetOrCreate<AzureEmailSettings>();
+            azureEmailSettings.IsEnabled = true;
+            azureEmailSettings.DefaultSender = "admin@example.com";
+            azureEmailSettings.ConnectionString = protector.Protect("endpoint=https://example.communication.azure.com/;accesskey=test-key");
+            site.Put(azureEmailSettings);
+
+            var emailSettings = site.GetOrCreate<EmailSettings>();
+            emailSettings.DefaultProviderName = AzureEmailProvider.TechnicalName;
+            site.Put(emailSettings);
+
+            notifier.RequestUpdate<AzureEmailOptions>();
+            notifier.RequestUpdate<EmailProviderOptions>();
+            notifier.RequestUpdate<EmailOptions>();
+
+            await siteService.UpdateSiteSettingsAsync(site);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            Assert.Equal(shellContextTicks, scope.ShellContext.UtcTicks);
+
+            var azureOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<AzureEmailOptions>>().CurrentValue;
+            Assert.True(azureOptions.IsEnabled);
+            Assert.Equal("admin@example.com", azureOptions.DefaultSender);
+            Assert.Equal("endpoint=https://example.communication.azure.com/;accesskey=test-key", azureOptions.ConnectionString);
+
+            var providerOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailProviderOptions>>().CurrentValue;
+            Assert.True(providerOptions.Providers[AzureEmailProvider.TechnicalName].IsEnabled);
+
+            var emailOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailOptions>>().CurrentValue;
+            Assert.Equal(AzureEmailProvider.TechnicalName, emailOptions.DefaultProviderName);
+
+            var providerResolver = scope.ServiceProvider.GetRequiredService<IEmailProviderResolver>();
+            var provider = await providerResolver.GetAsync();
+
+            Assert.IsType<AzureEmailProvider>(provider);
+        });
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email.Azure/AzureEmailOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email.Azure/AzureEmailOptionsMonitorTests.cs
@@ -27,8 +27,10 @@ public class AzureEmailOptionsMonitorTests
         await context.UsingTenantScopeAsync(async scope =>
         {
             var shellFeaturesManager = scope.ServiceProvider.GetRequiredService<IShellFeaturesManager>();
+            var availableFeatures = await shellFeaturesManager.GetAvailableFeaturesAsync();
+            var featuresToEnable = availableFeatures.Where(feature => feature.Id == "OrchardCore.Email.Azure");
 
-            await shellFeaturesManager.EnableFeaturesAsync("OrchardCore.Email.Azure");
+            await shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force: true);
         });
 
         await context.WaitForDeferredTasksAsync(CancellationToken.None);
@@ -40,7 +42,7 @@ public class AzureEmailOptionsMonitorTests
             shellContextTicks = scope.ShellContext.UtcTicks;
 
             Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<AzureEmailOptions>>().CurrentValue.IsEnabled);
-            Assert.Null(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailOptions>>().CurrentValue.DefaultProviderName);
+            Assert.Equal(AzureEmailProvider.TechnicalName, scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailOptions>>().CurrentValue.DefaultProviderName);
             Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailProviderOptions>>().CurrentValue.Providers[AzureEmailProvider.TechnicalName].IsEnabled);
 
             return Task.CompletedTask;

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email.Azure/AzureEmailProviderBaseTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email.Azure/AzureEmailProviderBaseTests.cs
@@ -1,0 +1,67 @@
+using Azure.Communication.Email;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using OrchardCore.Email.Azure.Models;
+using OrchardCore.Email.Azure.Services;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Email.Azure;
+
+public class AzureEmailProviderBaseTests
+{
+    [Fact]
+    public void GetOrCreateEmailClient_ReturnsCachedClient_WhenConnectionStringIsUnchanged()
+    {
+        var provider = CreateProvider();
+        const string connectionString = "endpoint=https://example.communication.azure.com/;accesskey=test-key";
+
+        var client = provider.GetClient(connectionString);
+        var cachedClient = provider.GetClient(connectionString);
+
+        Assert.Same(client, cachedClient);
+        Assert.Equal(1, provider.CreatedClientCount);
+    }
+
+    [Fact]
+    public void GetOrCreateEmailClient_RecreatesClient_WhenConnectionStringChanges()
+    {
+        var provider = CreateProvider();
+        const string oldConnectionString = "endpoint=https://example.communication.azure.com/;accesskey=test-key";
+        const string newConnectionString = "endpoint=https://example.communication.azure.com/;accesskey=new-test-key";
+
+        var client = provider.GetClient(oldConnectionString);
+        var updatedClient = provider.GetClient(newConnectionString);
+
+        Assert.NotSame(client, updatedClient);
+        Assert.Equal(2, provider.CreatedClientCount);
+    }
+
+    private static TestAzureEmailProvider CreateProvider()
+    {
+        var optionsMonitor = Mock.Of<IOptionsMonitor<AzureEmailOptions>>();
+        var localizer = new Mock<IStringLocalizer>().Object;
+
+        return new TestAzureEmailProvider(optionsMonitor, localizer);
+    }
+
+    private sealed class TestAzureEmailProvider : AzureEmailProviderBase<AzureEmailOptions>
+    {
+        public TestAzureEmailProvider(IOptionsMonitor<AzureEmailOptions> optionsMonitor, IStringLocalizer stringLocalizer)
+            : base(optionsMonitor, NullLogger.Instance, stringLocalizer)
+        {
+        }
+
+        public int CreatedClientCount { get; private set; }
+
+        public override LocalizedString DisplayName => new(nameof(TestAzureEmailProvider), nameof(TestAzureEmailProvider));
+
+        public EmailClient GetClient(string connectionString) => GetOrCreateEmailClient(connectionString);
+
+        protected override EmailClient CreateEmailClient(string connectionString)
+        {
+            CreatedClientCount++;
+            return base.CreateEmailClient(connectionString);
+        }
+    }
+}


### PR DESCRIPTION
Partially address #19740

This pull request introduces significant improvements to how email-related options are managed and updated in Orchard Core, particularly around the Azure Email and general Email modules. The changes modernize the use of options by switching to `IOptionsMonitor` for dynamic configuration, introduce a new `IOptionsUpdateNotifier` abstraction to propagate options updates, and ensure that email providers and settings respond to changes without requiring a shell reload. The update also refactors dependencies and service registrations to support these enhancements.

Key changes include:

**Dynamic Options and Update Notification Infrastructure:**

* Introduced the `IOptionsUpdateNotifier` interface and implemented extension methods to register signal-backed options change token sources, enabling options to be invalidated and refreshed after configuration changes. (`IOptionsUpdateNotifier.cs` [[1]](diffhunk://#diff-4ad3064c4dd6f026e56fb121d243e25ccc55da5874012149a01df573162a7d28R1-R20) `OptionsServiceCollectionExtensions.cs` [[2]](diffhunk://#diff-7f752edbd06da8860fa7040807b3d9c7aea37edfb6ac6031393be4456297cc63R1-R22)

* Updated service registrations in both the Azure Email and Email modules to use `AddSignalOptionsChangeTokenSource` for relevant options, ensuring that changes propagate correctly. (`Startup.cs` in both modules [[1]](diffhunk://#diff-14eda6f3fdbfbecbaa9c3c2d715b395196c48f20e0d84e59816eec7ab7c89aa9R24-R25) [[2]](diffhunk://#diff-c6b2e3a344ccf8a1c9ceb638414d4858dc92078db94aa9c775e6c4bdeada5c4fR18-R19)

**Refactoring to Use IOptionsMonitor:**

* Replaced usage of `IOptions<T>` and direct options instances with `IOptionsMonitor<T>` throughout controllers, drivers, and configuration classes, allowing for real-time options updates. (`AdminController.cs` [[1]](diffhunk://#diff-028cad5bf3dc7dcd6fdf8b208108c3e4e5e65d5eb250310b8a7627788823e65aL18-R19) [[2]](diffhunk://#diff-028cad5bf3dc7dcd6fdf8b208108c3e4e5e65d5eb250310b8a7627788823e65aL29-R39) [[3]](diffhunk://#diff-dbd752af85bdd1af4ccc58d3ebd6df37c5f92016042be151460e9ad3fdaafa11L20-R23) [[4]](diffhunk://#diff-dbd752af85bdd1af4ccc58d3ebd6df37c5f92016042be151460e9ad3fdaafa11L33-R57) [[5]](diffhunk://#diff-a016670ee026d1fb8563ea8928c9022236321c75851323c778e773d56fe4a32cL9-R24) [[6]](diffhunk://#diff-a016670ee026d1fb8563ea8928c9022236321c75851323c778e773d56fe4a32cL35-R35)

* Refactored email provider base classes and implementations to access options via delegates or `IOptionsMonitor`, ensuring they always work with the latest configuration. (`AzureEmailProvider.cs` [[1]](diffhunk://#diff-6dd41e9cbd0eb63e72b16978bd7494d8eb8f68f8b3872428705204e0b96101e5L13-R16) `AzureEmailProviderBase.cs` [[2]](diffhunk://#diff-d08fe83c2310686044a4cab9c04f374d0f60ba9d0d0989791a4ee8e4f4e72057L82-R95) [[3]](diffhunk://#diff-d08fe83c2310686044a4cab9c04f374d0f60ba9d0d0989791a4ee8e4f4e72057L111-R120) [[4]](diffhunk://#diff-d08fe83c2310686044a4cab9c04f374d0f60ba9d0d0989791a4ee8e4f4e72057L158-R167) `DefaultAzureEmailProvider.cs` [[5]](diffhunk://#diff-2079c0aaba021931ad9ce13b4243b3b93dd12f665e3dc7c261b651514b3f9d02L16-R16)

**Options Update Handling in Settings Drivers:**

* Updated settings display drivers to use `IOptionsUpdateNotifier` instead of `IShellReleaseManager`, queuing options invalidation requests when settings are changed, and ensuring that updates are applied without requiring a full shell reload. (`AzureEmailSettingsDisplayDriver.cs` [[1]](diffhunk://#diff-698978f27ab80944f91418c4f4360598bee929ca432b29605d5893b053b578b5R11-R24) [[2]](diffhunk://#diff-698978f27ab80944f91418c4f4360598bee929ca432b29605d5893b053b578b5L32-R40) [[3]](diffhunk://#diff-698978f27ab80944f91418c4f4360598bee929ca432b29605d5893b053b578b5L141-R145); `EmailSettingsDisplayDriver.cs` [[4]](diffhunk://#diff-dbd752af85bdd1af4ccc58d3ebd6df37c5f92016042be151460e9ad3fdaafa11L20-R23) [[5]](diffhunk://#diff-dbd752af85bdd1af4ccc58d3ebd6df37c5f92016042be151460e9ad3fdaafa11L33-R57) [[6]](diffhunk://#diff-dbd752af85bdd1af4ccc58d3ebd6df37c5f92016042be151460e9ad3fdaafa11L79-R78)

**Minor Cleanups and Consistency:**

* Removed unused or obsolete code and dependencies, such as direct `IOptions` injections and shell reload warnings. (`EmailSettings.Edit.cshtml` [[1]](diffhunk://#diff-ed870404af36013fcf79093b8343051eca7f5d5b05d165f4d09e16eac14cecd0L1-L8) `EmailSettingsDisplayDriver.cs` [[2]](diffhunk://#diff-dbd752af85bdd1af4ccc58d3ebd6df37c5f92016042be151460e9ad3fdaafa11L33-R57)

* Ensured all provider and settings access use `CurrentValue` from `IOptionsMonitor` for consistency. (`AdminController.cs` [[1]](diffhunk://#diff-028cad5bf3dc7dcd6fdf8b208108c3e4e5e65d5eb250310b8a7627788823e65aL56-R56) [[2]](diffhunk://#diff-028cad5bf3dc7dcd6fdf8b208108c3e4e5e65d5eb250310b8a7627788823e65aL139-R139) `EmailSettingsDisplayDriver.cs` [[3]](diffhunk://#diff-dbd752af85bdd1af4ccc58d3ebd6df37c5f92016042be151460e9ad3fdaafa11L89-R88)

These changes together make the email configuration system more robust, responsive to runtime changes, and aligned with modern .NET practices for options management.