### PR TITLE
Set MenuItem.Id from AdminNode.UniqueId in the admin node navigation builders

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminNodes/LinkAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminNodes/LinkAdminNodeNavigationBuilder.cs
@@ -54,6 +54,7 @@ public class LinkAdminNodeNavigationBuilder : IAdminNodeNavigationBuilder
             }
 
             // Add the actual link.
+            itemBuilder.Id(node.UniqueId);
             itemBuilder.MenuName(node.MenuName);
             itemBuilder.Url(nodeLinkUrl);
             itemBuilder.Target(node.Target);

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminNodes/PlaceholderAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminNodes/PlaceholderAdminNodeNavigationBuilder.cs
@@ -32,6 +32,7 @@ public class PlaceholderAdminNodeNavigationBuilder : IAdminNodeNavigationBuilder
 
         return builder.AddAsync(new LocalizedString(node.LinkText, node.LinkText), async itemBuilder =>
         {
+            itemBuilder.Id(node.UniqueId);
             itemBuilder.MenuName(node.MenuName);
             itemBuilder.Priority(node.Priority);
             itemBuilder.Position(node.Position);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
@@ -58,6 +58,7 @@ public class ContentTypesAdminNodeNavigationBuilder : IAdminNodeNavigationBuilde
                     contentTypeId = ctd.Name,
                 }));
 
+                itemBuilder.Id($"{node.UniqueId}-{ctd.Name}");
                 itemBuilder.MenuName(node.MenuName);
                 itemBuilder.Priority(node.Priority);
                 itemBuilder.Position(node.Position);

--- a/src/OrchardCore.Modules/OrchardCore.Lists/AdminNodes/ListsAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/AdminNodes/ListsAdminNodeNavigationBuilder.cs
@@ -58,6 +58,7 @@ public class ListsAdminNodeNavigationBuilder : IAdminNodeNavigationBuilder
 
             await builder.AddAsync(new LocalizedString(_contentType.DisplayName, _contentType.DisplayName), async listTypeMenu =>
             {
+                listTypeMenu.Id(_node.UniqueId);
                 AddPrefixToClasses(_node.IconForParentLink).ForEach(c => listTypeMenu.AddClass(c));
                 listTypeMenu.Permission(ContentTypePermissionsHelper.CreateDynamicPermission(
                     ContentTypePermissionsHelper.PermissionTemplates[CommonPermissions.EditContent.Name], _contentType));
@@ -94,6 +95,7 @@ public class ListsAdminNodeNavigationBuilder : IAdminNodeNavigationBuilder
             {
                 listTypeMenu.Add(new LocalizedString(ci.DisplayText, ci.DisplayText), itemBuilder =>
                 {
+                    itemBuilder.Id($"{_node.UniqueId}-{ci.ContentItemId}");
                     itemBuilder.MenuName(_node.MenuName);
                     itemBuilder.Action(cim.AdminRouteValues["Action"] as string, cim.AdminRouteValues["Controller"] as string, cim.AdminRouteValues);
                     itemBuilder.Resource(ci);


### PR DESCRIPTION
This sets Id from UniqueId in the four admin node builders. 

MenuItem.Id was previously null for these items, and NavigationManager.Merge continues to match on Text.Name regardless of whether Id is set. Nodes become targetable by templates via the existing NavigationItemText_Id__{Id} alternates, the same way provider items already are.

ContentTypesAdminNode and ListsAdminNode expand one node into many items, so their Ids are qualified with the content type name / content item id to stay unique per built item while remaining stable when display names change.

There was a discussion opened for this [#19731](https://github.com/orgs/OrchardCMS/discussions/19731) for more detail.