### PR TITLE
Make the scripting cancellation token stop the script

### DIFF
--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
@@ -1,5 +1,6 @@
 using Acornima.Ast;
 using Jint;
+using Jint.Constraints;
 using Jint.Native;
 using Jint.Runtime.Descriptors;
 using Microsoft.Extensions.Caching.Memory;
@@ -62,13 +63,73 @@ public sealed class JavaScriptEngine : IScriptingEngine
         return result;
     }
 
+    /// <summary>
+    /// Evaluates a script, observing <paramref name="cancellationToken"/> for the whole evaluation.
+    /// </summary>
+    /// <remarks>
+    /// Jint's own <c>EvaluateAsync</c> observes the token only while awaiting promise settlement — the
+    /// script is interpreted to completion first — so forwarding it there bounds an evaluation that awaits
+    /// something and nothing at all for one that does not. A script that never yields is the case that
+    /// matters, and it was the case the token did not cover.
+    /// <para>
+    /// The interpreter is bounded instead by the engine's <see cref="OperationDeadlineConstraint"/>, armed
+    /// here with the token and disarmed in the <see langword="finally"/>. It is armed with
+    /// <see cref="Timeout.InfiniteTimeSpan"/>, which is that constraint's cancellation-only shape: no time
+    /// budget is introduced, because how long a script may run is a policy for the site to set through
+    /// <c>IOptions&lt;Jint.Options&gt;</c> and not for this method to invent.
+    /// </para>
+    /// <para>
+    /// Cancellation surfaces as <see cref="OperationCanceledException"/> carrying the token, the type the
+    /// rest of a .NET call stack already filters on, rather than as a scripting error. A token cancelled
+    /// before the call is observed before the script starts; one cancelled while the script is running is
+    /// observed on the engine's amortized constraint cadence, so a runaway script is stopped within a
+    /// bounded number of statements rather than at the exact statement the cancellation arrived. That
+    /// cadence is what keeps the interpreter's tight-loop lane armed, and it is the same one the built-in
+    /// <c>CancellationToken</c> and <c>TimeoutInterval</c> constraints are checked on.
+    /// </para>
+    /// </remarks>
     public async Task<object> EvaluateAsync(IScriptingScope scope, string script, CancellationToken cancellationToken = default)
     {
+        // A token that is already cancelled means the work should not start, and saying so here is what
+        // makes that deterministic: the constraint below is amortized, so it is consulted on a statement
+        // cadence rather than at every statement, and a script small enough to finish inside that cadence
+        // would otherwise run to completion.
+        cancellationToken.ThrowIfCancellationRequested();
+
         var jsScope = GetJavaScriptScope(scope);
+        var preparedScript = PrepareScript(script);
 
-        var result = await jsScope.Engine.EvaluateAsync(PrepareScript(script), cancellationToken);
+        // Find() walks the engine's constraints, so it is only worth asking when there is a token that can
+        // actually be cancelled. CancellationToken.None never can, which is what every caller in this
+        // repository passes today.
+        var deadline = cancellationToken.CanBeCanceled
+            ? jsScope.Engine.Constraints.Find<OperationDeadlineConstraint>()
+            : null;
 
-        return result.ToObject();
+        if (deadline is null)
+        {
+            // Either there is nothing to observe, or a site has replaced the constraints this module
+            // registers. Neither is a reason to fail the evaluation; it behaves as it did before.
+            var unbounded = await jsScope.Engine.EvaluateAsync(preparedScript, cancellationToken);
+
+            return unbounded.ToObject();
+        }
+
+        deadline.Begin(Timeout.InfiniteTimeSpan, cancellationToken);
+
+        try
+        {
+            var result = await jsScope.Engine.EvaluateAsync(preparedScript, cancellationToken);
+
+            return result.ToObject();
+        }
+        finally
+        {
+            // Awaited rather than returned, so the constraint is disarmed once the evaluation has actually
+            // finished rather than once its Task exists. An engine that outlives this call - a scope held
+            // for a whole request - must not carry a finished evaluation's token into the next one.
+            deadline.End();
+        }
     }
 
     private Prepared<Script> PrepareScript(string script)

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Dynamic;
 using System.Text.Json.Nodes;
 using Jint;
+using Jint.Constraints;
 using Jint.Runtime.Interop;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
