### PR TITLE
Use options monitor for Twilio SMS settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/TwilioSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/TwilioSettingsDisplayDriver.cs
@@ -147,7 +147,9 @@ public sealed class TwilioSettingsDisplayDriver : SiteDisplayDriver<TwilioSettin
 
         if (hasChanges)
         {
-            _optionsUpdateNotifier.RequestUpdate<SmsProviderOptions>();
+            _optionsUpdateNotifier
+                .RequestUpdate<TwilioOptions>()
+                .RequestUpdate<SmsProviderOptions>();
         }
 
         return Edit(site, settings, context);

--- a/src/OrchardCore.Modules/OrchardCore.Sms/HealthChecks/SmsHealthCheck.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/HealthChecks/SmsHealthCheck.cs
@@ -1,8 +1,7 @@
 using System.Net.Http.Headers;
 using System.Text;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using OrchardCore.Settings;
+using Microsoft.Extensions.Options;
 using OrchardCore.Sms.Models;
 using OrchardCore.Sms.Services;
 
@@ -11,20 +10,17 @@ namespace OrchardCore.Sms.HealthChecks;
 internal sealed class SmsHealthCheck : IHealthCheck
 {
     private readonly ISmsService _smsService;
-    private readonly ISiteService _siteService;
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly IDataProtectionProvider _dataProtectionProvider;
+    private readonly IOptionsMonitor<TwilioOptions> _twilioOptions;
 
     public SmsHealthCheck(
         ISmsService smsService,
-        ISiteService siteService,
         IHttpClientFactory httpClientFactory,
-        IDataProtectionProvider dataProtectionProvider)
+        IOptionsMonitor<TwilioOptions> twilioOptions)
     {
         _smsService = smsService;
-        _siteService = siteService;
         _httpClientFactory = httpClientFactory;
-        _dataProtectionProvider = dataProtectionProvider;
+        _twilioOptions = twilioOptions;
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
@@ -36,11 +32,9 @@ internal sealed class SmsHealthCheck : IHealthCheck
                 return HealthCheckResult.Unhealthy(description: $"The service '{nameof(ISmsService)}' isn't registered.");
             }
 
-            var settings = await _siteService.GetSettingsAsync<TwilioSettings>();
+            var settings = _twilioOptions.CurrentValue;
 
-            var dataProtector = _dataProtectionProvider.CreateProtector(TwilioSmsProvider.ProtectorName);
-
-            if (await ValidateTwilioCredentialsAsync(settings.AccountSID, dataProtector.Unprotect(settings.AuthToken)))
+            if (await ValidateTwilioCredentialsAsync(settings.AccountSID, settings.AuthToken))
             {
                 return HealthCheckResult.Healthy();
             }

--- a/src/OrchardCore/OrchardCore.Sms.Core/Models/TwilioOptions.cs
+++ b/src/OrchardCore/OrchardCore.Sms.Core/Models/TwilioOptions.cs
@@ -1,0 +1,27 @@
+namespace OrchardCore.Sms.Models;
+
+/// <summary>
+/// Represents the runtime Twilio SMS provider options loaded from site settings.
+/// </summary>
+public class TwilioOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the provider is enabled.
+    /// </summary>
+    public bool IsEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the sending phone number.
+    /// </summary>
+    public string PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Twilio account SID.
+    /// </summary>
+    public string AccountSID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the decrypted Twilio auth token.
+    /// </summary>
+    public string AuthToken { get; set; }
+}

--- a/src/OrchardCore/OrchardCore.Sms.Core/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Sms.Core/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Options;
+using OrchardCore.Sms.Models;
 using OrchardCore.Sms.Services;
 
 namespace OrchardCore.Sms;
@@ -47,7 +48,9 @@ public static class ServiceCollectionExtensions
             client.BaseAddress = new Uri("https://api.twilio.com/2010-04-01/Accounts/");
         }).AddStandardResilienceHandler();
 
-        return services.AddSmsProviderOptionsConfiguration<TwilioProviderOptionsConfigurations>();
+        return services.AddSignalOptionsChangeTokenSource<TwilioOptions>()
+            .AddSmsProviderOptionsConfiguration<TwilioProviderOptionsConfigurations>()
+            .AddTransient<IConfigureOptions<TwilioOptions>, TwilioOptionsConfiguration>();
     }
 
     public static IServiceCollection AddLogSmsProvider(this IServiceCollection services)

