### PR TITLE
Use IOptionsMonitor for ReCaptcha settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
@@ -3,23 +3,22 @@ using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.ReCaptcha.Configuration;
-using OrchardCore.Settings;
 using OrchardCore.Users.Models;
 
 namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class ReCaptchaForgotPasswordFormDisplayDriver : DisplayDriver<ForgotPasswordForm>
 {
-    private readonly ReCaptchaSettings _settings;
+    private readonly IOptionsMonitor<ReCaptchaSettings> _settings;
 
-    public ReCaptchaForgotPasswordFormDisplayDriver(IOptions<ReCaptchaSettings> options)
+    public ReCaptchaForgotPasswordFormDisplayDriver(IOptionsMonitor<ReCaptchaSettings> options)
     {
-        _settings = options.Value;
+        _settings = options;
     }
 
     public override async Task<IDisplayResult> EditAsync(ForgotPasswordForm model, BuildEditorContext context)
     {
-        if (!_settings.ConfigurationExists())
+        if (!_settings.CurrentValue.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
@@ -10,16 +10,16 @@ namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class ReCaptchaLoginFormDisplayDriver : DisplayDriver<LoginForm>
 {
-    private readonly ReCaptchaSettings _settings;
+    private readonly IOptionsMonitor<ReCaptchaSettings> _settings;
 
-    public ReCaptchaLoginFormDisplayDriver(IOptions<ReCaptchaSettings> options)
+    public ReCaptchaLoginFormDisplayDriver(IOptionsMonitor<ReCaptchaSettings> options)
     {
-        _settings = options.Value;
+        _settings = options;
     }
 
     public override async Task<IDisplayResult> EditAsync(LoginForm model, BuildEditorContext context)
     {
-        if (!_settings.ConfigurationExists())
+        if (!_settings.CurrentValue.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
@@ -10,16 +10,16 @@ namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class ReCaptchaResetPasswordFormDisplayDriver : DisplayDriver<ResetPasswordForm>
 {
-    private readonly ReCaptchaSettings _settings;
+    private readonly IOptionsMonitor<ReCaptchaSettings> _settings;
 
-    public ReCaptchaResetPasswordFormDisplayDriver(IOptions<ReCaptchaSettings> options)
+    public ReCaptchaResetPasswordFormDisplayDriver(IOptionsMonitor<ReCaptchaSettings> options)
     {
-        _settings = options.Value;
+        _settings = options;
     }
 
     public override async Task<IDisplayResult> EditAsync(ResetPasswordForm model, BuildEditorContext context)
     {
-        if (!_settings.ConfigurationExists())
+        if (!_settings.CurrentValue.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Options;
 using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.ReCaptcha.ViewModels;
 using OrchardCore.Settings;
@@ -14,16 +14,16 @@ public sealed class ReCaptchaSettingsDisplayDriver : SiteDisplayDriver<ReCaptcha
 {
     public const string GroupId = "recaptcha";
 
-    private readonly IShellReleaseManager _shellReleaseManager;
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
 
     public ReCaptchaSettingsDisplayDriver(
-        IShellReleaseManager shellReleaseManager,
+        IOptionsUpdateNotifier optionsUpdateNotifier,
         IHttpContextAccessor httpContextAccessor,
         IAuthorizationService authorizationService)
     {
-        _shellReleaseManager = shellReleaseManager;
+        _optionsUpdateNotifier = optionsUpdateNotifier;
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
     }
@@ -39,8 +39,6 @@ public sealed class ReCaptchaSettingsDisplayDriver : SiteDisplayDriver<ReCaptcha
         {
             return null;
         }
-
-        context.AddTenantReloadWarningWrapper();
 
         return Initialize<ReCaptchaSettingsViewModel>("ReCaptchaSettings_Edit", model =>
         {
@@ -63,10 +61,16 @@ public sealed class ReCaptchaSettingsDisplayDriver : SiteDisplayDriver<ReCaptcha
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        settings.SiteKey = model.SiteKey?.Trim();
-        settings.SecretKey = model.SecretKey?.Trim();
+        var siteKey = model.SiteKey?.Trim();
+        var secretKey = model.SecretKey?.Trim();
 
-        _shellReleaseManager.RequestRelease();
+        if (settings.SiteKey != siteKey || settings.SecretKey != secretKey)
+        {
+            _optionsUpdateNotifier.RequestUpdate<ReCaptchaSettings>();
+        }
+
+        settings.SiteKey = siteKey;
+        settings.SecretKey = secretKey;
 
         return await EditAsync(site, settings, context);
     }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/RegisterUserFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/RegisterUserFormDisplayDriver.cs
@@ -10,16 +10,16 @@ namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class RegisterUserFormDisplayDriver : DisplayDriver<RegisterUserForm>
 {
-    private readonly ReCaptchaSettings _settings;
+    private readonly IOptionsMonitor<ReCaptchaSettings> _settings;
 
-    public RegisterUserFormDisplayDriver(IOptions<ReCaptchaSettings> options)
+    public RegisterUserFormDisplayDriver(IOptionsMonitor<ReCaptchaSettings> options)
     {
-        _settings = options.Value;
+        _settings = options;
     }
 
     public override async Task<IDisplayResult> EditAsync(RegisterUserForm model, BuildEditorContext context)
     {
-        if (!_settings.ConfigurationExists())
+        if (!_settings.CurrentValue.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Forms/ReCaptchaPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Forms/ReCaptchaPartDisplayDriver.cs
@@ -9,18 +9,18 @@ namespace OrchardCore.ReCaptcha.Forms;
 
 public sealed class ReCaptchaPartDisplayDriver : ContentPartDisplayDriver<ReCaptchaPart>
 {
-    private readonly ReCaptchaSettings _settings;
+    private readonly IOptionsMonitor<ReCaptchaSettings> _settings;
 
-    public ReCaptchaPartDisplayDriver(IOptions<ReCaptchaSettings> options)
+    public ReCaptchaPartDisplayDriver(IOptionsMonitor<ReCaptchaSettings> options)
     {
-        _settings = options.Value;
+        _settings = options;
     }
 
     public override IDisplayResult Display(ReCaptchaPart part, BuildPartDisplayContext context)
     {
         return Initialize<ReCaptchaPartViewModel>("ReCaptchaPart", async model =>
         {
-            model.SettingsAreConfigured = _settings.ConfigurationExists();
+            model.SettingsAreConfigured = _settings.CurrentValue.ConfigurationExists();
         }).Location(OrchardCoreConstants.DisplayType.Detail, "Content");
     }
 
@@ -28,7 +28,7 @@ public sealed class ReCaptchaPartDisplayDriver : ContentPartDisplayDriver<ReCapt
     {
         return Initialize<ReCaptchaPartViewModel>("ReCaptchaPart_Fields_Edit", async model =>
         {
-            model.SettingsAreConfigured = _settings.ConfigurationExists();
+            model.SettingsAreConfigured = _settings.CurrentValue.ConfigurationExists();
         });
     }
 }

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.Environment.Options;
 using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.ReCaptcha.Services;
 using OrchardCore.ReCaptcha.TagHelpers;
@@ -16,6 +17,7 @@ public static class ServiceCollectionExtensions
         // c.f. https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests
         services.AddSingleton<ReCaptchaService>();
         services.AddShapeAttributes<ReCaptchaShape>();
+        services.AddSignalOptionsChangeTokenSource<ReCaptchaSettings>();
         services
             .AddHttpClient(nameof(ReCaptchaService))
             .AddResilienceHandler("oc-handler", builder => builder

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaService.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaService.cs
@@ -15,24 +15,22 @@ public sealed class ReCaptchaService
         PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance,
     };
 
-    private readonly ReCaptchaSettings _reCaptchaSettings;
+    private readonly IOptionsMonitor<ReCaptchaSettings> _reCaptchaSettings;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger _logger;
-    private readonly string _verifyHost;
 
     internal readonly IStringLocalizer S;
 
     public ReCaptchaService(
         IHttpClientFactory httpClientFactory,
-        IOptions<ReCaptchaSettings> optionsAccessor,
+        IOptionsMonitor<ReCaptchaSettings> optionsAccessor,
         IHttpContextAccessor httpContextAccessor,
         ILogger<ReCaptchaService> logger,
         IStringLocalizer<ReCaptchaService> stringLocalizer)
     {
         _httpClientFactory = httpClientFactory;
-        _reCaptchaSettings = optionsAccessor.Value;
-        _verifyHost = $"{optionsAccessor.Value.ReCaptchaApiUri?.TrimEnd('/')}/siteverify";
+        _reCaptchaSettings = optionsAccessor;
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
         S = stringLocalizer;
@@ -44,9 +42,13 @@ public sealed class ReCaptchaService
     /// <param name="reCaptchaResponse"></param>
     /// <returns></returns>
     public async Task<bool> VerifyCaptchaResponseAsync(string reCaptchaResponse)
-        => !string.IsNullOrWhiteSpace(reCaptchaResponse)
-            && _reCaptchaSettings.ConfigurationExists()
-            && await VerifyAsync(reCaptchaResponse);
+    {
+        var settings = _reCaptchaSettings.CurrentValue;
+
+        return !string.IsNullOrWhiteSpace(reCaptchaResponse)
+            && settings.ConfigurationExists()
+            && await VerifyAsync(reCaptchaResponse, settings);
+    }
 
     /// <summary>
     /// Validates the captcha that is in the Form of the current request.
@@ -54,7 +56,9 @@ public sealed class ReCaptchaService
     /// <param name="reportError">Lambda for reporting errors.</param>
     public async Task<bool> ValidateCaptchaAsync(Action<string, string> reportError)
     {
-        if (!_reCaptchaSettings.ConfigurationExists())
+        var settings = _reCaptchaSettings.CurrentValue;
+
+        if (!settings.ConfigurationExists())
         {
             _logger.LogWarning("The ReCaptcha settings are invalid");
 
@@ -85,18 +89,18 @@ public sealed class ReCaptchaService
     /// </summary>
     /// <param name="responseToken">Token received from the ReCaptcha UI.</param>
     /// <returns>A boolean indicating if the token is valid.</returns>
-    private async Task<bool> VerifyAsync(string responseToken)
+    private async Task<bool> VerifyAsync(string responseToken, ReCaptchaSettings settings)
     {
         try
         {
             var content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
-                { "secret", _reCaptchaSettings.SecretKey },
+                { "secret", settings.SecretKey },
                 { "response", responseToken },
             });
 
             var httpClient = _httpClientFactory.CreateClient(nameof(ReCaptchaService));
-            var response = await httpClient.PostAsync(_verifyHost, content);
+            var response = await httpClient.PostAsync(GetVerifyHost(settings), content);
             response.EnsureSuccessStatusCode();
             var result = await response.Content.ReadFromJsonAsync<ReCaptchaResponse>(s_jsonSerializerOptions);
 
@@ -109,4 +113,7 @@ public sealed class ReCaptchaService
 
         return false;
     }
+
+    private static string GetVerifyHost(ReCaptchaSettings settings)
+        => $"{settings.ReCaptchaApiUri?.TrimEnd('/')}/siteverify";
 }

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaShape.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaShape.cs
@@ -17,18 +17,18 @@ namespace OrchardCore.ReCaptcha.Services;
 [Feature("OrchardCore.ReCaptcha")]
 public sealed class ReCaptchaShape : IShapeAttributeProvider
 {
-    private readonly ReCaptchaSettings _settings;
+    private readonly IOptionsMonitor<ReCaptchaSettings> _settings;
     private readonly ILocalizationService _localizationService;
     private readonly IResourceManager _resourceManager;
     private readonly ILogger _logger;
 
     public ReCaptchaShape(
-        IOptions<ReCaptchaSettings> options,
+        IOptionsMonitor<ReCaptchaSettings> options,
         ILocalizationService localizationService,
         IResourceManager resourceManager,
         ILogger<ReCaptchaShape> logger)
     {
-        _settings = options.Value;
+        _settings = options;
         _localizationService = localizationService;
         _resourceManager = resourceManager;
         _logger = logger;
@@ -37,19 +37,21 @@ public sealed class ReCaptchaShape : IShapeAttributeProvider
     [Shape]
     public async Task<IHtmlContent> ReCaptcha(string language, string onload)
     {
-        if (!_settings.ConfigurationExists())
+        var settings = _settings.CurrentValue;
+
+        if (!settings.ConfigurationExists())
         {
             return HtmlString.Empty;
         }
 
         var script = new TagBuilder("script");
-        script.MergeAttribute("src", await GetReCaptchaScriptUrlAsync(_settings.ReCaptchaScriptUri, language, onload));
+        script.MergeAttribute("src", await GetReCaptchaScriptUrlAsync(settings.ReCaptchaScriptUri, language, onload));
 
         _resourceManager.RegisterFootScript(script);
 
         var div = new TagBuilder("div");
         div.AddCssClass("g-recaptcha");
-        div.MergeAttribute("data-sitekey", _settings.SiteKey);
+        div.MergeAttribute("data-sitekey", settings.SiteKey);
 
         return div;
     }

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -30,6 +30,7 @@ If your own settings UI updates values that feed those options, register Orchard
 
 - `EmailOptions`, `EmailProviderOptions`, and `AzureEmailOptions` now participate in this refresh pipeline. `AzureEmailProviderBase` changed accordingly: it is now generic (`AzureEmailProviderBase<TOptions> where TOptions : AzureEmailOptions`), its constructor takes `IOptionsMonitor<TOptions>` instead of a `Func<AzureEmailOptions>`, and it reuses the `EmailClient` instance until the current connection string changes. Custom Azure email providers derived from the old non-generic base class must update their inheritance and constructor calls.
 - `ShapeRenderingOptions` now participates in this refresh pipeline, so the **Debugging** settings screen can toggle shape debug output without forcing a shell release.
+- `ReCaptchaSettings` now participates in this refresh pipeline, so enabling or updating ReCaptcha site settings takes effect without forcing a shell release. Custom code that cached `ReCaptchaSettings` from `IOptions<ReCaptchaSettings>` must switch to `IOptionsMonitor<ReCaptchaSettings>` and read `CurrentValue`.
 
 ### Media Module
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.ReCaptcha/ReCaptchaOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.ReCaptcha/ReCaptchaOptionsMonitorTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Entities;
+using OrchardCore.Environment.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.ReCaptcha.Configuration;
+using OrchardCore.Settings;
+using OrchardCore.Tests.Apis.Context;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.ReCaptcha;
+
+public class ReCaptchaOptionsMonitorTests
+{
+    [Fact]
+    public async Task RequestUpdate_ShouldRefreshReCaptchaOptionsWithoutReleasingTenant()
+    {
+        using var context = new SiteContext()
+            .WithRecipe("SaaS");
+
+        await context.InitializeAsync();
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var shellFeaturesManager = scope.ServiceProvider.GetRequiredService<IShellFeaturesManager>();
+            var availableFeatures = await shellFeaturesManager.GetAvailableFeaturesAsync();
+            var featuresToEnable = availableFeatures.Where(feature => feature.Id == "OrchardCore.ReCaptcha");
+
+            await shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force: true);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        long shellContextTicks = 0;
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            shellContextTicks = scope.ShellContext.UtcTicks;
+
+            var options = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<ReCaptchaSettings>>().CurrentValue;
+
+            Assert.False(options.ConfigurationExists());
+
+            return Task.CompletedTask;
+        });
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
+            var notifier = scope.ServiceProvider.GetRequiredService<IOptionsUpdateNotifier>();
+
+            var site = await siteService.LoadSiteSettingsAsync();
+            site.Put(new ReCaptchaSettings
+            {
+                SiteKey = "site-key",
+                SecretKey = "secret-key",
+            });
+
+            notifier.RequestUpdate<ReCaptchaSettings>();
+
+            await siteService.UpdateSiteSettingsAsync(site);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            Assert.Equal(shellContextTicks, scope.ShellContext.UtcTicks);
+
+            var options = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<ReCaptchaSettings>>().CurrentValue;
+
+            Assert.True(options.ConfigurationExists());
+            Assert.Equal("site-key", options.SiteKey);
+            Assert.Equal("secret-key", options.SecretKey);
+
+            return Task.CompletedTask;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- replace the ReCaptcha settings shell release flow with signal-backed IOptionsMonitor refresh
- switch ReCaptcha consumers to IOptionsMonitor<ReCaptchaSettings>
- add a focused monitor refresh test and a single 4.0.0 breaking-change bullet