### PR TITLE
Use options monitor for Azure AI Search settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/AdminMenu.cs
@@ -16,21 +16,21 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", AzureAISearchDefaultSettingsDisplayDriver.GroupId},
     };
 
-    private readonly AzureAISearchDefaultOptions _azureAISearchSettings;
+    private readonly IOptionsMonitor<AzureAISearchDefaultOptions> _azureAISearchSettings;
 
     internal readonly IStringLocalizer S;
 
     public AdminMenu(
-        IOptions<AzureAISearchDefaultOptions> azureAISearchSettings,
+        IOptionsMonitor<AzureAISearchDefaultOptions> azureAISearchSettings,
         IStringLocalizer<AdminMenu> stringLocalizer)
     {
-        _azureAISearchSettings = azureAISearchSettings.Value;
+        _azureAISearchSettings = azureAISearchSettings;
         S = stringLocalizer;
     }
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (_azureAISearchSettings.DisableUIConfiguration)
+        if (_azureAISearchSettings.CurrentValue.DisableUIConfiguration)
         {
             return ValueTask.CompletedTask;
         }

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/Drivers/AzureAISearchDefaultSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/Drivers/AzureAISearchDefaultSettingsDisplayDriver.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Options;
 using OrchardCore.Mvc.ModelBinding;
 using OrchardCore.AzureAI.Models;
 using OrchardCore.AzureAI.Services;
@@ -22,9 +22,9 @@ public sealed class AzureAISearchDefaultSettingsDisplayDriver : SiteDisplayDrive
 
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
-    private readonly AzureAISearchDefaultOptions _searchOptions;
+    private readonly IOptionsMonitor<AzureAISearchDefaultOptions> _searchOptions;
     private readonly IDataProtectionProvider _dataProtectionProvider;
-    private readonly IShellReleaseManager _shellReleaseManager;
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
 
     internal readonly IStringLocalizer S;
 
@@ -32,24 +32,26 @@ public sealed class AzureAISearchDefaultSettingsDisplayDriver : SiteDisplayDrive
         => GroupId;
 
     public AzureAISearchDefaultSettingsDisplayDriver(
-        IShellReleaseManager shellReleaseManager,
+        IOptionsUpdateNotifier optionsUpdateNotifier,
         IHttpContextAccessor httpContextAccessor,
         IAuthorizationService authorizationService,
-        IOptions<AzureAISearchDefaultOptions> searchOptions,
+        IOptionsMonitor<AzureAISearchDefaultOptions> searchOptions,
         IDataProtectionProvider dataProtectionProvider,
         IStringLocalizer<AzureAISearchDefaultSettingsDisplayDriver> stringLocalizer)
     {
-        _shellReleaseManager = shellReleaseManager;
+        _optionsUpdateNotifier = optionsUpdateNotifier;
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
-        _searchOptions = searchOptions.Value;
+        _searchOptions = searchOptions;
         _dataProtectionProvider = dataProtectionProvider;
         S = stringLocalizer;
     }
 
     public override IDisplayResult Edit(ISite site, AzureAISearchDefaultSettings settings, BuildEditorContext context)
     {
-        if (_searchOptions.DisableUIConfiguration)
+        var searchOptions = _searchOptions.CurrentValue;
+
+        if (searchOptions.DisableUIConfiguration)
         {
             return null;
         }
@@ -63,7 +65,7 @@ public sealed class AzureAISearchDefaultSettingsDisplayDriver : SiteDisplayDrive
                 new SelectListItem(S["API Key"], nameof(AzureAIAuthenticationType.ApiKey)),
             ];
 
-            model.ConfigurationsAreOptional = _searchOptions.FileConfigurationExists();
+            model.ConfigurationsAreOptional = searchOptions.FileConfigurationExists();
             model.AuthenticationType = settings.AuthenticationType;
             model.UseCustomConfiguration = settings.UseCustomConfiguration;
             model.Endpoint = settings.Endpoint;
