### PR TITLE
Use options monitor for external login settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
@@ -37,7 +37,6 @@ public sealed class ExternalAuthenticationsController : AccountBaseController
     private readonly IUserService _userService;
     private readonly INotifier _notifier;
     private readonly IEnumerable<IExternalLoginEventHandler> _externalLoginEventHandlers;
-    private readonly ExternalLoginOptions _externalLoginOption;
     private readonly IdentityOptions _identityOptions;
 
     internal readonly IHtmlLocalizer H;
@@ -57,7 +56,6 @@ public sealed class ExternalAuthenticationsController : AccountBaseController
         IUserService userService,
         INotifier notifier,
         IEnumerable<IExternalLoginEventHandler> externalLoginEventHandlers,
-        IOptions<ExternalLoginOptions> externalLoginOption,
         IOptions<IdentityOptions> identityOptions)
     {
         _signInManager = signInManager;
@@ -71,7 +69,6 @@ public sealed class ExternalAuthenticationsController : AccountBaseController
         _userService = userService;
         _notifier = notifier;
         _externalLoginEventHandlers = externalLoginEventHandlers;
-        _externalLoginOption = externalLoginOption.Value;
         _identityOptions = identityOptions.Value;
 
         H = htmlLocalizer;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/ExternalLoginSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/ExternalLoginSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Http;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Options;
 using OrchardCore.Settings;
 using OrchardCore.Users.Models;
 
@@ -13,16 +13,16 @@ public sealed class ExternalLoginSettingsDisplayDriver : SiteDisplayDriver<Exter
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
-    private readonly IShellReleaseManager _shellReleaseManager;
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
 
     public ExternalLoginSettingsDisplayDriver(
         IHttpContextAccessor httpContextAccessor,
         IAuthorizationService authorizationService,
-        IShellReleaseManager shellReleaseManager)
+        IOptionsUpdateNotifier optionsUpdateNotifier)
     {
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
-        _shellReleaseManager = shellReleaseManager;
+        _optionsUpdateNotifier = optionsUpdateNotifier;
     }
 
     protected override string SettingsGroupId
