### PR TITLE
Add RequiredStartupAttribute

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/RequireFeaturesAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/RequireFeaturesAttribute.cs
@@ -4,7 +4,7 @@ namespace OrchardCore.Modules;
 
 /// <summary>
 /// When used on a class, it includes the service only if the specified features are enabled.
-/// An explicitly empty declaration, <c>[RequireFeatures()]</c>, composes the service for every tenant.
+/// Omitting the attribute or declaring it without feature names adds no named feature requirements.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public class RequireFeaturesAttribute : Attribute
@@ -18,21 +18,6 @@ public class RequireFeaturesAttribute : Attribute
     /// The names of the required features.
     /// </summary>
     public IList<string> RequiredFeatureNames { get; }
-
-    /// <summary>
-    /// Gets a value indicating whether the attributed type is composed for every tenant.
-    /// </summary>
-    public bool IsAlwaysComposed => RequiredFeatureNames.Count == 0;
-
-    /// <summary>
-    /// Gets a value indicating whether the specified type explicitly declares an empty
-    /// <see cref="RequireFeaturesAttribute"/> and is therefore composed for every tenant.
-    /// </summary>
-    /// <param name="type">The type to inspect.</param>
-    public static bool IsAlwaysComposedForType(Type type)
-    {
-        return type.GetCustomAttributes<RequireFeaturesAttribute>(false).FirstOrDefault()?.IsAlwaysComposed ?? false;
-    }
 
     /// <summary>
     /// Gets the feature names required by the specified type.

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/RequiredStartupAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/RequiredStartupAttribute.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Modules;
 /// The marked type and services registered by its startup class are attributed to
 /// <see cref="Application.DefaultFeatureId"/>. This attribute can be combined with
 /// <see cref="RequireFeaturesAttribute"/>; the type is composed when it is marked required
-/// or all named feature requirements are enabled.
+/// and all named feature requirements are enabled.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public sealed class RequiredStartupAttribute : Attribute

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/RequiredStartupAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/RequiredStartupAttribute.cs
@@ -1,0 +1,32 @@
+using System.Reflection;
+
+namespace OrchardCore.Modules;
+
+/// <summary>
+/// Marks a component type to be composed for every tenant.
+/// </summary>
+/// <remarks>
+/// The marked type and services registered by its startup class are attributed to
+/// <see cref="Application.DefaultFeatureId"/>. This attribute can be combined with
+/// <see cref="RequireFeaturesAttribute"/>; the type is composed when it is marked required
+/// or all named feature requirements are enabled.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public sealed class RequiredStartupAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequiredStartupAttribute"/> class.
+    /// </summary>
+    public RequiredStartupAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the specified type must be composed for every tenant.
+    /// </summary>
+    /// <param name="type">The type to inspect.</param>
+    public static bool IsRequiredForType(Type type)
+    {
+        return type.GetCustomAttributes<RequiredStartupAttribute>(false).Any();
+    }
+}