@@ -76,7 +78,9 @@ public sealed class AzureAISearchDefaultSettingsDisplayDriver : SiteDisplayDrive
 
     public override async Task<IDisplayResult> UpdateAsync(ISite site, AzureAISearchDefaultSettings settings, UpdateEditorContext context)
     {
-        if (_searchOptions.DisableUIConfiguration)
+        var searchOptions = _searchOptions.CurrentValue;
+
+        if (searchOptions.DisableUIConfiguration)
         {
             return null;
         }
@@ -90,7 +94,7 @@ public sealed class AzureAISearchDefaultSettingsDisplayDriver : SiteDisplayDrive
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        if (!_searchOptions.FileConfigurationExists())
+        if (!searchOptions.FileConfigurationExists())
         {
             model.UseCustomConfiguration = true;
         }
@@ -132,13 +136,13 @@ public sealed class AzureAISearchDefaultSettingsDisplayDriver : SiteDisplayDrive
         settings.UseCustomConfiguration = model.UseCustomConfiguration;
 
         if (context.Updater.ModelState.IsValid &&
-            (_searchOptions.Credential?.Key != model.ApiKey ||
-             _searchOptions.Endpoint != settings.Endpoint ||
-             _searchOptions.AuthenticationType != settings.AuthenticationType ||
-             _searchOptions.IdentityClientId != settings.IdentityClientId ||
+            (searchOptions.Credential?.Key != model.ApiKey ||
+             searchOptions.Endpoint != settings.Endpoint ||
+             searchOptions.AuthenticationType != settings.AuthenticationType ||
+             searchOptions.IdentityClientId != settings.IdentityClientId ||
              useCustomConfigurationChanged))
         {
-            _shellReleaseManager.RequestRelease();
+            _optionsUpdateNotifier.RequestUpdate<AzureAISearchDefaultOptions>();
         }
 
         return Edit(site, settings, context);

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/Drivers/AzureAISearchIndexProfileDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/Drivers/AzureAISearchIndexProfileDisplayDriver.cs
@@ -11,11 +11,11 @@ namespace OrchardCore.AzureAI.Drivers;
 
 internal sealed class AzureAISearchIndexProfileDisplayDriver : DisplayDriver<IndexProfile>
 {
-    private readonly AzureAISearchDefaultOptions _azureAIOptions;
+    private readonly IOptionsMonitor<AzureAISearchDefaultOptions> _azureAIOptions;
 
-    public AzureAISearchIndexProfileDisplayDriver(IOptions<AzureAISearchDefaultOptions> azureAIOptions)
+    public AzureAISearchIndexProfileDisplayDriver(IOptionsMonitor<AzureAISearchDefaultOptions> azureAIOptions)
     {
-        _azureAIOptions = azureAIOptions.Value;
+        _azureAIOptions = azureAIOptions;
     }
 
     public override IDisplayResult Edit(IndexProfile indexProfile, BuildEditorContext context)
@@ -24,6 +24,8 @@ internal sealed class AzureAISearchIndexProfileDisplayDriver : DisplayDriver<Ind
         {
             return null;
         }
+
+        var azureAIOptions = _azureAIOptions.CurrentValue;
 
         var data = Initialize<AzureAISettingsIndexProfileViewModel>("AzureAISearchIndexProfile_Edit", model =>
         {
@@ -34,13 +36,13 @@ internal sealed class AzureAISearchIndexProfileDisplayDriver : DisplayDriver<Ind
                 model.AnalyzerName = metadata.AnalyzerName ?? AzureAISearchDefaultOptions.DefaultAnalyzer;
             }
 
-            model.Analyzers = _azureAIOptions.Analyzers.Select(x => new SelectListItem(x, x));
+            model.Analyzers = azureAIOptions.Analyzers.Select(x => new SelectListItem(x, x));
         }).Location("Content:5");
 
         var queryData = Initialize<AzureAISearchDefaultQueryViewModel>("AzureAISearchQuerySettings_Edit", model =>
         {
             model.QueryAnalyzerName = AzureAISearchDefaultOptions.DefaultAnalyzer;
-            model.Analyzers = _azureAIOptions.Analyzers.Select(x => new SelectListItem(x, x));
+            model.Analyzers = azureAIOptions.Analyzers.Select(x => new SelectListItem(x, x));
 
             string[] defaultSearchFields = null;
 

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Options;
 using OrchardCore.AzureAI.Handlers;
 using OrchardCore.AzureAI.Models;
 using OrchardCore.AzureAI.Services;
@@ -12,6 +13,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAzureAISearchServices(this IServiceCollection services)
     {
         services.AddAzureClientsCore();
+        services.AddSignalOptionsChangeTokenSource<AzureAISearchDefaultOptions>();
         services.AddTransient<IConfigureOptions<AzureAISearchDefaultOptions>, AzureAISearchDefaultOptionsConfigurations>();
         services.AddScoped<AzureAISearchContentFieldMapper>();
         services.AddScoped<IAzureAISearchFieldIndexEvents, DefaultAzureAISearchFieldIndexEvents>();

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAIClientFactory.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAIClientFactory.cs
@@ -7,17 +7,20 @@ using OrchardCore.AzureAI.Models;
 
 namespace OrchardCore.AzureAI.Services;
 
-public class AzureAIClientFactory
+public sealed class AzureAIClientFactory : IDisposable
 {
-    private readonly AzureAISearchDefaultOptions _defaultOptions;
+    private readonly IOptionsMonitor<AzureAISearchDefaultOptions> _defaultOptions;
+    private readonly IDisposable _optionsChangeRegistration;
+    private readonly object _syncLock = new();
 
     private SearchIndexClient _searchIndexClient;
 
     private ConcurrentDictionary<string, SearchClient> _clients;
 
-    public AzureAIClientFactory(IOptions<AzureAISearchDefaultOptions> defaultOptions)
+    public AzureAIClientFactory(IOptionsMonitor<AzureAISearchDefaultOptions> defaultOptions)
     {
-        _defaultOptions = defaultOptions.Value;
+        _defaultOptions = defaultOptions;
+        _optionsChangeRegistration = _defaultOptions.OnChange((_, _) => ResetClients());
     }
 
     public SearchClient CreateSearchClient(string indexFullName)
@@ -25,26 +28,27 @@ public class AzureAIClientFactory
         ArgumentException.ThrowIfNullOrWhiteSpace(indexFullName, nameof(indexFullName));
 
         _clients ??= [];
+        var defaultOptions = _defaultOptions.CurrentValue;
 
         if (!_clients.TryGetValue(indexFullName, out var client))
         {
-            if (!_defaultOptions.ConfigurationExists())
+            if (!defaultOptions.ConfigurationExists())
             {
                 throw new Exception("Azure AI was not configured.");
             }
 
-            if (!Uri.TryCreate(_defaultOptions.Endpoint, UriKind.Absolute, out var endpoint))
+            if (!Uri.TryCreate(defaultOptions.Endpoint, UriKind.Absolute, out var endpoint))
             {
                 throw new Exception("The Endpoint provided to Azure AI Options contains invalid value.");
             }
 
-            if (_defaultOptions.AuthenticationType == AzureAIAuthenticationType.ApiKey && _defaultOptions.Credential != null)
+            if (defaultOptions.AuthenticationType == AzureAIAuthenticationType.ApiKey && defaultOptions.Credential != null)
             {
-                client = new SearchClient(endpoint, indexFullName, _defaultOptions.Credential);
+                client = new SearchClient(endpoint, indexFullName, defaultOptions.Credential);
             }
-            else if (_defaultOptions.AuthenticationType == AzureAIAuthenticationType.ManagedIdentity)
+            else if (defaultOptions.AuthenticationType == AzureAIAuthenticationType.ManagedIdentity)
             {
-                client = new SearchClient(endpoint, indexFullName, GetManagedIdentityCredential());
+                client = new SearchClient(endpoint, indexFullName, GetManagedIdentityCredential(defaultOptions));
             }
             else
             {
@@ -59,25 +63,27 @@ public class AzureAIClientFactory
 
     public SearchIndexClient CreateSearchIndexClient()
     {
+        var defaultOptions = _defaultOptions.CurrentValue;
+
         if (_searchIndexClient == null)
         {
-            if (!_defaultOptions.ConfigurationExists())
+            if (!defaultOptions.ConfigurationExists())
             {
                 throw new Exception("Azure AI was not configured.");
             }
 
-            if (!Uri.TryCreate(_defaultOptions.Endpoint, UriKind.Absolute, out var endpoint))
+            if (!Uri.TryCreate(defaultOptions.Endpoint, UriKind.Absolute, out var endpoint))
             {
                 throw new Exception("The Endpoint provided to Azure AI Options contains invalid value.");
             }
 
-            if (_defaultOptions.AuthenticationType == AzureAIAuthenticationType.ApiKey && _defaultOptions.Credential != null)
+            if (defaultOptions.AuthenticationType == AzureAIAuthenticationType.ApiKey && defaultOptions.Credential != null)
             {
-                _searchIndexClient = new SearchIndexClient(endpoint, _defaultOptions.Credential);
+                _searchIndexClient = new SearchIndexClient(endpoint, defaultOptions.Credential);
             }
-            else if (_defaultOptions.AuthenticationType == AzureAIAuthenticationType.ManagedIdentity)
+            else if (defaultOptions.AuthenticationType == AzureAIAuthenticationType.ManagedIdentity)
             {
-                _searchIndexClient = new SearchIndexClient(endpoint, GetManagedIdentityCredential());
+                _searchIndexClient = new SearchIndexClient(endpoint, GetManagedIdentityCredential(defaultOptions));
             }
             else
             {
@@ -88,8 +94,20 @@ public class AzureAIClientFactory
         return _searchIndexClient;
     }
 
-    private ManagedIdentityCredential GetManagedIdentityCredential()
-        => !string.IsNullOrEmpty(_defaultOptions.IdentityClientId)
-        ? new(ManagedIdentityId.FromUserAssignedClientId(_defaultOptions.IdentityClientId))
+    public void Dispose()
+        => _optionsChangeRegistration.Dispose();
+
+    private static ManagedIdentityCredential GetManagedIdentityCredential(AzureAISearchDefaultOptions defaultOptions)
+        => !string.IsNullOrEmpty(defaultOptions.IdentityClientId)
+        ? new(ManagedIdentityId.FromUserAssignedClientId(defaultOptions.IdentityClientId))
         : new(ManagedIdentityId.SystemAssigned);
+
+    private void ResetClients()
+    {
+        lock (_syncLock)
+        {
+            _clients = null;
+            _searchIndexClient = null;
+        }
+    }
 }

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchIndexNameProvider.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchIndexNameProvider.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Indexing;
@@ -8,20 +7,15 @@ namespace OrchardCore.AzureAI.Services;
 
 public sealed class AzureAISearchIndexNameProvider : IIndexNameProvider
 {
-    private readonly IMemoryCache _memoryCache;
     private readonly ShellSettings _shellSettings;
-    private readonly AzureAISearchDefaultOptions _azureAIOptions;
-    private readonly string _prefixCacheKey;
+    private readonly IOptionsMonitor<AzureAISearchDefaultOptions> _azureAIOptions;
 
     public AzureAISearchIndexNameProvider(
-        IMemoryCache memoryCache,
         ShellSettings shellSettings,
-        IOptions<AzureAISearchDefaultOptions> azureAIOptions)
+        IOptionsMonitor<AzureAISearchDefaultOptions> azureAIOptions)
     {
-        _memoryCache = memoryCache;
         _shellSettings = shellSettings;
-        _azureAIOptions = azureAIOptions.Value;
-        _prefixCacheKey = $"AzureAISearchIndexesPrefix_{shellSettings.Name}";
+        _azureAIOptions = azureAIOptions;
     }
 
     public string GetFullIndexName(string indexName)
@@ -33,26 +27,19 @@ public sealed class AzureAISearchIndexNameProvider : IIndexNameProvider
 
     private string GetIndexPrefix()
     {
-        if (!_memoryCache.TryGetValue<string>(_prefixCacheKey, out var value))
+        var prefix = _shellSettings.Name.ToLowerInvariant();
+        var azureAIOptions = _azureAIOptions.CurrentValue;
+
+        if (!string.IsNullOrWhiteSpace(azureAIOptions.IndexesPrefix))
         {
-            var prefix = _shellSettings.Name.ToLowerInvariant();
-
-            if (!string.IsNullOrWhiteSpace(_azureAIOptions.IndexesPrefix))
-            {
-                prefix = $"{_azureAIOptions.IndexesPrefix.ToLowerInvariant()}-{prefix}";
-            }
-
-            if (AzureAISearchIndexNamingHelper.TryGetSafePrefix(prefix, out var safePrefix))
-            {
-                value = safePrefix;
-                _memoryCache.Set(_prefixCacheKey, safePrefix);
-            }
-            else
-            {
-                throw new InvalidOperationException($"Unable to create a safe index prefix for AI Search. Attempted to created a safe name using '{safePrefix}'.");
-            }
+            prefix = $"{azureAIOptions.IndexesPrefix.ToLowerInvariant()}-{prefix}";
         }
 
-        return value ?? string.Empty;
+        if (AzureAISearchIndexNamingHelper.TryGetSafePrefix(prefix, out var safePrefix))
+        {
+            return safePrefix;
+        }
+
+        throw new InvalidOperationException($"Unable to create a safe index prefix for AI Search. Attempted to created a safe name using '{safePrefix}'.");
     }
 }

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchService.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchService.cs
@@ -14,16 +14,16 @@ public sealed class AzureAISearchService : ISearchService
 {
     private readonly AzureAISearchDocumentIndexManager _indexDocumentManager;
     private readonly ILogger<AzureAISearchService> _logger;
-    private readonly AzureAISearchDefaultOptions _azureAIOptions;
+    private readonly IOptionsMonitor<AzureAISearchDefaultOptions> _azureAIOptions;
 
     public AzureAISearchService(
         AzureAISearchDocumentIndexManager documentManager,
         ILogger<AzureAISearchService> logger,
-        IOptions<AzureAISearchDefaultOptions> azureAIOptions)
+        IOptionsMonitor<AzureAISearchDefaultOptions> azureAIOptions)
     {
         _indexDocumentManager = documentManager;
         _logger = logger;
-        _azureAIOptions = azureAIOptions.Value;
+        _azureAIOptions = azureAIOptions;
     }
 
     public string Name
@@ -34,8 +34,9 @@ public sealed class AzureAISearchService : ISearchService
         ArgumentNullException.ThrowIfNull(index);
 
         var result = new SearchResult();
+        var azureAIOptions = _azureAIOptions.CurrentValue;
 
-        if (!_azureAIOptions.ConfigurationExists())
+        if (!azureAIOptions.ConfigurationExists())
         {
             _logger.LogWarning("Azure AI Search: Couldn't execute search. Azure AI Search has not been configured yet.");
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -33,6 +33,7 @@ If your own settings UI updates values that feed those options, register Orchard
 - `ReCaptchaSettings` now participates in this refresh pipeline, so enabling or updating ReCaptcha site settings takes effect without forcing a shell release. Custom code that cached `ReCaptchaSettings` from `IOptions<ReCaptchaSettings>` must switch to `IOptionsMonitor<ReCaptchaSettings>` and read `CurrentValue`.
 - `RegistrationOptions` now participates in this refresh pipeline, so changes to registration settings take effect without forcing a shell release. Custom code that cached `RegistrationOptions` from `IOptions<RegistrationOptions>` must switch to `IOptionsMonitor<RegistrationOptions>` and read `CurrentValue`.
 - `ExternalLoginOptions` now participates in this refresh pipeline, so changes to external login settings take effect without forcing a shell release. Custom code that cached `ExternalLoginOptions` from `IOptions<ExternalLoginOptions>` must switch to `IOptionsMonitor<ExternalLoginOptions>` and read `CurrentValue`.
+- `AzureAISearchDefaultOptions` now participates in this refresh pipeline, so changes to Azure AI Search settings take effect without forcing a shell release. Custom code that cached `AzureAISearchDefaultOptions` from `IOptions<AzureAISearchDefaultOptions>` must switch to `IOptionsMonitor<AzureAISearchDefaultOptions>` and read `CurrentValue`.
 
 ### Media Module
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Search.AzureAI/AzureAISearchDefaultOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Search.AzureAI/AzureAISearchDefaultOptionsMonitorTests.cs
@@ -1,0 +1,105 @@
+using System.Reflection;
+using Azure.Search.Documents.Indexes;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.AzureAI.Models;
+using OrchardCore.AzureAI.Services;
+using OrchardCore.Entities;
+using OrchardCore.Environment.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Settings;
+using OrchardCore.Tests.Apis.Context;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.AzureAI;
+
+public class AzureAISearchDefaultOptionsMonitorTests
+{
+    [Fact]
+    public async Task RequestUpdate_ShouldRefreshAzureAISearchOptionsWithoutReleasingTenant()
+    {
+        using var context = new SiteContext()
+            .WithRecipe("SaaS");
+
+        await context.InitializeAsync();
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var shellFeaturesManager = scope.ServiceProvider.GetRequiredService<IShellFeaturesManager>();
+            var availableFeatures = await shellFeaturesManager.GetAvailableFeaturesAsync();
+            var featuresToEnable = availableFeatures.Where(feature => feature.Id == "OrchardCore.AzureAI");
+
+            await shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force: true);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        long shellContextTicks = 0;
+
+        await ConfigureOptionsAsync(context, "https://first.search.windows.net", "first-key");
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            shellContextTicks = scope.ShellContext.UtcTicks;
+
+            var options = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<AzureAISearchDefaultOptions>>().CurrentValue;
+            var clientFactory = scope.ServiceProvider.GetRequiredService<AzureAIClientFactory>();
+
+            Assert.True(options.ConfigurationExists());
+            Assert.Equal("https://first.search.windows.net", options.Endpoint);
+            Assert.Equal("https://first.search.windows.net", GetEndpoint(clientFactory.CreateSearchIndexClient()));
+
+            return Task.CompletedTask;
+        });
+
+        await ConfigureOptionsAsync(context, "https://second.search.windows.net", "second-key");
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            Assert.Equal(shellContextTicks, scope.ShellContext.UtcTicks);
+
+            var options = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<AzureAISearchDefaultOptions>>().CurrentValue;
+            var clientFactory = scope.ServiceProvider.GetRequiredService<AzureAIClientFactory>();
+
+            Assert.True(options.ConfigurationExists());
+            Assert.Equal("https://second.search.windows.net", options.Endpoint);
+            Assert.Equal("https://second.search.windows.net", GetEndpoint(clientFactory.CreateSearchIndexClient()));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    private static async Task ConfigureOptionsAsync(SiteContext context, string endpoint, string apiKey)
+    {
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
+            var notifier = scope.ServiceProvider.GetRequiredService<IOptionsUpdateNotifier>();
+            var dataProtectionProvider = scope.ServiceProvider.GetRequiredService<IDataProtectionProvider>();
+            var protector = dataProtectionProvider.CreateProtector(AzureAISearchDefaultOptionsConfigurations.ProtectorName);
+
+            var site = await siteService.LoadSiteSettingsAsync();
+            var settings = site.GetOrCreate<AzureAISearchDefaultSettings>();
+            settings.UseCustomConfiguration = true;
+            settings.AuthenticationType = AzureAIAuthenticationType.ApiKey;
+            settings.Endpoint = endpoint;
+            settings.ApiKey = protector.Protect(apiKey);
+            settings.IdentityClientId = null;
+            site.Put(settings);
+
+            notifier.RequestUpdate<AzureAISearchDefaultOptions>();
+
+            await siteService.UpdateSiteSettingsAsync(site);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+    }
+
+    private static string GetEndpoint(SearchIndexClient client)
+    {
+        var endpointProperty = client.GetType().GetProperty("Endpoint", BindingFlags.Public | BindingFlags.Instance);
+        var endpoint = Assert.IsType<Uri>(endpointProperty?.GetValue(client));
+
+        return endpoint.AbsoluteUri.TrimEnd('/');
+    }
+}


### PR DESCRIPTION
## Summary
- refresh `AzureAISearchDefaultOptions` through `IOptionsMonitor` instead of a shell release
- reset Azure AI Search client caches when the default options change so updated endpoints and credentials take effect immediately
- add a focused monitor test and one 4.0.0 breaking-change bullet for `AzureAISearchDefaultOptions`

## Testing
- dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --filter-class "*AzureAISearchDefaultOptionsMonitorTests" --filter-class "*NamingTests" --filter-class "*VectorSearchIndexTests"