@@ -53,7 +53,7 @@ public sealed class ExternalLoginSettingsDisplayDriver : SiteDisplayDriver<Exter
 
         if (valueBefore != settings.UseExternalProviderIfOnlyOneDefined)
         {
-            _shellReleaseManager.RequestRelease();
+            _optionsUpdateNotifier.RequestUpdate<ExternalLoginOptions>();
         }
 
         return Edit(site, settings, context);

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/ExternalLoginFormEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/ExternalLoginFormEvents.cs
@@ -13,20 +13,20 @@ namespace OrchardCore.Users.Services;
 
 public sealed class ExternalLoginFormEvents : LoginFormEventBase
 {
-    private readonly ExternalLoginOptions _externalLoginOptions;
+    private readonly IOptionsMonitor<ExternalLoginOptions> _externalLoginOptions;
     private readonly SignInManager<IUser> _signInManager;
     private readonly LinkGenerator _linkGenerator;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ISiteService _siteService;
 
     public ExternalLoginFormEvents(
-        IOptions<ExternalLoginOptions> externalLoginOptions,
+        IOptionsMonitor<ExternalLoginOptions> externalLoginOptions,
         SignInManager<IUser> signInManager,
         LinkGenerator linkGenerator,
         IHttpContextAccessor httpContextAccessor,
         ISiteService siteService)
     {
-        _externalLoginOptions = externalLoginOptions.Value;
+        _externalLoginOptions = externalLoginOptions;
         _signInManager = signInManager;
         _linkGenerator = linkGenerator;
         _httpContextAccessor = httpContextAccessor;
@@ -35,7 +35,7 @@ public sealed class ExternalLoginFormEvents : LoginFormEventBase
 
     public override async Task<IActionResult> LoggingInAsync()
     {
-        if (!_externalLoginOptions.UseExternalProviderIfOnlyOneDefined)
+        if (!_externalLoginOptions.CurrentValue.UseExternalProviderIfOnlyOneDefined)
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -267,6 +267,7 @@ public sealed class ExternalAuthenticationStartup : StartupBase
         services.AddDisplayDriver<UserMenu, ExternalAuthenticationUserMenuDisplayDriver>();
         services.AddSiteDisplayDriver<ExternalRegistrationSettingsDisplayDriver>();
         services.AddSiteDisplayDriver<ExternalLoginSettingsDisplayDriver>();
+        services.AddSignalOptionsChangeTokenSource<ExternalLoginOptions>();
         services.AddTransient<IConfigureOptions<ExternalLoginOptions>, ExternalLoginOptionsConfigurations>();
     }
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -32,6 +32,7 @@ If your own settings UI updates values that feed those options, register Orchard
 - `ShapeRenderingOptions` now participates in this refresh pipeline, so the **Debugging** settings screen can toggle shape debug output without forcing a shell release.
 - `ReCaptchaSettings` now participates in this refresh pipeline, so enabling or updating ReCaptcha site settings takes effect without forcing a shell release. Custom code that cached `ReCaptchaSettings` from `IOptions<ReCaptchaSettings>` must switch to `IOptionsMonitor<ReCaptchaSettings>` and read `CurrentValue`.
 - `RegistrationOptions` now participates in this refresh pipeline, so changes to registration settings take effect without forcing a shell release. Custom code that cached `RegistrationOptions` from `IOptions<RegistrationOptions>` must switch to `IOptionsMonitor<RegistrationOptions>` and read `CurrentValue`.
+- `ExternalLoginOptions` now participates in this refresh pipeline, so changes to external login settings take effect without forcing a shell release. Custom code that cached `ExternalLoginOptions` from `IOptions<ExternalLoginOptions>` must switch to `IOptionsMonitor<ExternalLoginOptions>` and read `CurrentValue`.
 
 ### Media Module
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/ExternalLoginOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/ExternalLoginOptionsMonitorTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Entities;
+using OrchardCore.Environment.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Settings;
+using OrchardCore.Tests.Apis.Context;
+using OrchardCore.Users.Models;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Users;
+
+public class ExternalLoginOptionsMonitorTests
+{
+    [Fact]
+    public async Task RequestUpdate_ShouldRefreshExternalLoginOptionsWithoutReleasingTenant()
+    {
+        using var context = new SiteContext()
+            .WithRecipe("SaaS");
+
+        await context.InitializeAsync();
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var shellFeaturesManager = scope.ServiceProvider.GetRequiredService<IShellFeaturesManager>();
+            var availableFeatures = await shellFeaturesManager.GetAvailableFeaturesAsync();
+            var featuresToEnable = availableFeatures.Where(feature => feature.Id == "OrchardCore.GitHub.Authentication");
+
+            await shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force: true);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        long shellContextTicks = 0;
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            shellContextTicks = scope.ShellContext.UtcTicks;
+
+            Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<ExternalLoginOptions>>().CurrentValue.UseExternalProviderIfOnlyOneDefined);
+
+            return Task.CompletedTask;
+        });
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
+            var notifier = scope.ServiceProvider.GetRequiredService<IOptionsUpdateNotifier>();
+
+            var site = await siteService.LoadSiteSettingsAsync();
+            var settings = site.GetOrCreate<ExternalLoginSettings>();
+            settings.UseExternalProviderIfOnlyOneDefined = true;
+            site.Put(settings);
+
+            notifier.RequestUpdate<ExternalLoginOptions>();
+
+            await siteService.UpdateSiteSettingsAsync(site);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            Assert.Equal(shellContextTicks, scope.ShellContext.UtcTicks);
+            Assert.True(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<ExternalLoginOptions>>().CurrentValue.UseExternalProviderIfOnlyOneDefined);
+
+            return Task.CompletedTask;
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- refresh external login settings through `IOptionsMonitor<ExternalLoginOptions>` instead of a shell release
- invalidate `ExternalLoginOptions` from the site settings editor with `IOptionsUpdateNotifier`
- add a focused monitor test and one 4.0.0 breaking-change bullet for `ExternalLoginOptions`

## Testing
- dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --filter-class "*ExternalLoginOptionsMonitorTests" --filter-class "*AccountControllerTests"