--- a/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
@@ -48,7 +48,7 @@ public class CompositionStrategy : ICompositionStrategy
 
             foreach (var exportedType in _typeFeatureProvider.GetTypesForFeature(feature))
             {
-                if (RequireFeaturesAttribute.IsAlwaysComposedForType(exportedType))
+                if (RequiredStartupAttribute.IsRequiredForType(exportedType))
                 {
                     continue;
                 }
@@ -72,7 +72,7 @@ public class CompositionStrategy : ICompositionStrategy
         {
             foreach (var exportedType in _typeFeatureProvider.GetTypesForFeature(feature))
             {
-                if (RequireFeaturesAttribute.IsAlwaysComposedForType(exportedType))
+                if (RequiredStartupAttribute.IsRequiredForType(exportedType))
                 {
                     alwaysComposedTypes.Add(exportedType);
                 }

--- a/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/CompositionStrategy.cs
@@ -72,10 +72,19 @@ public class CompositionStrategy : ICompositionStrategy
         {
             foreach (var exportedType in _typeFeatureProvider.GetTypesForFeature(feature))
             {
-                if (RequiredStartupAttribute.IsRequiredForType(exportedType))
+                if (!RequiredStartupAttribute.IsRequiredForType(exportedType))
                 {
-                    alwaysComposedTypes.Add(exportedType);
+                    continue;
                 }
+
+                var requiredFeatures = RequireFeaturesAttribute.GetRequiredFeatureNamesForType(exportedType);
+
+                if (!requiredFeatures.All(x => featureNames.Contains(x)))
+                {
+                    continue;
+                }
+
+                alwaysComposedTypes.Add(exportedType);
             }
         }
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -238,7 +238,7 @@ core (`OrchardCore.Extensions.ExtensionManager`).
 
 ### Always-Composed Components
 
-An explicitly empty `[RequireFeatures()]` attribute now composes a public component type for every tenant, even when the feature that contains it is disabled. These components and the services their startup classes register are attributed to `Application.DefaultFeatureId`, rather than to the disabled feature. Omitting `[RequireFeatures]` retains the existing behavior, and named feature requirements remain conditional on every named feature being enabled.
+The new `[RequiredStartup]` attribute composes a public component type for every tenant, even when the feature that contains it is disabled. These components and the services their startup classes register are attributed to `Application.DefaultFeatureId`, rather than to the disabled feature. `[RequireFeatures]` is reserved for named conditional requirements: omitting it or using `[RequireFeatures()]` adds no named requirements, while named requirements remain conditional on every named feature being enabled. `[RequiredStartup]` can be combined with `[RequireFeatures(...)]`; the component is composed once when either condition applies.
 
 ### File Upload Security
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -107,6 +107,10 @@ Static assets are excluded from the tenant rate limiter because the middleware i
 
 ## Change Logs
 
+### Always-Composed Components
+
+The new `[RequiredStartup]` attribute causes a public component type to be composed for every tenant, even if the feature that defines it is disabled. The component and any services registered by its startup class are associated with `Application.DefaultFeatureId` rather than with the disabled feature. `[RequiredStartup]` can be combined with `[RequireFeatures(...)]`; in that case, the component is composed only when all required features are enabled.
+
 ### Content Fields Module
 
 The `TextField` settings now expose optional **Minimum length** and **Maximum length** values. When set to a value greater than `0`, the field's content is validated on save, and the corresponding `minlength`/`maxlength` attributes are rendered on the standard and `TextArea` editors. An empty value (the default) means no limit, so existing content types are unaffected.
@@ -235,10 +239,6 @@ features now appear correctly with their category and Enable button in the Featu
 `IFeaturesProvider` implementations are now resolved as a collection via `IServiceProvider.GetServices<IFeaturesProvider>()` instead of a single required
 service, allowing subsystems such as `OrchardCore.DisplayManagement` to contribute their own feature providers without introducing theme-awareness into
 core (`OrchardCore.Extensions.ExtensionManager`).
-
-### Always-Composed Components
-
-The new `[RequiredStartup]` attribute composes a public component type for every tenant, even when the feature that contains it is disabled. These components and the services their startup classes register are attributed to `Application.DefaultFeatureId`, rather than to the disabled feature. `[RequireFeatures]` is reserved for named conditional requirements: omitting it or using `[RequireFeatures()]` adds no named requirements, while named requirements remain conditional on every named feature being enabled. `[RequiredStartup]` can be combined with `[RequireFeatures(...)]`; the component is composed once when either condition applies.
 
 ### File Upload Security
 

--- a/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
+++ b/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
@@ -205,7 +205,7 @@ public class CompositionStrategyTests
 
         var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
         typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
-            .Returns([typeof(RequiredStartupTypeWithRequiredFeatures)]);
+            .Returns([typeof(RequiredStartupType)]);
         typeFeatureProvider.Setup(p => p.GetTypesForFeature(applicationFeature))
             .Returns([]);
 
@@ -216,8 +216,36 @@ public class CompositionStrategyTests
 
         // Assert
         var dependency = Assert.Single(blueprint.Dependencies);
-        Assert.Equal(typeof(RequiredStartupTypeWithRequiredFeatures), dependency.Key);
+        Assert.Equal(typeof(RequiredStartupType), dependency.Key);
         Assert.Equal(applicationFeature, Assert.Single(dependency.Value));
+    }
+
+    [Fact]
+    public async Task ComposeAsync_RequiredStartupAndNamedFeaturesDisabled_DoesNotCompose()
+    {
+        // Arrange
+        var moduleFeature = CreateFeature("FeatureA");
+        var applicationFeature = CreateFeature(Application.DefaultFeatureId);
+
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(m => m.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([]);
+        extensionManager.Setup(m => m.GetFeatures())
+            .Returns([moduleFeature, applicationFeature]);
+
+        var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
+            .Returns([typeof(RequiredStartupTypeWithRequiredFeatures)]);
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(applicationFeature))
+            .Returns([]);
+
+        var strategy = new CompositionStrategy(extensionManager.Object, typeFeatureProvider.Object, Mock.Of<ILogger<CompositionStrategy>>());
+
+        // Act
+        var blueprint = await strategy.ComposeAsync(new ShellSettings { Name = "Test" }, new ShellDescriptor());
+
+        // Assert
+        Assert.Empty(blueprint.Dependencies);
     }
 
     [Fact]
@@ -466,6 +494,9 @@ public class CompositionStrategyTests
 
     [RequireFeatures("FeatureA", "FeatureB")]
     public class TypeWithMultipleRequiredFeatures;
+
+    [RequiredStartup]
+    public class RequiredStartupType;
 
     [RequiredStartup]
     [RequireFeatures("FeatureA", "FeatureB")]

--- a/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
+++ b/test/OrchardCore.Tests/Shell/CompositionStrategyTests.cs
@@ -123,17 +123,75 @@ public class CompositionStrategyTests
     public void RequireFeatures_AbsentEmptyAndNamedAttributes_HaveExpectedCompositionSemantics()
     {
         Assert.Empty(RequireFeaturesAttribute.GetRequiredFeatureNamesForType(typeof(DummyType)));
-        Assert.False(RequireFeaturesAttribute.IsAlwaysComposedForType(typeof(DummyType)));
+        Assert.False(RequiredStartupAttribute.IsRequiredForType(typeof(DummyType)));
 
-        Assert.Empty(RequireFeaturesAttribute.GetRequiredFeatureNamesForType(typeof(AlwaysComposedType)));
-        Assert.True(RequireFeaturesAttribute.IsAlwaysComposedForType(typeof(AlwaysComposedType)));
+        Assert.Empty(RequireFeaturesAttribute.GetRequiredFeatureNamesForType(typeof(TypeWithEmptyRequiredFeatures)));
+        Assert.False(RequiredStartupAttribute.IsRequiredForType(typeof(TypeWithEmptyRequiredFeatures)));
 
         Assert.Equal(["FeatureA", "FeatureB"], RequireFeaturesAttribute.GetRequiredFeatureNamesForType(typeof(TypeWithMultipleRequiredFeatures)));
-        Assert.False(RequireFeaturesAttribute.IsAlwaysComposedForType(typeof(TypeWithMultipleRequiredFeatures)));
+        Assert.False(RequiredStartupAttribute.IsRequiredForType(typeof(TypeWithMultipleRequiredFeatures)));
+
+        Assert.True(RequiredStartupAttribute.IsRequiredForType(typeof(RequiredStartupTypeWithRequiredFeatures)));
     }
 
     [Fact]
-    public async Task ComposeAsync_ExplicitEmptyRequiredFeaturesAndOwningFeatureDisabled_ComposesAsApplicationFeature()
+    public async Task ComposeAsync_EmptyRequiredFeaturesAndOwningFeatureDisabled_DoesNotCompose()
+    {
+        // Arrange
+        var moduleFeature = CreateFeature("FeatureA");
+
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(m => m.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([]);
+        extensionManager.Setup(m => m.GetFeatures())
+            .Returns([moduleFeature]);
+
+        var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
+            .Returns([typeof(TypeWithEmptyRequiredFeatures)]);
+
+        var strategy = new CompositionStrategy(extensionManager.Object, typeFeatureProvider.Object, Mock.Of<ILogger<CompositionStrategy>>());
+
+        // Act
+        var blueprint = await strategy.ComposeAsync(new ShellSettings { Name = "Test" }, new ShellDescriptor());
+
+        // Assert
+        Assert.Empty(blueprint.Dependencies);
+    }
+
+    [Fact]
+    public async Task ComposeAsync_EmptyRequiredFeaturesAndOwningFeatureEnabled_ComposesAsOwningFeature()
+    {
+        // Arrange
+        var moduleFeature = CreateFeature("FeatureA");
+
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(m => m.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([moduleFeature]);
+        extensionManager.Setup(m => m.GetFeatures())
+            .Returns([moduleFeature]);
+
+        var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
+            .Returns([typeof(TypeWithEmptyRequiredFeatures)]);
+
+        var strategy = new CompositionStrategy(extensionManager.Object, typeFeatureProvider.Object, Mock.Of<ILogger<CompositionStrategy>>());
+        var descriptor = new ShellDescriptor
+        {
+            Features = [new ShellFeature { Id = moduleFeature.Id }],
+        };
+
+        // Act
+        var blueprint = await strategy.ComposeAsync(new ShellSettings { Name = "Test" }, descriptor);
+
+        // Assert
+        var dependency = Assert.Single(blueprint.Dependencies);
+        Assert.Equal(typeof(TypeWithEmptyRequiredFeatures), dependency.Key);
+        Assert.Equal(moduleFeature, Assert.Single(dependency.Value));
+    }
+
+    [Fact]
+    public async Task ComposeAsync_RequiredStartupAndOwningFeatureDisabled_ComposesAsApplicationFeature()
     {
         // Arrange
         var moduleFeature = CreateFeature("FeatureA");
@@ -147,7 +205,7 @@ public class CompositionStrategyTests
 
         var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
         typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
-            .Returns([typeof(AlwaysComposedType)]);
+            .Returns([typeof(RequiredStartupTypeWithRequiredFeatures)]);
         typeFeatureProvider.Setup(p => p.GetTypesForFeature(applicationFeature))
             .Returns([]);
 
@@ -158,33 +216,40 @@ public class CompositionStrategyTests
 
         // Assert
         var dependency = Assert.Single(blueprint.Dependencies);
-        Assert.Equal(typeof(AlwaysComposedType), dependency.Key);
+        Assert.Equal(typeof(RequiredStartupTypeWithRequiredFeatures), dependency.Key);
         Assert.Equal(applicationFeature, Assert.Single(dependency.Value));
     }
 
     [Fact]
-    public async Task ComposeAsync_ExplicitEmptyRequiredFeaturesAndOwningFeatureEnabled_ComposesOnceAsApplicationFeature()
+    public async Task ComposeAsync_RequiredStartupAndNamedFeaturesEnabled_ComposesOnceAsApplicationFeature()
     {
         // Arrange
         var moduleFeature = CreateFeature("FeatureA");
+        var requiredFeature = CreateFeature("FeatureB");
         var applicationFeature = CreateFeature(Application.DefaultFeatureId);
 
         var extensionManager = new Mock<IExtensionManager>();
         extensionManager.Setup(m => m.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>()))
-            .ReturnsAsync([moduleFeature]);
+            .ReturnsAsync([moduleFeature, requiredFeature]);
         extensionManager.Setup(m => m.GetFeatures())
-            .Returns([moduleFeature, applicationFeature]);
+            .Returns([moduleFeature, requiredFeature, applicationFeature]);
 
         var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
         typeFeatureProvider.Setup(p => p.GetTypesForFeature(moduleFeature))
-            .Returns([typeof(AlwaysComposedType)]);
+            .Returns([typeof(RequiredStartupTypeWithRequiredFeatures)]);
+        typeFeatureProvider.Setup(p => p.GetTypesForFeature(requiredFeature))
+            .Returns([]);
         typeFeatureProvider.Setup(p => p.GetTypesForFeature(applicationFeature))
             .Returns([]);
 
         var strategy = new CompositionStrategy(extensionManager.Object, typeFeatureProvider.Object, Mock.Of<ILogger<CompositionStrategy>>());
         var descriptor = new ShellDescriptor
         {
-            Features = [new ShellFeature { Id = moduleFeature.Id }],
+            Features =
+            [
+                new ShellFeature { Id = moduleFeature.Id },
+                new ShellFeature { Id = requiredFeature.Id },
+            ],
         };
 
         // Act
@@ -192,7 +257,7 @@ public class CompositionStrategyTests
 
         // Assert
         var dependency = Assert.Single(blueprint.Dependencies);
-        Assert.Equal(typeof(AlwaysComposedType), dependency.Key);
+        Assert.Equal(typeof(RequiredStartupTypeWithRequiredFeatures), dependency.Key);
         Assert.Equal(applicationFeature, Assert.Single(dependency.Value));
     }
 
@@ -394,13 +459,17 @@ public class CompositionStrategyTests
     public class DummyType;
 
     [RequireFeatures()]
-    public class AlwaysComposedType;
+    public class TypeWithEmptyRequiredFeatures;
 
     [RequireFeatures("MissingFeature")] // This feature will not be present in descriptor
     public class TypeWithRequiredFeature;
 
     [RequireFeatures("FeatureA", "FeatureB")]
     public class TypeWithMultipleRequiredFeatures;
+
+    [RequiredStartup]
+    [RequireFeatures("FeatureA", "FeatureB")]
+    public class RequiredStartupTypeWithRequiredFeatures;
 
     private static IFeatureInfo CreateFeature(string id)
     {


### PR DESCRIPTION
## Summary
- add the public [RequiredStartup] marker for components composed for every tenant
- keep [RequireFeatures] limited to named conditional requirements, including empty declarations
- cover composition, attribution, OR semantics, and duplicate prevention

## Testing
- dotnet test test\OrchardCore.Tests\OrchardCore.Tests.csproj --filter-class 'OrchardCore.Tests.Shell.CompositionStrategyTests' --no-restore