@@ -16,6 +17,20 @@ public static class ServiceCollectionExtensions
         services.Configure<Options>(option =>
         {
             option.ExperimentalFeatures |= ExperimentalFeature.TaskInterop;
+
+            // The cancellation token IScriptingManager.EvaluateAsync() accepts has to reach the interpreter
+            // somehow, and the built-in helpers cannot carry it: Options.CancellationToken() takes the token
+            // when the options are configured, and one Jint.Options instance serves every engine of the
+            // tenant for the lifetime of the tenant, while the token belongs to one evaluation.
+            //
+            // OperationDeadlineConstraint is the shape that fits. The host arms it around the work it wants
+            // bounded and disarms it afterwards, so JavaScriptEngine.EvaluateAsync() can hand it the token
+            // of the call it is serving. A factory rather than an instance, because the options are shared:
+            // each engine has to get its own, or two concurrent evaluations would arm and disarm the same
+            // one. Disarmed - which is every synchronous evaluation, and every asynchronous one whose token
+            // cannot be cancelled - a check reads two fields and takes no timestamp, and the constraint
+            // declares itself amortizable, so the interpreter's tight-loop lane stays armed either way.
+            option.Constraint(static () => new OperationDeadlineConstraint());
             // The dynamic wrappers are unwrapped to the node they carry, because a DynamicObject exposes
             // nothing a script can read. The type Jint hands over describes the member the value was read
             // from, not the node it is replaced by, and the two are unrelated: JsonDynamicObject derives

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -78,6 +78,14 @@ Three things are worth knowing about how that instance is used:
 
 No execution constraints are configured by default, so a script such as `while (true) {}` runs until the process is recycled. Sites that let non-administrators author scripts should set at least one.
 
+One constraint *is* registered, and it bounds nothing until asked to. `IScriptingManager.EvaluateAsync()` and `IScriptingEngine.EvaluateAsync()` take a `CancellationToken`, and Jint's own `EvaluateAsync` observes a token only while awaiting promise settlement — the script is interpreted to completion first. Forwarding the token there therefore bounded an evaluation that awaits something and nothing at all for one that does not, which is the case that matters. `AddJavaScriptEngine()` registers a `Jint.Constraints.OperationDeadlineConstraint` factory, and `JavaScriptEngine.EvaluateAsync()` arms that engine's instance with the token for the duration of the call. Three things follow:
+
+- **Cancelling the token stops the script**, not only the promise settlement. It surfaces as `OperationCanceledException` carrying the token — the type the rest of a .NET call stack already filters on — rather than as a scripting error.
+- **A token cancelled before the call is observed before the script starts.** One cancelled while the script is running is observed on the engine's amortized constraint cadence, so a runaway script stops within a bounded number of statements rather than at the exact statement cancellation arrived. That cadence is why the interpreter keeps its tight-loop fast path, and it is the same cadence the built-in `CancellationToken()` and `TimeoutInterval()` constraints are checked on.
+- **No time budget is introduced.** The constraint is armed with `Timeout.InfiniteTimeSpan`, its cancellation-only shape. How long a script may run stays a policy for the site to set with the helpers above. A disarmed `OperationDeadlineConstraint` — every synchronous evaluation, and every asynchronous one whose token cannot be cancelled — reads two fields and takes no timestamp.
+
+The built-in `CancellationToken()` helper cannot serve this: it takes the token when the options are configured, and one `Jint.Options` instance serves every engine of the tenant for the tenant's lifetime, while the token belongs to a single evaluation.
+
 ### Global methods are created on demand
 
 The globals contributed by `IGlobalMethodProvider` implementations are declared on every engine but are not built until a script reads the name. A recipe expression such as `[js:uuid()]` therefore only pays for `uuid`, not for every registered global. This is not observable from script — the properties exist, they are non-enumerable, and the value a name resolves to is stable for the whole evaluation — but the `Func<IServiceProvider, Delegate>` you supply is invoked lazily, and not at all when the script does not use the method. Keep it free of side effects that the surrounding code depends on.

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -192,6 +192,16 @@ Three further changes arrived with the update to Jint 4.16.0 and are visible to 
 
 See the [Scripting documentation](../reference/modules/Scripting/README.md#configuring-the-javascript-engine) for the current behavior.
 
+### The Scripting Cancellation Token Now Stops the Script
+
+`IScriptingManager.EvaluateAsync()` and `IScriptingEngine.EvaluateAsync()` have always accepted a `CancellationToken`, and it did not bound the script. Jint's `EvaluateAsync` observes a token only while awaiting promise settlement — the script is interpreted to completion first — so the token bounded an evaluation that awaited something, and nothing at all for one that did not. Passing an already-cancelled token still ran a script to the end.
+
+`AddJavaScriptEngine()` now registers a `Jint.Constraints.OperationDeadlineConstraint` factory, which Jint 4.16.0 added for exactly this shape, and `JavaScriptEngine.EvaluateAsync()` arms that engine's instance with the token of the call it is serving. Cancelling now stops the interpreter, and surfaces as `OperationCanceledException` carrying the token rather than as a scripting error.
+
+No time budget is introduced: the constraint is armed with `Timeout.InfiniteTimeSpan`, its cancellation-only shape, so how long a script may run remains a policy a site sets through `IOptions<Jint.Options>`. A token cancelled before the call is observed before the script starts; one cancelled while the script runs is observed on the engine's amortized constraint cadence, which is what keeps the interpreter's tight-loop fast path armed.
+
+Nothing in this repository passed a token to these methods, so no in-tree behavior changes. A module that did was silently getting no cancellation and now gets it.
+
 ### Lazily Registered JavaScript Globals
 
 The globals contributed by `IGlobalMethodProvider` implementations are no longer created up front for every engine. `JavaScriptEngine` declares them on the shared Jint options with `Options.AddLazyGlobal()`, so each engine gets a lazy property per global and the delegate behind it is only built when a script reads the name. Because `DefaultScriptingManager` creates an engine per evaluation, a directive such as `[js:uuid()]` used to install every registered global — around forty on a typical site — in order to call one of them.

--- a/test/OrchardCore.Tests/Scripting/JavaScriptEngineCancellationTests.cs
+++ b/test/OrchardCore.Tests/Scripting/JavaScriptEngineCancellationTests.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using OrchardCore.Scripting;
+using OrchardCore.Scripting.JavaScript;
+
+namespace OrchardCore.Tests.Scripting;
+
+public class JavaScriptEngineCancellationTests
+{
+    // Long enough that a test failing to cancel is unmistakable, short enough that such a failure still
+    // finishes rather than hanging the run.
+    private const string LongRunningScript = "var n = 0; for (var i = 0; i < 200000000; i++) { n += i; } return n;";
+
+    [Fact]
+    public async Task EvaluateAsync_WithAnAlreadyCancelledToken_DoesNotRunTheScript()
+    {
+        var (engine, scope) = CreateScope();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var stopwatch = Stopwatch.StartNew();
+
+        // Before the constraint was armed here the token was only observed while awaiting promise
+        // settlement, so a script that never yields ran to completion with the token already cancelled.
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => engine.EvaluateAsync(scope, LongRunningScript, cts.Token));
+
+        stopwatch.Stop();
+
+        // The script itself takes seconds; failing before it starts is the observable difference.
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), $"took {stopwatch.Elapsed}");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WhenTheTokenIsCancelledWhileTheScriptRuns_StopsTheScript()
+    {
+        var (engine, scope) = CreateScope();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => engine.EvaluateAsync(scope, LongRunningScript, cts.Token));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_CarriesTheTokenThatWasCancelled()
+    {
+        var (engine, scope) = CreateScope();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // A host filtering with 'when (e is not OperationCanceledException)' needs the cancellation it
+        // asked for to be distinguishable from a script failure, and needs the token to identify it. A
+        // script this small never reaches an amortized constraint check, so this also pins that a token
+        // cancelled before the call is observed before the script starts rather than not at all.
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(
+            () => engine.EvaluateAsync(scope, "return 1 + 1;", cts.Token));
+
+        Assert.Equal(cts.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithoutACancellableToken_IsUnaffected()
+    {
+        var (engine, scope) = CreateScope();
+
+        // CancellationToken.None is what the parameter defaults to, and CanBeCanceled is false for it, so
+        // this is the path every caller in this repository takes today.
+        Assert.Equal(2, Convert.ToInt32(await engine.EvaluateAsync(scope, "return 1 + 1;", CancellationToken.None)));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_AfterACancelledEvaluation_TheSameScopeStillWorks()
+    {
+        var (engine, scope) = CreateScope();
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => engine.EvaluateAsync(scope, "return 1 + 1;", cts.Token));
+
+        // The constraint is disarmed in a finally, so the finished evaluation's token is not carried into
+        // the next one. A scope is held for a whole request by JavascriptConditionEvaluator, so an engine
+        // really does outlive the evaluation that cancelled.
+        Assert.Equal(2, Convert.ToInt32(await engine.EvaluateAsync(scope, "return 1 + 1;", CancellationToken.None)));
+        Assert.Equal(2, Convert.ToInt32(engine.Evaluate(scope, "return 1 + 1;")));
+    }
+
+    [Fact]
+    public void Evaluate_TheSynchronousPath_IsUnaffected()
+    {
+        // Nothing arms the constraint on this path, and a disarmed constraint bounds nothing.
+        var (engine, scope) = CreateScope();
+
+        Assert.Equal(2, Convert.ToInt32(engine.Evaluate(scope, "return 1 + 1;")));
+    }
+
+    private static (IScriptingEngine Engine, IScriptingScope Scope) CreateScope()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddMemoryCache()
+            .AddScripting()
+            .AddJavaScriptEngine()
+            .BuildServiceProvider();
+
+        var engine = serviceProvider.GetServices<IScriptingEngine>().First(engine => engine.Prefix == "js");
+
+        return (engine, engine.CreateScope([], serviceProvider, null, null));
+    }
+}


### PR DESCRIPTION
## The problem

`IScriptingManager.EvaluateAsync()` and `IScriptingEngine.EvaluateAsync()` have always accepted a `CancellationToken`. **It does not bound the script.**

Jint's `Engine.EvaluateAsync` is documented as observing the token only while awaiting promise settlement — the script is interpreted to completion first, and only then is the token consulted at event-loop continuation boundaries. Forwarding it there bounds an evaluation that awaits something, and nothing at all for one that does not.

Measured against Jint 4.16.0, a script handed a token that was **already cancelled before the call**:

```
token already cancelled, yet the script ran to completion in 1894 ms, result=199999990000000
```

The case the token does not cover is the case the token exists for.

## Why the built-in helper cannot fix it

`Options.CancellationToken(token)` takes the token when the *options* are configured. One `Jint.Options` instance serves every engine of a tenant for the tenant's lifetime, while the token belongs to a single evaluation. There is nowhere to put a per-call token on a per-tenant object.

## The change

Jint 4.16.0 (#19733, already in `main`) added `Jint.Constraints.OperationDeadlineConstraint` for exactly this shape: the host arms it around the work it wants bounded and disarms it afterwards, and its `Reset()` is deliberately a no-op so the engine's per-entry constraint reset cannot rewind it.

- `AddJavaScriptEngine()` registers it as a **factory**. The options are shared, so each engine needs its own instance — an instance registration would let two concurrent evaluations arm and disarm the same one.
- `JavaScriptEngine.EvaluateAsync()` finds that engine's instance and arms it with the token of the call it is serving, in a `try`/`finally`. The result is `await`ed rather than returned, so the constraint is disarmed once the evaluation has actually finished rather than once its `Task` exists — an engine that outlives the call (`JavascriptConditionEvaluator` holds a scope for a whole request) must not carry a finished evaluation's token into the next one.

**No time budget is introduced.** It is armed with `Timeout.InfiniteTimeSpan`, which is that constraint's documented cancellation-only shape. How long a script may run is a policy for a site to set through `IOptions<Jint.Options>` — see #19646 — not for this method to invent.

## Two properties worth naming

- **The token is checked once up front** (`ThrowIfCancellationRequested`). The constraint is amortized, so it is consulted on a statement cadence rather than at every statement; a script small enough to finish inside that cadence would otherwise still run to completion with the token already cancelled. Cancelling *during* a long script is then observed on that cadence, so a runaway stops within a bounded number of statements rather than at the exact statement cancellation arrived — the same cadence the built-in `CancellationToken()` and `TimeoutInterval()` constraints are checked on, and what keeps the interpreter's tight-loop fast path armed.
- **A disarmed constraint costs almost nothing.** Every synchronous evaluation, and every asynchronous one whose token `CanBeCanceled` is false, leaves it disarmed; a disarmed check reads two fields and takes no timestamp. Because it declares itself amortizable, the tight-loop lane stays armed either way. `Constraints.Find<T>()` walks the constraint list, so it is only called when there is a token that can actually be cancelled.

Cancellation surfaces as `OperationCanceledException` carrying the token — the type the rest of a .NET call stack already filters on, and what `catch (Exception e) when (e is not OperationCanceledException)` expects — rather than as a scripting error.

## Blast radius

**Nothing in this repository passes a token to these methods**, so no in-tree behavior changes. `RecipeExecutor`, `VariablesMethodProvider`, `ScriptExternalLoginEventHandler` and `JavaScriptWorkflowScriptEvaluator` all call the parameterless overload. A module outside this repository that *did* pass one was silently getting no cancellation, and now gets it.

If a site has replaced the constraints this module registers, `Find` returns `null` and the evaluation behaves exactly as it did before rather than failing.

## Tests

6 new in `test/OrchardCore.Tests/Scripting/JavaScriptEngineCancellationTests.cs`: an already-cancelled token not running the script (and failing in well under the seconds the script takes), a token cancelled while the script runs stopping it, the exception carrying the token that was cancelled, a non-cancellable token leaving behavior unchanged, the synchronous path unchanged, and the same scope still working after a cancelled evaluation.

**Against the unfixed code, four of the six fail** — `Assert.Throws() Failure: No exception was thrown`, each after ~21 seconds of running a script that should never have started. With the fix the class runs in 1.5 s.

Full suite: **2594 passed, 0 failed**, 1 CI-only skip. Solution builds with 0 warnings. The test assembly runs with Jint's host-contract verifiers on.

Documented in the Scripting README and the 4.0.0 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
