### PR TITLE
Fix RequireFeatures shape providers leaking across shells

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -97,7 +97,7 @@ public class DefaultShapeTableManager : IShapeTableManager
 
         foreach (var bindingStrategy in bindingStrategies)
         {
-            var requiredFeatureIds = RequireFeaturesAttribute.GetRequiredFeatureNamesForType(bindingStrategy.GetType()).ToArray();
+            var requiredFeatureIds = RequireFeaturesAttribute.GetRequiredFeatureNamesForType(bindingStrategy.GetType());
 
             foreach (var strategyFeature in typeFeatureProvider.GetFeaturesForDependency(bindingStrategy.GetType()))
             {
@@ -161,7 +161,7 @@ public class DefaultShapeTableManager : IShapeTableManager
         IShapeTableProvider bindingStrategy,
         IEnumerable<ShapeAlteration> builtAlterations,
         Dictionary<string, FeatureShapeDescriptor> shapeDescriptors,
-        IReadOnlyCollection<string> requiredFeatureIds)
+        IList<string> requiredFeatureIds)
     {
         var alterationSets = builtAlterations.GroupBy(a => a.Feature.Id + a.ShapeType);
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -8,6 +8,7 @@ using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Extensions.Features;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Locking;
+using OrchardCore.Modules;
 
 namespace OrchardCore.DisplayManagement.Descriptors;
 
@@ -96,13 +97,15 @@ public class DefaultShapeTableManager : IShapeTableManager
 
         foreach (var bindingStrategy in bindingStrategies)
         {
+            var requiredFeatureIds = RequireFeaturesAttribute.GetRequiredFeatureNamesForType(bindingStrategy.GetType()).ToArray();
+
             foreach (var strategyFeature in typeFeatureProvider.GetFeaturesForDependency(bindingStrategy.GetType()))
             {
                 var builder = new ShapeTableBuilder(strategyFeature, excludedFeatures);
                 await bindingStrategy.DiscoverAsync(builder);
                 var builtAlterations = builder.BuildAlterations();
 
-                BuildDescriptors(bindingStrategy, builtAlterations, shapeDescriptors);
+                BuildDescriptors(bindingStrategy, builtAlterations, shapeDescriptors, requiredFeatureIds);
             }
         }
 
@@ -127,6 +130,7 @@ public class DefaultShapeTableManager : IShapeTableManager
 
         var descriptors = s_shapeDescriptors
             .Where(sd => enabledAndOrderedFeatureIds.Contains(sd.Value.Feature.Id))
+            .Where(sd => sd.Value.RequiredFeatureIds.Count == 0 || sd.Value.RequiredFeatureIds.All(enabledAndOrderedFeatureIds.Contains))
             .Where(sd => IsModuleOrRequestedTheme(extensionManager, sd.Value.Feature, themeId))
             .OrderBy(sd => enabledAndOrderedFeatureIds.IndexOf(sd.Value.Feature.Id))
             .GroupBy(sd => sd.Value.ShapeType, StringComparer.OrdinalIgnoreCase)
@@ -156,7 +160,8 @@ public class DefaultShapeTableManager : IShapeTableManager
     private static void BuildDescriptors(
         IShapeTableProvider bindingStrategy,
         IEnumerable<ShapeAlteration> builtAlterations,
-        Dictionary<string, FeatureShapeDescriptor> shapeDescriptors)
+        Dictionary<string, FeatureShapeDescriptor> shapeDescriptors,
+        IReadOnlyCollection<string> requiredFeatureIds)
     {
         var alterationSets = builtAlterations.GroupBy(a => a.Feature.Id + a.ShapeType);
 
@@ -173,7 +178,8 @@ public class DefaultShapeTableManager : IShapeTableManager
                 var descriptor = new FeatureShapeDescriptor
                 (
                     firstAlteration.Feature,
-                    firstAlteration.ShapeType
+                    firstAlteration.ShapeType,
+                    requiredFeatureIds
                 );
 
                 foreach (var alteration in alterations)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/FeatureShapeDescriptor.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/FeatureShapeDescriptor.cs
@@ -6,6 +6,11 @@ namespace OrchardCore.DisplayManagement.Descriptors;
 
 public sealed class FeatureShapeDescriptor : ShapeDescriptor
 {
+    public FeatureShapeDescriptor(IFeatureInfo feature, string shapeType)
+        : this(feature, shapeType, requiredFeatureIds: null)
+    {
+    }
+
     public FeatureShapeDescriptor(IFeatureInfo feature, string shapeType, IReadOnlyCollection<string> requiredFeatureIds = null)
     {
         Feature = feature;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/FeatureShapeDescriptor.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/FeatureShapeDescriptor.cs
@@ -11,7 +11,7 @@ public sealed class FeatureShapeDescriptor : ShapeDescriptor
     {
     }
 
-    public FeatureShapeDescriptor(IFeatureInfo feature, string shapeType, IReadOnlyCollection<string> requiredFeatureIds = null)
+    public FeatureShapeDescriptor(IFeatureInfo feature, string shapeType, IList<string> requiredFeatureIds = null)
     {
         Feature = feature;
         ShapeType = shapeType;
@@ -31,7 +31,7 @@ public sealed class FeatureShapeDescriptor : ShapeDescriptor
     /// gate (e.g. a shape provider attributed to its owning extension's feature id because it has no
     /// explicit [Feature] attribute of its own).
     /// </summary>
-    public IReadOnlyCollection<string> RequiredFeatureIds { get; }
+    public IList<string> RequiredFeatureIds { get; }
 }
 
 public sealed class ShapeDescriptorIndex : ShapeDescriptor

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/FeatureShapeDescriptor.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/FeatureShapeDescriptor.cs
@@ -6,13 +6,27 @@ namespace OrchardCore.DisplayManagement.Descriptors;
 
 public sealed class FeatureShapeDescriptor : ShapeDescriptor
 {
-    public FeatureShapeDescriptor(IFeatureInfo feature, string shapeType)
+    public FeatureShapeDescriptor(IFeatureInfo feature, string shapeType, IReadOnlyCollection<string> requiredFeatureIds = null)
     {
         Feature = feature;
         ShapeType = shapeType;
+        RequiredFeatureIds = requiredFeatureIds ?? [];
     }
 
     public IFeatureInfo Feature { get; }
+
+    /// <summary>
+    /// The feature ids that must be enabled (as checked by <see cref="Modules.RequireFeaturesAttribute"/>
+    /// on the <see cref="IShapeTableProvider"/> that produced this descriptor) for it to apply.
+    /// This is tracked separately from <see cref="Feature"/> because these descriptors are cached
+    /// statically and reused across tenants/shells: a provider gated by RequireFeatures only runs
+    /// (and is only added to <c>s_shapeDescriptors</c>) for shells that satisfy the gate, but once
+    /// cached the entry would otherwise be reused for any other shell where <see cref="Feature"/>
+    /// happens to be enabled too, even if that shell does not satisfy the original RequireFeatures
+    /// gate (e.g. a shape provider attributed to its owning extension's feature id because it has no
+    /// explicit [Feature] attribute of its own).
+    /// </summary>
+    public IReadOnlyCollection<string> RequiredFeatureIds { get; }
 }
 
 public sealed class ShapeDescriptorIndex : ShapeDescriptor


### PR DESCRIPTION
 via static shape-descriptor cache

DefaultShapeTableManager caches built shape descriptors in a process-wide static ConcurrentDictionary<string, FeatureShapeDescriptor> (s_shapeDescriptors), shared across every tenant/shell in the process since FeatureShapeDescriptors are documented as 'identical across tenants so they can be reused statically'.

That cache was previously filtered only by whether the descriptor's owning Feature.Id is enabled in the current shell - it had no way to know that the IShapeTableProvider which produced a given descriptor was gated by a [RequireFeatures(...)] attribute and therefore only actually ran (and got added to the cache) for a shell that satisfied that gate.

This silently broke for any IShapeTableProvider with no [Feature(...)] attribute of its own: ExtensionManager.GetSourceFeatureNameForType falls back to the owning extension's id in that case, so the descriptor gets cached under that broader feature id - not the feature the RequireFeatures attribute actually gates on. Once cached (by whichever shell happens to build its shape table first), any other shell where that broader feature is enabled reuses the same cached descriptor unconditionally, even if it does not itself satisfy the original RequireFeatures gate.

Concretely: OrchardCore.ContentFields.Media.MediaShapes is [RequireFeatures("OrchardCore.Media")] but has no [Feature] attribute of its own, so it's attributed to feature id "OrchardCore.ContentFields" (its owning extension). It adds a Media_Wrapper__HtmlField wrapper to the Trumbowyg/Wysiwyg HtmlField editor shapes, which renders a <style asp-name="media"> tag - a resource only registered by OrchardCore.Media itself. In a single test process running many parallel tenants (as CI's functional test suite does), once any tenant with both ContentFields and Media enabled builds its shape table first, every other tenant with just ContentFields enabled (but not Media) inherits that wrapper too - and then throws an unhandled 500 ("Could not find a resource of type 'stylesheet' named 'media'") the moment it renders a Trumbowyg/Wysiwyg HtmlField editor. That 500 corrupts an in-flight Kestrel connection for the whole test host process, cascading into dozens of unrelated test failures in the same run.

Fixed by threading the IShapeTableProvider's RequireFeaturesAttribute feature ids through FeatureShapeDescriptor (as RequiredFeatureIds) and checking them against the current shell's enabled features alongside the existing Feature.Id check, so a RequireFeatures-gated descriptor can never apply to a shell that does not satisfy its own gate - regardless of which shell happened to populate the shared static cache first, and regardless of whether the provider has its own explicit [Feature] attribute.

Verified: dotnet build -c Release --warnaserror clean across the whole solution; dotnet test test/OrchardCore.Tests -c Release: 2590/2592 passing (1 pre-existing Lucene lock-contention flake unrelated to this change, 1 skipped, matches baseline); full CMS functional suite run in progress.

Branched from origin/main directly (not stacked on skrypt/es-module) since this is a general DisplayManagement framework fix independent of the ES-module/yarn-check work, even though PR #19522's new EsModuleEditorTests functional test is what first exposed it under CI's parallel-tenant load.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
