### PR TITLE
Use IOptionsMonitor for registration settings

### DIFF
--- a/.github/workflows/assets_validation.yml
+++ b/.github/workflows/assets_validation.yml
@@ -10,7 +10,6 @@ on:
       - 'src/docs/**/*'
     branches: [ main, release/** ]
   pull_request:
-    branches: [ main, release/** ]
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-assets_validation

--- a/.github/workflows/frontend_unit_tests.yml
+++ b/.github/workflows/frontend_unit_tests.yml
@@ -8,7 +8,6 @@ on:
       - 'src/docs/**/*'
     branches: [ main, release/** ]
   pull_request:
-    branches: [ main, release/** ]
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-frontend_unit_tests

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -1,7 +1,6 @@
 name: PR - CI
 on: 
   pull_request:
-    branches: [ main, release/** ]
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -29,7 +29,6 @@ public sealed class AccountController : AccountBaseController
     private readonly ILogger _logger;
     private readonly ISiteService _siteService;
     private readonly IEnumerable<ILoginFormEvent> _loginFormEvents;
-    private readonly RegistrationOptions _registrationOptions;
     private readonly IDisplayManager<LoginForm> _loginFormDisplayManager;
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly INotifier _notifier;
@@ -47,7 +46,6 @@ public sealed class AccountController : AccountBaseController
         IHtmlLocalizer<AccountController> htmlLocalizer,
         IStringLocalizer<AccountController> stringLocalizer,
         IEnumerable<ILoginFormEvent> loginFormEvents,
-        IOptions<RegistrationOptions> registrationOptions,
         INotifier notifier,
         IDisplayManager<LoginForm> loginFormDisplayManager,
         IUpdateModelAccessor updateModelAccessor,
@@ -59,7 +57,6 @@ public sealed class AccountController : AccountBaseController
         _logger = logger;
         _siteService = siteService;
         _loginFormEvents = loginFormEvents;
-        _registrationOptions = registrationOptions.Value;
         _notifier = notifier;
         _loginFormDisplayManager = loginFormDisplayManager;
         _updateModelAccessor = updateModelAccessor;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ResetPasswordController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ResetPasswordController.cs
@@ -22,7 +22,7 @@ public sealed class ResetPasswordController : Controller
     private readonly UserManager<IUser> _userManager;
     private readonly ISiteService _siteService;
     private readonly IEnumerable<IPasswordRecoveryFormEvents> _passwordRecoveryFormEvents;
-    private readonly RegistrationOptions _registrationOptions;
+    private readonly IOptionsMonitor<RegistrationOptions> _registrationOptions;
     private readonly ILogger _logger;
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly IDisplayManager<ForgotPasswordForm> _forgotPasswordDisplayManager;
@@ -41,7 +41,7 @@ public sealed class ResetPasswordController : Controller
         UserEmailService userEmailService,
         IDisplayManager<ResetPasswordForm> resetPasswordDisplayManager,
         IEnumerable<IPasswordRecoveryFormEvents> passwordRecoveryFormEvents,
-        IOptions<RegistrationOptions> registrationOptions,
+        IOptionsMonitor<RegistrationOptions> registrationOptions,
         IStringLocalizer<ResetPasswordController> stringLocalizer)
     {
         _userService = userService;
@@ -53,7 +53,7 @@ public sealed class ResetPasswordController : Controller
         _userEmailService = userEmailService;
         _resetPasswordDisplayManager = resetPasswordDisplayManager;
         _passwordRecoveryFormEvents = passwordRecoveryFormEvents;
-        _registrationOptions = registrationOptions.Value;
+        _registrationOptions = registrationOptions;
         S = stringLocalizer;
     }
 
@@ -96,7 +96,7 @@ public sealed class ResetPasswordController : Controller
                 return RedirectToAction(nameof(ForgotPasswordConfirmation));
             }
 
-            if (_registrationOptions.UsersMustValidateEmail && !await _userManager.IsEmailConfirmedAsync(user))
+            if (_registrationOptions.CurrentValue.UsersMustValidateEmail && !await _userManager.IsEmailConfirmedAsync(user))
             {
                 ModelState.AddModelError(string.Empty, S["Before you can reset your password, you need to verify your email address."]);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Options;
 using OrchardCore.Settings;
 using OrchardCore.Users.Models;
 
@@ -15,16 +15,16 @@ public sealed class RegistrationSettingsDisplayDriver : SiteDisplayDriver<Regist
 
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
-    private readonly IShellReleaseManager _shellReleaseManager;
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
 
     public RegistrationSettingsDisplayDriver(
         IHttpContextAccessor httpContextAccessor,
         IAuthorizationService authorizationService,
-        IShellReleaseManager shellReleaseManager)
+        IOptionsUpdateNotifier optionsUpdateNotifier)
     {
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
-        _shellReleaseManager = shellReleaseManager;
+        _optionsUpdateNotifier = optionsUpdateNotifier;
     }
 
     protected override string SettingsGroupId
@@ -38,8 +38,6 @@ public sealed class RegistrationSettingsDisplayDriver : SiteDisplayDriver<Regist
         {
             return null;
         }
-
-        context.AddTenantReloadWarningWrapper();
 
         return Initialize<RegistrationSettings>("RegistrationSettings_Edit", model =>
         {
@@ -74,7 +72,7 @@ public sealed class RegistrationSettingsDisplayDriver : SiteDisplayDriver<Regist
 
         if (hasChange)
         {
-            _shellReleaseManager.RequestRelease();
+            _optionsUpdateNotifier.RequestUpdate<RegistrationOptions>();
         }
 
         return await EditAsync(site, settings, context);

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/DisabledUserLoginFormEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/DisabledUserLoginFormEvent.cs
@@ -17,19 +17,19 @@ internal sealed class DisabledUserLoginFormEvent : LoginFormEventBase
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ITempDataDictionaryFactory _tempDataDictionaryFactory;
-    private readonly RegistrationOptions _registrationOptions;
+    private readonly IOptionsMonitor<RegistrationOptions> _registrationOptions;
 
     private readonly IStringLocalizer S;
 
     public DisabledUserLoginFormEvent(
         IHttpContextAccessor httpContextAccessor,
         ITempDataDictionaryFactory tempDataDictionaryFactory,
-        IOptions<RegistrationOptions> registrationOptions,
+        IOptionsMonitor<RegistrationOptions> registrationOptions,
         IStringLocalizer<DisabledUserLoginFormEvent> stringLocalizer)
     {
         _httpContextAccessor = httpContextAccessor;
         _tempDataDictionaryFactory = tempDataDictionaryFactory;
-        _registrationOptions = registrationOptions.Value;
+        _registrationOptions = registrationOptions;
         S = stringLocalizer;
     }
 
@@ -44,7 +44,7 @@ internal sealed class DisabledUserLoginFormEvent : LoginFormEventBase
 
         // When user moderation is enabled, newly registered users are created disabled by design;
         // UserModerationLoginFormEvent handles redirecting them to the RegistrationPending page.
-        if (_registrationOptions.UsersAreModerated)
+        if (_registrationOptions.CurrentValue.UsersAreModerated)
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/EmailConfirmationLoginFormEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/EmailConfirmationLoginFormEvent.cs
@@ -12,17 +12,17 @@ namespace OrchardCore.Users.Handlers;
 
 internal sealed class EmailConfirmationLoginFormEvent : LoginFormEventBase
 {
-    private readonly RegistrationOptions _registrationOptions;
+    private readonly IOptionsMonitor<RegistrationOptions> _registrationOptions;
     private readonly UserManager<IUser> _userManager;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public EmailConfirmationLoginFormEvent(
-        IOptions<RegistrationOptions> registrationOptions,
+        IOptionsMonitor<RegistrationOptions> registrationOptions,
         UserManager<IUser> userManager,
         IHttpContextAccessor httpContextAccessor
         )
     {
-        _registrationOptions = registrationOptions.Value;
+        _registrationOptions = registrationOptions;
         _userManager = userManager;
         _httpContextAccessor = httpContextAccessor;
     }
@@ -30,7 +30,7 @@ internal sealed class EmailConfirmationLoginFormEvent : LoginFormEventBase
     public override async Task<IActionResult> ValidatingLoginAsync(IUser user)
     {
         // Require that the users have a confirmed email before they can log on.
-        if (!_registrationOptions.UsersMustValidateEmail || await _userManager.IsEmailConfirmedAsync(user))
+        if (!_registrationOptions.CurrentValue.UsersMustValidateEmail || await _userManager.IsEmailConfirmedAsync(user))
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/EmailConfirmationRegistrationFormEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/EmailConfirmationRegistrationFormEvents.cs
@@ -8,23 +8,23 @@ namespace OrchardCore.Users.Handlers;
 
 internal sealed class EmailConfirmationRegistrationFormEvents : RegistrationFormEventsBase
 {
-    private readonly RegistrationOptions _registrationOptions;
+    private readonly IOptionsMonitor<RegistrationOptions> _registrationOptions;
     private readonly UserManager<IUser> _userManager;
     private readonly UserEmailService _userEmailConfirmationService;
 
     public EmailConfirmationRegistrationFormEvents(
-        IOptions<RegistrationOptions> registrationOptions,
+        IOptionsMonitor<RegistrationOptions> registrationOptions,
         UserManager<IUser> userManager,
         UserEmailService userEmailConfirmationService)
     {
-        _registrationOptions = registrationOptions.Value;
+        _registrationOptions = registrationOptions;
         _userManager = userManager;
         _userEmailConfirmationService = userEmailConfirmationService;
     }
 
     public override async Task RegisteringAsync(UserRegisteringContext context)
     {
-        if (!_registrationOptions.UsersMustValidateEmail || await _userManager.IsEmailConfirmedAsync(context.User))
+        if (!_registrationOptions.CurrentValue.UsersMustValidateEmail || await _userManager.IsEmailConfirmedAsync(context.User))
         {
             return;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/UserModerationLoginFormEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/UserModerationLoginFormEvent.cs
@@ -12,23 +12,23 @@ namespace OrchardCore.Users.Handlers;
 
 internal sealed class UserModerationLoginFormEvent : LoginFormEventBase
 {
-    private readonly RegistrationOptions _registrationOptions;
+    private readonly IOptionsMonitor<RegistrationOptions> _registrationOptions;
     private readonly UserManager<IUser> _userManager;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public UserModerationLoginFormEvent(
-        IOptions<RegistrationOptions> registrationOptions,
+        IOptionsMonitor<RegistrationOptions> registrationOptions,
         UserManager<IUser> userManager,
         IHttpContextAccessor httpContextAccessor)
     {
-        _registrationOptions = registrationOptions.Value;
+        _registrationOptions = registrationOptions;
         _userManager = userManager;
         _httpContextAccessor = httpContextAccessor;
     }
 
     public override Task<IActionResult> ValidatingLoginAsync(IUser user)
     {
-        if (!_registrationOptions.UsersAreModerated || user is not User u || u.IsEnabled)
+        if (!_registrationOptions.CurrentValue.UsersAreModerated || user is not User u || u.IsEnabled)
         {
             return Task.FromResult<IActionResult>(null);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/UserModerationRegistrationFormEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/UserModerationRegistrationFormEvents.cs
@@ -6,17 +6,17 @@ namespace OrchardCore.Users.Handlers;
 
 internal sealed class UserModerationRegistrationFormEvents : RegistrationFormEventsBase
 {
-    private readonly RegistrationOptions _registrationOptions;
+    private readonly IOptionsMonitor<RegistrationOptions> _registrationOptions;
 
-    public UserModerationRegistrationFormEvents(IOptions<RegistrationOptions> registrationOptions)
+    public UserModerationRegistrationFormEvents(IOptionsMonitor<RegistrationOptions> registrationOptions)
     {
-        _registrationOptions = registrationOptions.Value;
+        _registrationOptions = registrationOptions;
     }
 
     public override Task RegisteringAsync(UserRegisteringContext context)
     {
         if (context.User is User user &&
-            _registrationOptions.UsersAreModerated &&
+            _registrationOptions.CurrentValue.UsersAreModerated &&
             !user.IsEnabled)
         {
             context.CancelSignIn = true;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -21,6 +21,7 @@ using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Environment.Commands;
+using OrchardCore.Environment.Options;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Environment.Shell.Scope;
@@ -485,6 +486,7 @@ public sealed class RegistrationStartup : StartupBase
         services.AddDisplayDriver<User, UserRegistrationAdminDisplayDriver>();
         services.AddSiteDisplayDriver<RegistrationSettingsDisplayDriver>();
         services.AddNavigationProvider<RegistrationAdminMenu>();
+        services.AddSignalOptionsChangeTokenSource<RegistrationOptions>();
 
         services.AddDisplayDriver<LoginForm, RegisterUserLoginFormDisplayDriver>();
         services.AddDisplayDriver<RegisterUserForm, RegisterUserFormDisplayDriver>();

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -19,9 +19,9 @@ public sealed class UserService : IUserService
     private readonly SignInManager<IUser> _signInManager;
     private readonly UserManager<IUser> _userManager;
     private readonly IdentityOptions _identityOptions;
+    private readonly IOptionsMonitor<RegistrationOptions> _registrationOptions;
     private readonly IEnumerable<IPasswordRecoveryFormEvents> _passwordRecoveryFormEvents;
     private readonly IEnumerable<IRegistrationFormEvents> _registrationFormEvents;
-    private readonly RegistrationOptions _registrationOptions;
     private readonly ISiteService _siteService;
     private readonly IEnumerable<IUserEventHandler> _handlers;
     private readonly PasswordTimingNormalizationService _timingNormalization;
@@ -35,7 +35,7 @@ public sealed class UserService : IUserService
         IOptions<IdentityOptions> identityOptions,
         IEnumerable<IPasswordRecoveryFormEvents> passwordRecoveryFormEvents,
         IEnumerable<IRegistrationFormEvents> registrationFormEvents,
-        IOptions<RegistrationOptions> registrationOptions,
+        IOptionsMonitor<RegistrationOptions> registrationOptions,
         ISiteService siteService,
         IEnumerable<IUserEventHandler> handlers,
         PasswordTimingNormalizationService timingNormalization,
@@ -45,9 +45,9 @@ public sealed class UserService : IUserService
         _signInManager = signInManager;
         _userManager = userManager;
         _identityOptions = identityOptions.Value;
+        _registrationOptions = registrationOptions;
         _passwordRecoveryFormEvents = passwordRecoveryFormEvents;
         _registrationFormEvents = registrationFormEvents;
-        _registrationOptions = registrationOptions.Value;
         _siteService = siteService;
         _handlers = handlers;
         _timingNormalization = timingNormalization;
@@ -354,14 +354,16 @@ public sealed class UserService : IUserService
 
     public async Task<IUser> RegisterAsync(RegisterUserForm model, Action<string, string> reportError)
     {
+        var registrationOptions = _registrationOptions.CurrentValue;
+
         await _registrationFormEvents.InvokeAsync((e, report) => e.RegistrationValidationAsync((key, message) => report(key, message)), reportError, _logger);
 
         var user = await CreateUserAsync(new User
         {
             UserName = model.UserName,
             Email = model.Email,
-            EmailConfirmed = !_registrationOptions.UsersMustValidateEmail,
-            IsEnabled = !_registrationOptions.UsersAreModerated,
+            EmailConfirmed = !registrationOptions.UsersMustValidateEmail,
+            IsEnabled = !registrationOptions.UsersAreModerated,
         }, model.Password, reportError);
 
         if (user == null)

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -31,6 +31,7 @@ If your own settings UI updates values that feed those options, register Orchard
 - `EmailOptions`, `EmailProviderOptions`, and `AzureEmailOptions` now participate in this refresh pipeline. `AzureEmailProviderBase` changed accordingly: it is now generic (`AzureEmailProviderBase<TOptions> where TOptions : AzureEmailOptions`), its constructor takes `IOptionsMonitor<TOptions>` instead of a `Func<AzureEmailOptions>`, and it reuses the `EmailClient` instance until the current connection string changes. Custom Azure email providers derived from the old non-generic base class must update their inheritance and constructor calls.
 - `ShapeRenderingOptions` now participates in this refresh pipeline, so the **Debugging** settings screen can toggle shape debug output without forcing a shell release.
 - `ReCaptchaSettings` now participates in this refresh pipeline, so enabling or updating ReCaptcha site settings takes effect without forcing a shell release. Custom code that cached `ReCaptchaSettings` from `IOptions<ReCaptchaSettings>` must switch to `IOptionsMonitor<ReCaptchaSettings>` and read `CurrentValue`.
+- `RegistrationOptions` now participates in this refresh pipeline, so changes to registration settings take effect without forcing a shell release. Custom code that cached `RegistrationOptions` from `IOptions<RegistrationOptions>` must switch to `IOptionsMonitor<RegistrationOptions>` and read `CurrentValue`.
 
 ### Media Module
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/RegistrationOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/RegistrationOptionsMonitorTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Entities;
+using OrchardCore.Environment.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Settings;
+using OrchardCore.Tests.Apis.Context;
+using OrchardCore.Users;
+using OrchardCore.Users.Models;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Users;
+
+public class RegistrationOptionsMonitorTests
+{
+    [Fact]
+    public async Task RequestUpdate_ShouldRefreshRegistrationOptionsWithoutReleasingTenant()
+    {
+        using var context = new SiteContext()
+            .WithRecipe("SaaS");
+
+        await context.InitializeAsync();
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var shellFeaturesManager = scope.ServiceProvider.GetRequiredService<IShellFeaturesManager>();
+            var availableFeatures = await shellFeaturesManager.GetAvailableFeaturesAsync();
+            var featuresToEnable = availableFeatures.Where(feature => feature.Id == UserConstants.Features.UserRegistration);
+
+            await shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force: true);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        long shellContextTicks = 0;
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            shellContextTicks = scope.ShellContext.UtcTicks;
+
+            var options = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<RegistrationOptions>>().CurrentValue;
+
+            Assert.False(options.UsersMustValidateEmail);
+            Assert.False(options.UsersAreModerated);
+            Assert.False(options.UseSiteTheme);
+
+            return Task.CompletedTask;
+        });
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
+            var notifier = scope.ServiceProvider.GetRequiredService<IOptionsUpdateNotifier>();
+
+            var site = await siteService.LoadSiteSettingsAsync();
+            site.Put(new RegistrationSettings
+            {
+                UsersMustValidateEmail = true,
+                UsersAreModerated = true,
+                UseSiteTheme = true,
+            });
+
+            notifier.RequestUpdate<RegistrationOptions>();
+
+            await siteService.UpdateSiteSettingsAsync(site);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            Assert.Equal(shellContextTicks, scope.ShellContext.UtcTicks);
+
+            var options = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<RegistrationOptions>>().CurrentValue;
+
+            Assert.True(options.UsersMustValidateEmail);
+            Assert.True(options.UsersAreModerated);
+            Assert.True(options.UseSiteTheme);
+
+            return Task.CompletedTask;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- replace the registration settings shell release flow with signal-backed IOptionsMonitor refresh
- switch RegistrationOptions consumers to IOptionsMonitor<RegistrationOptions>
- add a focused monitor refresh test and a single 4.0.0 breaking-change bullet