### PR TITLE
Use options monitor for SMTP settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Drivers/SmtpSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Drivers/SmtpSettingsDisplayDriver.cs
@@ -6,10 +6,11 @@ using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Email.Services;
 using OrchardCore.Email.Smtp.Services;
 using OrchardCore.Email.Smtp.ViewModels;
 using OrchardCore.Entities;
-using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Options;
 using OrchardCore.Mvc.ModelBinding;
 using OrchardCore.Settings;
 
@@ -20,10 +21,10 @@ public sealed class SmtpSettingsDisplayDriver : SiteDisplayDriver<SmtpSettings>
     [Obsolete("This property should no longer be used. Instead use EmailSettings.GroupId")]
     public const string GroupId = EmailSettings.GroupId;
 
-    private readonly IShellReleaseManager _shellReleaseManager;
+    private readonly IOptionsUpdateNotifier _optionsUpdateNotifier;
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly SmtpOptions _smtpOptions;
+    private readonly IOptionsMonitor<SmtpOptions> _smtpOptions;
     private readonly IAuthorizationService _authorizationService;
     private readonly IEmailAddressValidator _emailValidator;
 
@@ -33,18 +34,18 @@ public sealed class SmtpSettingsDisplayDriver : SiteDisplayDriver<SmtpSettings>
         => EmailSettings.GroupId;
 
     public SmtpSettingsDisplayDriver(
-        IShellReleaseManager shellReleaseManager,
+        IOptionsUpdateNotifier optionsUpdateNotifier,
         IDataProtectionProvider dataProtectionProvider,
         IHttpContextAccessor httpContextAccessor,
-        IOptions<SmtpOptions> options,
+        IOptionsMonitor<SmtpOptions> options,
         IAuthorizationService authorizationService,
         IEmailAddressValidator emailAddressValidator,
         IStringLocalizer<SmtpSettingsDisplayDriver> stringLocalizer)
     {
-        _shellReleaseManager = shellReleaseManager;
+        _optionsUpdateNotifier = optionsUpdateNotifier;
         _dataProtectionProvider = dataProtectionProvider;
         _httpContextAccessor = httpContextAccessor;
-        _smtpOptions = options.Value;
+        _smtpOptions = options;
         _authorizationService = authorizationService;
         _emailValidator = emailAddressValidator;
         S = stringLocalizer;
@@ -57,11 +58,13 @@ public sealed class SmtpSettingsDisplayDriver : SiteDisplayDriver<SmtpSettings>
             return null;
         }
 