--- a/src/OrchardCore/OrchardCore.Sms.Core/Services/TwilioOptionsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.Sms.Core/Services/TwilioOptionsConfiguration.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Settings;
+using OrchardCore.Sms.Models;
+
+namespace OrchardCore.Sms.Services;
+
+public sealed class TwilioOptionsConfiguration : IConfigureOptions<TwilioOptions>
+{
+    private readonly ISiteService _siteService;
+    private readonly IDataProtectionProvider _dataProtectionProvider;
+
+    public TwilioOptionsConfiguration(
+        ISiteService siteService,
+        IDataProtectionProvider dataProtectionProvider)
+    {
+        _siteService = siteService;
+        _dataProtectionProvider = dataProtectionProvider;
+    }
+
+    public void Configure(TwilioOptions options)
+    {
+        var settings = _siteService.GetSettings<TwilioSettings>();
+
+        options.IsEnabled = settings.IsEnabled;
+        options.PhoneNumber = settings.PhoneNumber;
+        options.AccountSID = settings.AccountSID;
+
+        if (!string.IsNullOrEmpty(settings.AuthToken))
+        {
+            var protector = _dataProtectionProvider.CreateProtector(TwilioSmsProvider.ProtectorName);
+
+            options.AuthToken = protector.Unprotect(settings.AuthToken);
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Sms.Core/Services/TwilioProviderOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.Sms.Core/Services/TwilioProviderOptionsConfigurations.cs
@@ -6,20 +6,17 @@ namespace OrchardCore.Sms.Services;
 
 public sealed class TwilioProviderOptionsConfigurations : IConfigureOptions<SmsProviderOptions>
 {
-    private readonly ISiteService _siteService;
+    private readonly IOptionsMonitor<TwilioOptions> _twilioOptions;
 
-    public TwilioProviderOptionsConfigurations(ISiteService siteService)
+    public TwilioProviderOptionsConfigurations(IOptionsMonitor<TwilioOptions> twilioOptions)
     {
-        _siteService = siteService;
+        _twilioOptions = twilioOptions;
     }
 
     public void Configure(SmsProviderOptions options)
     {
         var typeOptions = new SmsProviderTypeOptions(typeof(TwilioSmsProvider));
-
-        var settings = _siteService.GetSettings<TwilioSettings>();
-
-        typeOptions.IsEnabled = settings.IsEnabled;
+        typeOptions.IsEnabled = _twilioOptions.CurrentValue.IsEnabled;
 
         options.TryAddProvider(TwilioSmsProvider.TechnicalName, typeOptions);
     }

--- a/src/OrchardCore/OrchardCore.Sms.Core/Services/TwilioSmsProvider.cs
+++ b/src/OrchardCore/OrchardCore.Sms.Core/Services/TwilioSmsProvider.cs
@@ -2,11 +2,10 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OrchardCore.Infrastructure;
-using OrchardCore.Settings;
 using OrchardCore.Sms.Models;
 
 namespace OrchardCore.Sms.Services;
@@ -24,22 +23,19 @@ public class TwilioSmsProvider : ISmsProvider
 
     public LocalizedString Name => S["Twilio"];
 
-    private readonly ISiteService _siteService;
-    private readonly IDataProtectionProvider _dataProtectionProvider;
+    private readonly IOptionsMonitor<TwilioOptions> _options;
     private readonly ILogger<TwilioSmsProvider> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
 
     protected readonly IStringLocalizer S;
 
     public TwilioSmsProvider(
-        ISiteService siteService,
-        IDataProtectionProvider dataProtectionProvider,
+        IOptionsMonitor<TwilioOptions> options,
         ILogger<TwilioSmsProvider> logger,
         IHttpClientFactory httpClientFactory,
         IStringLocalizer<TwilioSmsProvider> stringLocalizer)
     {
-        _siteService = siteService;
-        _dataProtectionProvider = dataProtectionProvider;
+        _options = options;
         _logger = logger;
         _httpClientFactory = httpClientFactory;
         S = stringLocalizer;
@@ -67,7 +63,7 @@ public class TwilioSmsProvider : ISmsProvider
 
         try
         {
-            var settings = await GetSettingsAsync();
+            var settings = _options.CurrentValue;
 
             var senderNumber = settings.PhoneNumber;
 
@@ -109,7 +105,7 @@ public class TwilioSmsProvider : ISmsProvider
         }
     }
 
-    private HttpClient GetHttpClient(TwilioSettings settings)
+    private HttpClient GetHttpClient(TwilioOptions settings)
     {
         var token = $"{settings.AccountSID}:{settings.AuthToken}";
         var base64Token = Convert.ToBase64String(Encoding.ASCII.GetBytes(token));
@@ -119,27 +115,5 @@ public class TwilioSmsProvider : ISmsProvider
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64Token);
 
         return client;
-    }
-
-    private TwilioSettings _settings;
-
-    private async Task<TwilioSettings> GetSettingsAsync()
-    {
-        if (_settings == null)
-        {
-            var settings = await _siteService.GetSettingsAsync<TwilioSettings>();
-
-            var protector = _dataProtectionProvider.CreateProtector(ProtectorName);
-
-            // It is important to create a new instance of `TwilioSettings` privately to hold the plain auth-token value.
-            _settings = new TwilioSettings
-            {
-                PhoneNumber = settings.PhoneNumber,
-                AccountSID = settings.AccountSID,
-                AuthToken = settings.AuthToken == null ? null : protector.Unprotect(settings.AuthToken),
-            };
-        }
-
-        return _settings;
     }
 }

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -37,6 +37,7 @@ If your own settings UI updates values that feed those options, register Orchard
 - `SmtpOptions` now participates in this refresh pipeline, so changes to SMTP site settings take effect without forcing a shell release. Custom code that cached `SmtpOptions` from `IOptions<SmtpOptions>` must switch to `IOptionsMonitor<SmtpOptions>` and read `CurrentValue`.
 - `SmsProviderOptions` now participates in this refresh pipeline, so changes to the enabled SMS providers and SMS provider selection take effect without forcing a shell release. Custom code that cached `SmsProviderOptions` from `IOptions<SmsProviderOptions>` must switch to `IOptionsMonitor<SmsProviderOptions>` and read `CurrentValue`.
 - `AzureSmsOptions` now participates in this refresh pipeline, so changes to Azure Communication Services SMS settings take effect without forcing a shell release. Custom code that cached `AzureSmsOptions` from `IOptions<AzureSmsOptions>` must switch to `IOptionsMonitor<AzureSmsOptions>` and read `CurrentValue`.
+- `TwilioOptions` now participates in this refresh pipeline, so changes to Twilio SMS settings take effect without forcing a shell release. Custom code that cached `TwilioOptions` from `IOptions<TwilioOptions>` must switch to `IOptionsMonitor<TwilioOptions>` and read `CurrentValue`.
 
 ### Media Module
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Sms/TwilioOptionsMonitorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Sms/TwilioOptionsMonitorTests.cs
@@ -12,10 +12,10 @@ using OrchardCore.Tests.Apis.Context;
 
 namespace OrchardCore.Tests.Modules.OrchardCore.Sms;
 
-public class SmsProviderOptionsMonitorTests
+public class TwilioOptionsMonitorTests
 {
     [Fact]
-    public async Task RequestUpdate_ShouldRefreshSmsProviderOptionsWithoutReleasingTenant()
+    public async Task RequestUpdate_ShouldRefreshTwilioOptionsWithoutReleasingTenant()
     {
         using var context = new SiteContext()
             .WithRecipe("SaaS");
@@ -39,7 +39,7 @@ public class SmsProviderOptionsMonitorTests
         {
             shellContextTicks = scope.ShellContext.UtcTicks;
 
-            Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<SmsProviderOptions>>().CurrentValue.Providers[TwilioSmsProvider.TechnicalName].IsEnabled);
+            Assert.False(scope.ServiceProvider.GetRequiredService<IOptionsMonitor<TwilioOptions>>().CurrentValue.IsEnabled);
 
             return Task.CompletedTask;
         });
@@ -76,6 +76,12 @@ public class SmsProviderOptionsMonitorTests
         await context.UsingTenantScopeAsync(async scope =>
         {
             Assert.Equal(shellContextTicks, scope.ShellContext.UtcTicks);
+
+            var twilioOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<TwilioOptions>>().CurrentValue;
+            Assert.True(twilioOptions.IsEnabled);
+            Assert.Equal("+15555555555", twilioOptions.PhoneNumber);
+            Assert.Equal("account-sid", twilioOptions.AccountSID);
+            Assert.Equal("auth-token", twilioOptions.AuthToken);
 
             var providerOptions = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<SmsProviderOptions>>().CurrentValue;
             Assert.True(providerOptions.Providers[TwilioSmsProvider.TechnicalName].IsEnabled);


### PR DESCRIPTION
## Summary
- add a dedicated `TwilioOptions` mapping and refresh it through `IOptionsMonitor`
- invalidate `TwilioOptions` and `SmsProviderOptions` from the Twilio settings editor so Twilio settings changes take effect without a shell release
- add focused monitor tests and one 4.0.0 breaking-change bullet for `TwilioOptions`

## Testing
- dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --filter-class "*TwilioOptionsMonitorTests" --filter-class "*SmsProviderOptionsMonitorTests"