+        var smtpOptions = _smtpOptions.CurrentValue;
+
         return Initialize<SmtpSettingsViewModel>("SmtpSettings_Edit", model =>
         {
             // For backward compatibility with instances before the SMTP provider was factored out of
             // OrchardCore.Email, if IsEnabled is null, we check to see if there's already valid configuration.
-            model.IsEnabled = settings.IsEnabled ?? _smtpOptions.ConfigurationExists();
+            model.IsEnabled = settings.IsEnabled ?? smtpOptions.ConfigurationExists();
             model.DefaultSender = settings.DefaultSender;
             model.DeliveryMethod = settings.DeliveryMethod;
             model.PickupDirectoryLocation = string.IsNullOrWhiteSpace(settings.PickupDirectoryLocation)
@@ -189,7 +192,10 @@ public sealed class SmtpSettingsDisplayDriver : SiteDisplayDriver<SmtpSettings>
 
             if (hasChanges)
             {
-                _shellReleaseManager.RequestRelease();
+                _optionsUpdateNotifier
+                    .RequestUpdate<SmtpOptions>()
+                    .RequestUpdate<EmailProviderOptions>()
+                    .RequestUpdate<EmailOptions>();
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/DefaultSmtpEmailProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/DefaultSmtpEmailProvider.cs
@@ -4,16 +4,16 @@ using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Email.Smtp.Services;
 
-public class DefaultSmtpEmailProvider : SmtpEmailProviderBase
+public class DefaultSmtpEmailProvider : SmtpEmailProviderBase<DefaultSmtpOptions>
 {
     public const string TechnicalName = "DefaultSMTP";
 
     public DefaultSmtpEmailProvider(
-        IOptions<DefaultSmtpOptions> options,
+        IOptionsMonitor<DefaultSmtpOptions> options,
         IEmailAddressValidator emailAddressValidator,
         ILogger<DefaultSmtpEmailProvider> logger,
         IStringLocalizer<DefaultSmtpEmailProvider> stringLocalizer)
-        : base(options.Value, emailAddressValidator, logger, stringLocalizer)
+        : base(options, emailAddressValidator, logger, stringLocalizer)
     {
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpEmailProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpEmailProvider.cs
@@ -9,11 +9,11 @@ public class SmtpEmailProvider : SmtpEmailProviderBase
     public const string TechnicalName = "SMTP";
 
     public SmtpEmailProvider(
-        IOptions<SmtpOptions> options,
+        IOptionsMonitor<SmtpOptions> options,
         IEmailAddressValidator emailAddressValidator,
         ILogger<SmtpEmailProvider> logger,
         IStringLocalizer<SmtpEmailProvider> stringLocalizer)
-        : base(options.Value, emailAddressValidator, logger, stringLocalizer)
+        : base(options.CurrentValue, emailAddressValidator, logger, stringLocalizer)
     {
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpEmailProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpEmailProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Email.Smtp.Services;
 
-public class SmtpEmailProvider : SmtpEmailProviderBase
+public class SmtpEmailProvider : SmtpEmailProviderBase<SmtpOptions>
 {
     public const string TechnicalName = "SMTP";
 
@@ -13,7 +13,7 @@ public class SmtpEmailProvider : SmtpEmailProviderBase
         IEmailAddressValidator emailAddressValidator,
         ILogger<SmtpEmailProvider> logger,
         IStringLocalizer<SmtpEmailProvider> stringLocalizer)
-        : base(options.CurrentValue, emailAddressValidator, logger, stringLocalizer)
+        : base(options, emailAddressValidator, logger, stringLocalizer)
     {
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpEmailProviderBase.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpEmailProviderBase.cs
@@ -5,28 +5,30 @@ using MailKit.Net.Smtp;
 using MailKit.Security;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using MimeKit;
 using OrchardCore.Infrastructure;
 
 namespace OrchardCore.Email.Smtp.Services;
 
-public abstract class SmtpEmailProviderBase : IEmailProvider
+public abstract class SmtpEmailProviderBase<TOptions> : IEmailProvider
+    where TOptions : SmtpOptions
 {
     private const string EmailExtension = ".eml";
 
-    private readonly SmtpOptions _providerOptions;
+    private readonly IOptionsMonitor<TOptions> _optionsMonitor;
     private readonly IEmailAddressValidator _emailAddressValidator;
     private readonly ILogger _logger;
 
     protected readonly IStringLocalizer S;
 
     public SmtpEmailProviderBase(
-        SmtpOptions options,
+        IOptionsMonitor<TOptions> optionsMonitor,
         IEmailAddressValidator emailAddressValidator,
         ILogger logger,
         IStringLocalizer stringLocalizer)
     {
-        _providerOptions = options;
+        _optionsMonitor = optionsMonitor;
         _emailAddressValidator = emailAddressValidator;
         _logger = logger;
         S = stringLocalizer;
@@ -44,13 +46,13 @@ public abstract class SmtpEmailProviderBase : IEmailProvider
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        if (!_providerOptions.IsEnabled)
+        if (!_optionsMonitor.CurrentValue.IsEnabled)
         {
             return Result.Failed(S["The SMTP Email Provider is disabled."]);
         }
 
         var senderAddress = string.IsNullOrWhiteSpace(message.From)
-            ? _providerOptions.DefaultSender
+            ? _optionsMonitor.CurrentValue.DefaultSender
             : message.From;
 
         if (_logger.IsEnabled(LogLevel.Debug))
@@ -77,21 +79,21 @@ public abstract class SmtpEmailProviderBase : IEmailProvider
 
         try
         {
-            if (_providerOptions.DeliveryMethod == SmtpDeliveryMethod.Network)
+            if (_optionsMonitor.CurrentValue.DeliveryMethod == SmtpDeliveryMethod.Network)
             {
                 var response = await SendOnlineMessageAsync(mimeMessage);
 
                 return Result.Success(response);
             }
 
-            if (_providerOptions.DeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory)
+            if (_optionsMonitor.CurrentValue.DeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory)
             {
-                await SendOfflineMessageAsync(mimeMessage, _providerOptions.PickupDirectoryLocation);
+                await SendOfflineMessageAsync(mimeMessage, _optionsMonitor.CurrentValue.PickupDirectoryLocation);
 
                 return Result.Success();
             }
 
-            throw new NotSupportedException($"The '{_providerOptions.DeliveryMethod}' delivery method is not supported.");
+            throw new NotSupportedException($"The '{_optionsMonitor.CurrentValue.DeliveryMethod}' delivery method is not supported.");
         }
         catch (Exception ex)
         {
@@ -103,7 +105,7 @@ public abstract class SmtpEmailProviderBase : IEmailProvider
     {
         var mimeMessage = new MimeMessage();
         var submitterAddress = string.IsNullOrWhiteSpace(message.Sender)
-            ? _providerOptions.DefaultSender
+            ? _optionsMonitor.CurrentValue.DefaultSender
             : message.Sender;
 
         if (!string.IsNullOrEmpty(submitterAddress))
@@ -146,9 +148,9 @@ public abstract class SmtpEmailProviderBase : IEmailProvider
     {
         var secureSocketOptions = SecureSocketOptions.Auto;
 
-        if (!_providerOptions.AutoSelectEncryption)
+        if (!_optionsMonitor.CurrentValue.AutoSelectEncryption)
         {
-            secureSocketOptions = _providerOptions.EncryptionMethod switch
+            secureSocketOptions = _optionsMonitor.CurrentValue.EncryptionMethod switch
             {
                 SmtpEncryptionMethod.None => SecureSocketOptions.None,
                 SmtpEncryptionMethod.SslTls => SecureSocketOptions.SslOnConnect,
@@ -161,24 +163,24 @@ public abstract class SmtpEmailProviderBase : IEmailProvider
 
         client.ServerCertificateValidationCallback = CertificateValidationCallback;
 
-        await client.ConnectAsync(_providerOptions.Host, _providerOptions.Port, secureSocketOptions);
+        await client.ConnectAsync(_optionsMonitor.CurrentValue.Host, _optionsMonitor.CurrentValue.Port, secureSocketOptions);
 
-        if (_providerOptions.RequireCredentials)
+        if (_optionsMonitor.CurrentValue.RequireCredentials)
         {
-            if (_providerOptions.UseDefaultCredentials)
+            if (_optionsMonitor.CurrentValue.UseDefaultCredentials)
             {
                 // There's no notion of 'UseDefaultCredentials' in MailKit, so empty credentials is passed in.
                 await client.AuthenticateAsync(string.Empty, string.Empty);
             }
-            else if (!string.IsNullOrWhiteSpace(_providerOptions.UserName))
+            else if (!string.IsNullOrWhiteSpace(_optionsMonitor.CurrentValue.UserName))
             {
-                await client.AuthenticateAsync(_providerOptions.UserName, _providerOptions.Password);
+                await client.AuthenticateAsync(_optionsMonitor.CurrentValue.UserName, _optionsMonitor.CurrentValue.Password);
             }
         }
 
-        if (!string.IsNullOrEmpty(_providerOptions.ProxyHost))
+        if (!string.IsNullOrEmpty(_optionsMonitor.CurrentValue.ProxyHost))
         {
-            client.ProxyClient = new Socks5Client(_providerOptions.ProxyHost, _providerOptions.ProxyPort);
+            client.ProxyClient = new Socks5Client(_optionsMonitor.CurrentValue.ProxyHost, _optionsMonitor.CurrentValue.ProxyPort);
         }
 
         var response = await client.SendAsync(message);
@@ -223,6 +225,6 @@ public abstract class SmtpEmailProviderBase : IEmailProvider
             }
         }
 
-        return _providerOptions.IgnoreInvalidSslCertificate;
+        return _optionsMonitor.CurrentValue.IgnoreInvalidSslCertificate;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpProviderOptionsConfigurations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpProviderOptionsConfigurations.cs
@@ -5,14 +5,14 @@ namespace OrchardCore.Email.Smtp.Services;
 
 public sealed class SmtpProviderOptionsConfigurations : IConfigureOptions<EmailProviderOptions>
 {
-    private readonly SmtpOptions _smtpOptions;
+    private readonly IOptionsMonitor<SmtpOptions> _smtpOptions;
     private readonly DefaultSmtpOptions _defaultSmtpOptions;
 
     public SmtpProviderOptionsConfigurations(
-        IOptions<SmtpOptions> smtpOptions,
+        IOptionsMonitor<SmtpOptions> smtpOptions,
         IOptions<DefaultSmtpOptions> defaultSmtpOptions)
     {
-        _smtpOptions = smtpOptions.Value;
+        _smtpOptions = smtpOptions;
         _defaultSmtpOptions = defaultSmtpOptions.Value;
     }
 
@@ -30,7 +30,7 @@ public sealed class SmtpProviderOptionsConfigurations : IConfigureOptions<EmailP
     {
         var typeOptions = new EmailProviderTypeOptions(typeof(SmtpEmailProvider))
         {
-            IsEnabled = _smtpOptions.IsEnabled,
+            IsEnabled = _smtpOptions.CurrentValue.IsEnabled,
         };
 
         options.TryAddProvider(SmtpEmailProvider.TechnicalName, typeOptions);

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Startup.cs
@@ -5,6 +5,7 @@ using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Email.Smtp.Drivers;
 using OrchardCore.Email.Smtp.Extensions;
 using OrchardCore.Email.Smtp.Services;
+using OrchardCore.Environment.Options;
 using OrchardCore.Environment.Shell.Configuration;
 
 namespace OrchardCore.Email.Smtp;
@@ -22,6 +23,7 @@ public sealed class Startup
     {
         services.AddSmtpEmailProvider()
             .AddSiteDisplayDriver<SmtpSettingsDisplayDriver>()
+            .AddSignalOptionsChangeTokenSource<SmtpOptions>()
             .AddTransient<IConfigureOptions<SmtpOptions>, SmtpOptionsConfiguration>()
             .AddTransient<IPostConfigureOptions<DefaultSmtpOptions>, DefaultSmtpOptionsConfiguration>();
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -35,6 +35,7 @@ If your own settings UI updates values that feed those options, register Orchard
 - `ExternalLoginOptions` now participates in this refresh pipeline, so changes to external login settings take effect without forcing a shell release. Custom code that cached `ExternalLoginOptions` from `IOptions<ExternalLoginOptions>` must switch to `IOptionsMonitor<ExternalLoginOptions>` and read `CurrentValue`.
 - `AzureAISearchDefaultOptions` now participates in this refresh pipeline, so changes to Azure AI Search settings take effect without forcing a shell release. Custom code that cached `AzureAISearchDefaultOptions` from `IOptions<AzureAISearchDefaultOptions>` must switch to `IOptionsMonitor<AzureAISearchDefaultOptions>` and read `CurrentValue`.
 - `SmtpOptions` now participates in this refresh pipeline, so changes to SMTP site settings take effect without forcing a shell release. Custom code that cached `SmtpOptions` from `IOptions<SmtpOptions>` must switch to `IOptionsMonitor<SmtpOptions>` and read `CurrentValue`.
+- `SmtpEmailProviderBase` is now generic (`SmtpEmailProviderBase<TOptions> where TOptions : SmtpOptions`) and its constructor takes `IOptionsMonitor<TOptions>` instead of a `SmtpOptions` instance. Custom SMTP providers derived from the old non-generic base class must update their inheritance declaration and constructor to pass `IOptionsMonitor<TOptions>`.
 
 ### Media Module
 

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -34,6 +34,7 @@ If your own settings UI updates values that feed those options, register Orchard
 - `RegistrationOptions` now participates in this refresh pipeline, so changes to registration settings take effect without forcing a shell release. Custom code that cached `RegistrationOptions` from `IOptions<RegistrationOptions>` must switch to `IOptionsMonitor<RegistrationOptions>` and read `CurrentValue`.
 - `ExternalLoginOptions` now participates in this refresh pipeline, so changes to external login settings take effect without forcing a shell release. Custom code that cached `ExternalLoginOptions` from `IOptions<ExternalLoginOptions>` must switch to `IOptionsMonitor<ExternalLoginOptions>` and read `CurrentValue`.
 - `AzureAISearchDefaultOptions` now participates in this refresh pipeline, so changes to Azure AI Search settings take effect without forcing a shell release. Custom code that cached `AzureAISearchDefaultOptions` from `IOptions<AzureAISearchDefaultOptions>` must switch to `IOptionsMonitor<AzureAISearchDefaultOptions>` and read `CurrentValue`.
+- `SmtpOptions` now participates in this refresh pipeline, so changes to SMTP site settings take effect without forcing a shell release. Custom code that cached `SmtpOptions` from `IOptions<SmtpOptions>` must switch to `IOptionsMonitor<SmtpOptions>` and read `CurrentValue`.
 
 ### Media Module
 

--- a/test/OrchardCore.Tests/Email/EmailTests.cs
+++ b/test/OrchardCore.Tests/Email/EmailTests.cs
@@ -287,8 +287,8 @@ public class EmailTests
 
     private static SmtpEmailProvider CreateSmtpService(SmtpOptions smtpOptions)
     {
-        var options = new Mock<IOptions<SmtpOptions>>();
-        options.Setup(o => o.Value)
+        var options = new Mock<IOptionsMonitor<SmtpOptions>>();
+        options.Setup(o => o.CurrentValue)
             .Returns(smtpOptions);
 
         var logger = new Mock<ILogger<SmtpEmailProvider>>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email.Smtp/SmtpOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email.Smtp/SmtpOptionsMonitorTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Email;
+using OrchardCore.Email.Services;
+using OrchardCore.Email.Smtp.Services;
+using OrchardCore.Entities;
+using OrchardCore.Environment.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Settings;
+using OrchardCore.Tests.Apis.Context;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Email.Smtp;
+
+public class SmtpOptionsMonitorTests
+{
+    [Fact]
+    public async Task RequestUpdate_ShouldRefreshSmtpOptionsWithoutReleasingTenant()
+    {
+        using var context = new SiteContext()
+            .WithRecipe("SaaS");
+
+        await context.InitializeAsync();
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var shellFeaturesManager = scope.ServiceProvider.GetRequiredService<IShellFeaturesManager>();
+            var availableFeatures = await shellFeaturesManager.GetAvailableFeaturesAsync();
+            var featuresToEnable = availableFeatures.Where(feature => feature.Id == "OrchardCore.Email.Smtp");
+
+            await shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force: true);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        long shellContextTicks = 0;
+
+        await context.UsingTenantScopeAsync(scope =>
+        {
+            shellContextTicks = scope.ShellContext.UtcTicks;
+
+            Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<SmtpOptions>>().CurrentValue.IsEnabled);
+
+            return Task.CompletedTask;
+        });
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
+            var notifier = scope.ServiceProvider.GetRequiredService<IOptionsUpdateNotifier>();
+
+            var site = await siteService.LoadSiteSettingsAsync();
+
+            site.Put(new SmtpSettings
+            {
+                IsEnabled = true,
+                DefaultSender = "admin@example.com",
+                DeliveryMethod = SmtpDeliveryMethod.SpecifiedPickupDirectory,
+                PickupDirectoryLocation = "Email",
+            });
+
+            site.Put(new EmailSettings
+            {
+                DefaultProviderName = SmtpEmailProvider.TechnicalName,
+            });
+
+            notifier
+                .RequestUpdate<SmtpOptions>()
+                .RequestUpdate<EmailProviderOptions>()
+                .RequestUpdate<EmailOptions>();
+
+            await siteService.UpdateSiteSettingsAsync(site);
+        });
+
+        await context.WaitForDeferredTasksAsync(CancellationToken.None);
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            Assert.Equal(shellContextTicks, scope.ShellContext.UtcTicks);
+
+            var smtpOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<SmtpOptions>>().CurrentValue;
+            Assert.True(smtpOptions.IsEnabled);
+            Assert.Equal("admin@example.com", smtpOptions.DefaultSender);
+            Assert.Equal(SmtpDeliveryMethod.SpecifiedPickupDirectory, smtpOptions.DeliveryMethod);
+
+            var emailOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailOptions>>().CurrentValue;
+            Assert.Equal(SmtpEmailProvider.TechnicalName, emailOptions.DefaultProviderName);
+
+            var providerOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<EmailProviderOptions>>().CurrentValue;
+            Assert.True(providerOptions.Providers[SmtpEmailProvider.TechnicalName].IsEnabled);
+
+            var providerResolver = scope.ServiceProvider.GetRequiredService<IEmailProviderResolver>();
+            var provider = await providerResolver.GetAsync();
+
+            Assert.IsType<SmtpEmailProvider>(provider);
+        });
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
@@ -50,7 +50,7 @@ public class EmailTaskTests
 
     private static DefaultEmailService CreateSmtpService(SmtpOptions smtpOptions)
     {
-        var options = new Mock<IOptions<SmtpOptions>>();
+        var options = new Mock<IOptionsMonitor<SmtpOptions>>();
         var logger = new Mock<ILogger<SmtpEmailProvider>>();
         var logger2 = new Mock<ILogger<DefaultEmailService>>();
 
@@ -61,7 +61,7 @@ public class EmailTaskTests
         emailValidator.Setup(x => x.Validate(It.IsAny<string>()))
             .Returns(true);
 
-        options.Setup(o => o.Value)
+        options.Setup(o => o.CurrentValue)
             .Returns(smtpOptions);
 
         var smtp = new SmtpEmailProvider(options.Object, emailValidator.Object, logger.Object, localizer.Object);


### PR DESCRIPTION
## Summary
- refresh SMTP site settings through `IOptionsMonitor<SmtpOptions>` instead of a shell release
- invalidate `SmtpOptions`, `EmailProviderOptions`, and `EmailOptions` together when SMTP settings update
- add a focused monitor test and one 4.0.0 breaking-change bullet for `SmtpOptions`

## Testing
- dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --filter-class "*SmtpOptionsMonitorTests" --filter-class "*EmailTests" --filter-class "*EmailTaskTests" --filter-class "*SmtpOptionsConfigurationTests"