### PR TITLE
Improve Available Filters UI (Contents and Users)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminFilters-Card.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminFilters-Card.Thumbnail.cshtml
@@ -1,6 +1,8 @@
 @model IShape
-<div class="card mb-3">
-    <div class="card-body">
-        @Model.Metadata.ChildContent
+<div class="col">
+    <div class="card h-100">
+        <div class="card-body d-flex flex-column">
+            @Model.Metadata.ChildContent
+        </div>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminListSearch.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminListSearch.cshtml
@@ -38,57 +38,55 @@
 <zone name="Footer">
     <div class="modal fade" id="modalAuditTrailIndexOptionsFilterSyntax" tabindex="-1" role="dialog"
          aria-labelledby="audittrail-filters-syntax-title" aria-hidden="true">
-        <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-dialog modal-xl" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="audittrail-filters-syntax-title">@T["Available Filters"]</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <div class="row">
-                        <div class="col-12 card-columns">
-                            @await DisplayAsync(syntaxThumbnail)
-                        </div>
+                    <div class="mb-3">
+                        @await DisplayAsync(syntaxThumbnail)
                     </div>
                     <div class="card mb-3">
                         <div class="card-body">
                             <h4>@T["Filter syntax"]</h4>
                             <ul class="fa-ul">
-                                <li>
+                                <li class="mb-1">
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-check text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Default"]</span>
+                                    <strong>@T["Default"]</strong>
                                     <span class="hint dashed">@T["may be entered with or without the term name"]</span>
                                 </li>
-                                <li>
+                                <li class="mb-1">
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Single"]</span>
+                                    <strong>@T["Single"]</strong>
                                     <span class="hint dashed">@T["A single value can be entered"]</span>
                                 </li>
                                 <li>
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Multiple"]</span>
+                                    <strong>@T["Multiple"]</strong>
                                     <span class="hint dashed">@T["Logical operators and groups are supported"]</span>
-                                    <ul class="list-unstyled">
+                                    <ul class="list-unstyled mt-2 ms-1">
                                         @*NB The operators and examples are not localizable.*@
-                                        <li>
-                                            <span class="hint">OR</span>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">OR</code>
                                             <span class="hint dashed">@T["The default operator when whitespace is found, e.g. {0}", "text:foo bar -> text:foo OR bar"]</span>
                                         </li>
-                                        <li>
-                                            <span class="hint">AND</span>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">AND</code>
                                             <span class="hint dashed">@T["Combines, e.g. {0}", "text:foo AND bar"]</span>
                                         </li>
-                                        <li>
-                                            <span class="hint">NOT</span>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">NOT</code>
                                             <span class="hint dashed">@T["Negates, e.g. {0}", "text:foo NOT bar"]</span>
                                         </li>
-                                        <li>
-                                            <span class="hint">( ... )</span>
-                                            <span class="hint">@T["Groups operators, e.g. {0}", "text:((foo OR bar) NOT baz)"]</span>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">( ... )</code>
+                                            <span class="hint dashed">@T["Groups operators, e.g. {0}", "text:((foo OR bar) NOT baz)"]</span>
                                         </li>
                                         <li>
-                                            <span class="hint">" ... "</span>
-                                            <span class="hint">@T["Escape operators, e.g. {0}", "text:\"foo bar\""]</span>
+                                            <code class="fw-bold">" ... "</code>
+                                            <span class="hint dashed">@T["Escape operators, e.g. {0}", "text:\"foo bar\""]</span>
                                         </li>
                                     </ul>
                                 </li>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailIndexOptions.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailIndexOptions.Thumbnail.cshtml
@@ -7,4 +7,6 @@
         shape.Metadata.Wrappers.Add("AuditTrailAdminFilters_Thumbnail__Card");
     }
 }
-@await DisplayAsync(content)
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+    @await DisplayAsync(content)
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-Category.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-Category.Thumbnail.cshtml
@@ -3,11 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "category");
 }
 
-<h4 class="card-title">@T["Category"]</h4>
-<pre class="mb-3">@(term?.ToString() ?? "category:...")</pre>
-<p>@T["Filters on the audit trail category."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Category"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "category:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on the audit trail category."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-CorrelationId.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-CorrelationId.Thumbnail.cshtml
@@ -3,11 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "id");
 }
 
-<h4 class="card-title">@T["Id"]</h4>
-<pre class="mb-3">@(term?.ToString() ?? "id:...")</pre>
-<p>@T["Filters on a correlation id."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Id"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "id:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a correlation id."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-Date.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-Date.Thumbnail.cshtml
@@ -3,12 +3,12 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "date");
 }
 
-<h4 class="card-title">@T["Date"]</h4>
-<pre class="mb-3">@(term?.ToString() ?? "date:...")</pre>
-<p>@T["Filters by a date or range."]</p>
-<span class="hint">@T["ISO 8601 date format *see date range syntax"]</span>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Date"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "date:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters by a date or range."]</p>
+<span class="d-block small text-body-secondary">@T["ISO 8601 date format *see date range syntax"]</span>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-Event.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-Event.Thumbnail.cshtml
@@ -3,11 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "event");
 }
 
-<h4 class="card-title">@T["Event"]</h4>
-<pre class="mb-3">@(term?.ToString() ?? "event:...")</pre>
-<p>@T["Filters on the audit trail event, when a Correlation Id is used."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Event"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "event:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on the audit trail event, when a Correlation Id is used."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-UserId.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-UserId.Thumbnail.cshtml
@@ -3,11 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "userid");
 }
 
-<h4 class="card-title">@T["User Id"]</h4>
-<pre class="mb-3">@(term?.ToString() ?? "userid:...")</pre>
-<p>@T["Filters by the id of a user."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["User Id"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "userid:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters by the id of a user."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-UserName.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/Items/AuditTrailAdminFilters-UserName.Thumbnail.cshtml
@@ -3,14 +3,12 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "username");
 }
 
-<h4 class="card-title">@T["User Name"]</h4>
-<pre class="mb-3">@(term?.ToString() ?? "username:...")</pre>
-<p>@T["Filters by the name of a user."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-check text-primary" aria-hidden="true"></i>
-    </span>
-    <span>
-        <i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["User Name"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-check" title="@T["Default term - may be entered with or without the term name"]" aria-hidden="true"></i>
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "username:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters by the name of a user."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/Items/ContentsAdminFilters-Culture.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/Items/ContentsAdminFilters-Culture.Thumbnail.cshtml
@@ -3,11 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "culture");
 }
 
-<h4 class="card-title">@T["Culture"]</h4>
-<pre class="mb-3">@(term?.ToString() ?? "culture:...")</pre>
-<p>@T["Filters on a content items localization culture."]</p>
-<div class="d-block text-right">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Culture"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "culture:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a content items localization culture."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentOptionsViewModel.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentOptionsViewModel.Thumbnail.cshtml
@@ -7,4 +7,6 @@
         shape.Metadata.Wrappers.Add("ContentsAdminFilters_Thumbnail__Card");
     }
 }
-@await DisplayAsync(content)
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+    @await DisplayAsync(content)
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminFilters-Card.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminFilters-Card.Thumbnail.cshtml
@@ -1,6 +1,8 @@
 @model IShape
-<div class="card mb-3">
-    <div class="card-body">
-        @Model.Metadata.ChildContent
+<div class="col">
+    <div class="card h-100">
+        <div class="card-body d-flex flex-column">
+            @Model.Metadata.ChildContent
+        </div>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSearch.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSearch.cshtml
@@ -32,57 +32,55 @@
 <zone name="Footer">
     <div class="modal fade" id="modalContentOptionsFilterSyntax" tabindex="-1" role="dialog"
          aria-labelledby="content-filters-syntax-title" aria-hidden="true">
-        <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-dialog modal-xl" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="content-filters-syntax-title">@T["Available Filters"]</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <div class="row">
-                        <div class="col-12 card-columns">
-                            @await DisplayAsync(syntaxThumbnail)
-                        </div>
+                    <div class="mb-3">
+                        @await DisplayAsync(syntaxThumbnail)
                     </div>
                     <div class="card mb-3">
                         <div class="card-body">
                             <h4>@T["Filter syntax"]</h4>
                             <ul class="fa-ul">
-                                <li>
+                                <li class="mb-1">
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-check text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Default"]</span>
+                                    <strong>@T["Default"]</strong>
                                     <span class="hint dashed">@T["may be entered with or without the term name"]</span>
                                 </li>
-                                <li>
+                                <li class="mb-1">
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Single"]</span>
+                                    <strong>@T["Single"]</strong>
                                     <span class="hint dashed">@T["A single value can be entered"]</span>
                                 </li>
                                 <li>
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Multiple"]</span>
+                                    <strong>@T["Multiple"]</strong>
                                     <span class="hint dashed">@T["Logical operators and groups are supported"]</span>
-                                    <ul class="list-unstyled">
+                                    <ul class="list-unstyled mt-2 ms-1">
                                         @*NB The operators and examples are not localizable.*@
-                                        <li>
-                                            <span class="hint">OR</span>
-                                            <span class="hint dashed">@T["The default operator when whitespace is found, e.g."]&nbsp text:foo bar -> text:foo OR bar</span>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">OR</code>
+                                            <span class="hint dashed">@T["The default operator when whitespace is found, e.g."]&nbsp;<code>text:foo bar -> text:foo OR bar</code></span>
+                                        </li>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">AND</code>
+                                            <span class="hint dashed">@T["Combines, e.g."]&nbsp;<code>text:foo AND bar</code></span>
+                                        </li>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">NOT</code>
+                                            <span class="hint dashed">@T["Negates, e.g."]&nbsp;<code>text:foo NOT bar</code></span>
+                                        </li>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">( ... )</code>
+                                            <span class="hint dashed">@T["Groups operators, e.g."]&nbsp;<code>text:((foo OR bar) NOT baz)</code></span>
                                         </li>
                                         <li>
-                                            <span class="hint">AND</span>
-                                            <span class="hint dashed">@T["Combines, e.g."]&nbsp text:foo AND bar</span>
-                                        </li>
-                                        <li>
-                                            <span class="hint">NOT</span>
-                                            <span class="hint dashed">@T["Negates, e.g."]&nbsp text:foo NOT bar</span>
-                                        </li>
-                                        <li>
-                                            <span class="hint">( ... )</span>
-                                            <span class="hint">@T["Groups operators, e.g."]&nbsp text:((foo OR bar) NOT baz)</span>
-                                        </li>
-                                        <li>
-                                            <span class="hint">" ... "</span>
-                                            <span class="hint">@T["Escape operators, e.g."]&nbsp text:"foo bar"</span>
+                                            <code class="fw-bold">" ... "</code>
+                                            <span class="hint dashed">@T["Escape operators, e.g."]&nbsp;<code>text:"foo bar"</code></span>
                                         </li>
                                     </ul>
                                 </li>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-ContentType.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-ContentType.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "type");
 }
 
-<div class="ocat-wrapper">
-    <h4 class="card-title ocat-label">@T["Content Type"]</h4>
-    <div class="ocat-end">
-        <pre>@(term?.ToString() ?? "type:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on a specified content type."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Content Type"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "type:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a specified content type."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-DisplayText.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-DisplayText.Thumbnail.cshtml
@@ -3,18 +3,12 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "text");
 }
 
-<div class="ocat-wrapper">
-    <h4 class="card-title ocat-label">@T["Display Text"]</h4>
-    <div class="ocat-end">
-        <pre>@(term?.ToString() ?? "text:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on the Display Text of a content item."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-check text-primary" aria-hidden="true"></i>
-    </span>
-    <span>
-        <i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Display Text"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-check" title="@T["Default term - may be entered with or without the term name"]" aria-hidden="true"></i>
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "text:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on the Display Text of a content item."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Sort.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Sort.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "sort");
 }
 
-<div class="ocat-wrapper">
-    <h4 class="card-title ocat-label">@T["Sort"]</h4>
-    <div class="ocat-end">
-        <pre>@(term?.ToString() ?? "sort:...")</pre>
-    </div>
-</div>
-<p>@T["Orders by a content item value."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Sort"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "sort:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Orders by a content item value."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Status.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Status.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "status");
 }
 
-<div class="ocat-wrapper">
-    <h4 class="card-title ocat-label">@T["Status"]</h4>
-    <div class="ocat-end">
-        <pre>@(term?.ToString() ?? "status:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on a content item status."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Status"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "status:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a content item status."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Stereotype.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Stereotype.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "stereotype");
 }
 
-<div class="ocat-wrapper">
-    <h4 class="card-title ocat-label">@T["Content Type Stereotype"]</h4>
-    <div class="ocat-end">
-        <pre>@(term?.ToString() ?? "stereotype:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on a specified content type stereotype."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Content Type Stereotype"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "stereotype:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a specified content type stereotype."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Email.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Email.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "email");
 }
 
-<h4 class="card-title">@T["Email"]</h4>
-<div class="ocat-wrapper">
-    <div class="ocat-end-offset">
-        <pre class="mb-0">@(term?.ToString() ?? "email:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on the email address of a user."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Email"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "email:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on the email address of a user."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Name.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Name.Thumbnail.cshtml
@@ -3,18 +3,12 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "name");
 }
 
-<h4 class="card-title">@T["Name"]</h4>
-<div class="ocat-wrapper">
-    <div class="ocat-end-offset">
-        <pre class="mb-0">@(term?.ToString() ?? "name:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on the name of a user."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-check text-primary" aria-hidden="true"></i>
-    </span>
-    <span>
-        <i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Name"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-check" title="@T["Default term - may be entered with or without the term name"]" aria-hidden="true"></i>
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "name:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on the name of a user."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Role.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Role.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "role");
 }
 
-<h4 class="card-title">@T["Role"]</h4>
-<div class="ocat-wrapper">
-    <div class="ocat-end-offset">
-        <pre class="mb-0">@(term?.ToString() ?? "role:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on a role name."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Role"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "role:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a role name."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Sort.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Sort.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "sort");
 }
 
-<h4 class="card-title">@T["Sort"]</h4>
-<div class="ocat-wrapper">
-    <div class="ocat-end-offset">
-        <pre class="mb-0">@(term?.ToString() ?? "sort:...")</pre>
-    </div>
-</div>
-<p>@T["Orders by a user value."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Sort"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "sort:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Orders by a user value."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Status.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UsersAdminFilters-Status.Thumbnail.cshtml
@@ -3,15 +3,11 @@
     var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "status");
 }
 
-<h4 class="card-title">@T["Status"]</h4>
-<div class="ocat-wrapper">
-    <div class="ocat-end-offset">
-        <pre class="mb-0">@(term?.ToString() ?? "status:...")</pre>
-    </div>
-</div>
-<p>@T["Filters on a user status."]</p>
-<div class="d-block text-end">
-    <span>
-        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Status"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
     </span>
 </div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "status:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a user status."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserIndexOptions.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserIndexOptions.Thumbnail.cshtml
@@ -7,4 +7,6 @@
         shape.Metadata.Wrappers.Add("UsersAdminFilters_Thumbnail__Card");
     }
 }
-@await DisplayAsync(content)
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3">
+    @await DisplayAsync(content)
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminFilters-Card.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminFilters-Card.Thumbnail.cshtml
@@ -1,6 +1,8 @@
 @model IShape
-<div class="card mb-3">
-    <div class="card-body">
-        @Model.Metadata.ChildContent
+<div class="col">
+    <div class="card h-100">
+        <div class="card-body d-flex flex-column">
+            @Model.Metadata.ChildContent
+        </div>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminListSearch.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminListSearch.cshtml
@@ -34,57 +34,55 @@
 <zone name="Footer">
     <div class="modal fade" id="modalUserIndexOptionsFilterSyntax" tabindex="-1" role="dialog"
          aria-labelledby="user-filters-syntax-title" aria-hidden="true">
-        <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-dialog modal-xl" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="user-filters-syntax-title">@T["Available Filters"]</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <div class="row">
-                        <div class="col-12 card-columns">
-                            @await DisplayAsync(syntaxThumbnail)
-                        </div>
+                    <div class="mb-3">
+                        @await DisplayAsync(syntaxThumbnail)
                     </div>
                     <div class="card mb-3">
                         <div class="card-body">
                             <h4>@T["Filter syntax"]</h4>
                             <ul class="fa-ul">
-                                <li>
+                                <li class="mb-1">
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-check text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Default"]</span>
+                                    <strong>@T["Default"]</strong>
                                     <span class="hint dashed">@T["may be entered with or without the term name"]</span>
                                 </li>
-                                <li>
+                                <li class="mb-1">
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Single"]</span>
+                                    <strong>@T["Single"]</strong>
                                     <span class="hint dashed">@T["A single value can be entered"]</span>
                                 </li>
                                 <li>
                                     <span class="fa-li"><i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i></span>
-                                    <span class="hint">@T["Multiple"]</span>
+                                    <strong>@T["Multiple"]</strong>
                                     <span class="hint dashed">@T["Logical operators and groups are supported"]</span>
-                                    <ul class="list-unstyled">
+                                    <ul class="list-unstyled mt-2 ms-1">
                                         @*NB The operators and examples are not localizable.*@
-                                        <li>
-                                            <span class="hint">OR</span>
-                                            <span class="hint dashed">@T["The default operator when whitespace is found, e.g."]&nbsp text:foo bar -> text:foo OR bar</span>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">OR</code>
+                                            <span class="hint dashed">@T["The default operator when whitespace is found, e.g."]&nbsp;<code>text:foo bar -> text:foo OR bar</code></span>
+                                        </li>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">AND</code>
+                                            <span class="hint dashed">@T["Combines, e.g."]&nbsp;<code>text:foo AND bar</code></span>
+                                        </li>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">NOT</code>
+                                            <span class="hint dashed">@T["Negates, e.g."]&nbsp;<code>text:foo NOT bar</code></span>
+                                        </li>
+                                        <li class="mb-1">
+                                            <code class="fw-bold">( ... )</code>
+                                            <span class="hint dashed">@T["Groups operators, e.g."]&nbsp;<code>text:((foo OR bar) NOT baz)</code></span>
                                         </li>
                                         <li>
-                                            <span class="hint">AND</span>
-                                            <span class="hint dashed">@T["Combines, e.g."]&nbsp text:foo AND bar</span>
-                                        </li>
-                                        <li>
-                                            <span class="hint">NOT</span>
-                                            <span class="hint dashed">@T["Negates, e.g."]&nbsp text:foo NOT bar</span>
-                                        </li>
-                                        <li>
-                                            <span class="hint">( ... )</span>
-                                            <span class="hint">@T["Groups operators, e.g."]&nbsp text:((foo OR bar) NOT baz)</span>
-                                        </li>
-                                        <li>
-                                            <span class="hint">" ... "</span>
-                                            <span class="hint">@T["Escape operators, e.g."]&nbsp text:"foo bar"</span>
+                                            <code class="fw-bold">" ... "</code>
+                                            <span class="hint dashed">@T["Escape operators, e.g."]&nbsp;<code>text:"foo bar"</code></span>
                                         </li>
                                     </ul>
                                 </li>

--- a/src/docs/reference/modules/Contents/README.md
+++ b/src/docs/reference/modules/Contents/README.md
@@ -582,6 +582,63 @@ Now, when a user searches for a product's serial number in the administration UI
 
 The `UseExactMatch` option in the `ContentsAdminListFilterOptions` class modifies the default search behavior by enclosing searched terms within quotation marks, creating an exact match search by default, this unless if the search text explicitly uses 'OR' or 'AND' operators.
 
+## Documenting Filters in the Admin UI
+
+The content items admin list has a **Filters** dropdown next to the search box. Its **Filter syntax** entry opens the **Available Filters** dialog, which lists every filter a user can type into the search box (`text:`, `type:`, `status:`, `sort:`, …) as a compact grid of cards.
+
+Each card is a shape rendered with the `Thumbnail` display type of the `ContentOptionsViewModel`. The cards are provided by display drivers, so a module can add its own card without replacing any existing view. This only documents a filter for the end user; the filter itself still has to be implemented with an `IContentsAdminListFilterProvider` (see [Full-Text Search for Admin UI](#full-text-search-for-admin-ui) above).
+
+### Registering a filter card
+
+Implement a `DisplayDriver<ContentOptionsViewModel>` and return a `View` result placed in the `Content` zone of the `Thumbnail` display type. The position after `Content:` controls the order the card appears in.
+
+```csharp
+public sealed class ProductContentsAdminListDisplayDriver : DisplayDriver<ContentOptionsViewModel>
+{
+    public override IDisplayResult Display(ContentOptionsViewModel model, BuildDisplayContext context)
+    {
+        // The first argument is the shape type; the second is the display type/position.
+        return View("ContentsAdminFilters_Thumbnail__Product", model)
+            .Location("Thumbnail", "Content:35");
+    }
+}
+```
+
+Register the driver in your module's `Startup`:
+
+```csharp
+services.AddDisplayDriver<ContentOptionsViewModel, ProductContentsAdminListDisplayDriver>();
+```
+
+### The card template
+
+The shape name `ContentsAdminFilters_Thumbnail__Product` resolves to a Razor view named `ContentsAdminFilters-Product.Thumbnail.cshtml` placed under `Views/Items/`. Each card is automatically wrapped in a Bootstrap card and laid out in the responsive grid, so the template only supplies the card's inner content: a title with its capability icons on the first line, the filter token below it, and a short description.
+
+```html
+@model ShapeViewModel<ContentOptionsViewModel>
+@{
+    var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "product");
+}
+
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Product"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
+    </span>
+</div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "product:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a product serial number."]</p>
+```
+
+The capability icons next to the title summarize what the filter accepts. Use the same icons the built-in filters use so the shared legend at the bottom of the dialog stays accurate:
+
+| Icon | Font Awesome class | Meaning |
+|------|--------------------|---------|
+| ✓ | `fa-check` | **Default** term &mdash; may be entered with or without the term name. |
+| − | `fa-minus` | **Single** &mdash; accepts a single value. |
+| ☰ | `fa-bars` | **Multiple** &mdash; supports logical operators (`AND`, `OR`, `NOT`) and groups. |
+
+The same pattern is used by the [users admin list](../Users/README.md#documenting-filters-in-the-admin-ui) (`UserIndexOptions`) and the audit trail admin list (`AuditTrailIndexOptions`); provide a `DisplayDriver<UserIndexOptions>` or `DisplayDriver<AuditTrailIndexOptions>` and matching `UsersAdminFilters-*.Thumbnail.cshtml` / `AuditTrailAdminFilters-*.Thumbnail.cshtml` views to extend those dialogs.
 
 ## Content Version Pruning
 

--- a/src/docs/reference/modules/Users/README.md
+++ b/src/docs/reference/modules/Users/README.md
@@ -94,6 +94,76 @@ You can also create your own redactor simply by adding a singleton [`Redactor`](
 
 Note that when a user is deleted, all `User` snapshots are cleared out from existing Audit Trail events to comply with regulations about personal information retention.
 
+## Documenting Filters in the Admin UI
+
+The users admin list (**Security** → **Users**) has a **Filters** dropdown next to the search box. Its **Filter syntax** entry opens the **Available Filters** dialog, which lists every filter a user can type into the search box (`name:`, `email:`, `status:`, `role:`, `sort:`, …) as a compact grid of cards. Each card shows the filter title, its capability icons, the syntax token, and a short description.
+
+The list works exactly like the [content items admin list filters](../Contents/README.md#documenting-filters-in-the-admin-ui); only the model type differs. There are two independent extension points: the filter *logic* and the filter *card* that documents it in the dialog.
+
+### Registering the filter logic
+
+Implement `IUsersAdminListFilterProvider` and add your terms to the `QueryEngineBuilder<User>`:
+
+```csharp
+public sealed class SsnUsersAdminListFilterProvider : IUsersAdminListFilterProvider
+{
+    public void Build(QueryEngineBuilder<User> builder)
+    {
+        builder
+            .WithNamedTerm("ssn", builder => builder
+                .OneCondition((val, query) =>
+                    query.With<UserProfileIndex>(i => i.Ssn != null && i.Ssn.Contains(val))));
+    }
+}
+```
+
+Register it in your module's `Startup`:
+
+```csharp
+services.AddScoped<IUsersAdminListFilterProvider, SsnUsersAdminListFilterProvider>();
+```
+
+### Registering the filter card
+
+Implement a `DisplayDriver<UserIndexOptions>` and return a `View` result placed in the `Content` zone of the `Thumbnail` display type. The position after `Content:` controls the order the card appears in.
+
+```csharp
+public sealed class SsnUsersAdminListDisplayDriver : DisplayDriver<UserIndexOptions>
+{
+    public override IDisplayResult Display(UserIndexOptions model, BuildDisplayContext context)
+    {
+        return View("UsersAdminFilters_Thumbnail__Ssn", model)
+            .Location("Thumbnail", "Content:35");
+    }
+}
+```
+
+```csharp
+services.AddDisplayDriver<UserIndexOptions, SsnUsersAdminListDisplayDriver>();
+```
+
+### The card template
+
+The shape name `UsersAdminFilters_Thumbnail__Ssn` resolves to a Razor view named `UsersAdminFilters-Ssn.Thumbnail.cshtml` placed under `Views/Items/`. Each card is automatically wrapped in a Bootstrap card and laid out in the responsive grid, so the template only supplies the card's inner content: a title with its capability icons on the first line, the filter token below it, and a short description.
+
+```html
+@model ShapeViewModel<UserIndexOptions>
+@{
+    var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "ssn");
+}
+
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["SSN"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-minus" title="@T["Accepts a single value"]" aria-hidden="true"></i>
+    </span>
+</div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "ssn:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on a user's social security number."]</p>
+```
+
+Use the same capability icons the built-in filters use so the shared legend at the bottom of the dialog stays accurate: `fa-check` (**Default** — may be entered with or without the term name), `fa-minus` (**Single** — accepts a single value), and `fa-bars` (**Multiple** — supports the `AND`, `OR`, and `NOT` operators and groups).
+
 ## Recipe Configuration
 
 User module settings can be configured using the `Settings` recipe step:

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -251,6 +251,48 @@ The `Contents` admin list action now supports filtering by multiple content type
 - Pass `stereotype` as repeated query-string values or as a comma-separated list to scope the list to content types that match any value (e.g. `?stereotype=Widget&stereotype=Page` or `?stereotype=Widget,Page`).
 - Existing single-value route and query-string parameters continue to work as before.
 
+### Available Filters Dialog Redesign
+
+The **Available Filters** dialog (the **Filter syntax** entry in the **Filters** dropdown of the content items, users, and audit trail admin lists) was redesigned. The filter cards, previously stacked full-width one per row, are now laid out in a compact responsive grid, and the dialog was widened to `modal-xl`.
+
+This changes the markup contract of the per-filter *Thumbnail* templates. Custom filter cards still render — each is wrapped in a grid cell automatically — but a card that keeps the old markup will look out of place next to the built-in ones. If your module registers its own filter card (a `*AdminFilters-*.Thumbnail.cshtml` view contributed through a `DisplayDriver<ContentOptionsViewModel>`, `DisplayDriver<UserIndexOptions>`, or `DisplayDriver<AuditTrailIndexOptions>`), update its template to the new layout:
+
+**Before:**
+
+```html
+<div class="ocat-wrapper">
+    <h4 class="card-title ocat-label">@T["Display Text"]</h4>
+    <div class="ocat-end">
+        <pre>@(term?.ToString() ?? "text:...")</pre>
+    </div>
+</div>
+<p>@T["Filters on the Display Text of a content item."]</p>
+<div class="d-block text-end">
+    <span><i class="fa-solid fa-sm fa-check text-primary" aria-hidden="true"></i></span>
+    <span><i class="fa-solid fa-sm fa-bars text-primary" aria-hidden="true"></i></span>
+</div>
+```
+
+**After:**
+
+```html
+<div class="d-flex justify-content-between align-items-center gap-2">
+    <h6 class="card-title fw-semibold mb-0">@T["Display Text"]</h6>
+    <span class="text-primary text-nowrap">
+        <i class="fa-solid fa-sm fa-check" title="@T["Default term - may be entered with or without the term name"]" aria-hidden="true"></i>
+        <i class="fa-solid fa-sm fa-bars" title="@T["Supports logical operators and groups"]" aria-hidden="true"></i>
+    </span>
+</div>
+<div class="mt-1"><code class="small text-nowrap">@(term?.ToString() ?? "text:...")</code></div>
+<p class="card-text small text-body-secondary mt-1 mb-0">@T["Filters on the Display Text of a content item."]</p>
+```
+
+The template now provides only the card's inner content — the surrounding `.card` and grid cell are supplied for you. Put the title and its capability icons on the first line, the filter token on the next line, and the description last. Keep using the shared capability icons — `fa-check` (Default), `fa-minus` (Single), and `fa-bars` (Multiple) — so the legend at the bottom of the dialog stays accurate.
+
+If your module also overrides the grid container or card wrapper shapes (`ContentOptionsViewModel.Thumbnail.cshtml` / `UserIndexOptions.Thumbnail.cshtml` / `AuditTrailIndexOptions.Thumbnail.cshtml`, or the `*AdminFilters-Card.Thumbnail.cshtml` wrappers), re-check those overrides against the new templates, which now emit `row row-cols-*` and `col > card h-100` markup.
+
+See the [content filters documentation](../reference/modules/Contents/README.md#documenting-filters-in-the-admin-ui) and the [users filters documentation](../reference/modules/Users/README.md#documenting-filters-in-the-admin-ui) for the full extension guide.
+
 ### Theme Feature Discovery
 
 Fixed theme extensions disappearing from the Themes admin page when the assembly manifest included additional `[Feature]` attributes alongside `[Theme]`. Extra


### PR DESCRIPTION
## Here is how the available filters UI looks like:

### Enhanced Content Available Filters
<img width="1155" height="901" alt="image" src="https://github.com/user-attachments/assets/af7e06f8-d5d2-40d4-9281-71afd0ded346" />

### Enhanced Users Available Filters

<img width="1135" height="899" alt="image" src="https://github.com/user-attachments/assets/f7a51660-582f-47fa-8b02-9c9a67049ea5" />


## Here are how the available filters UI looked like:

### User Available Filters
<img width="804" height="905" alt="image" src="https://github.com/user-attachments/assets/142710d2-e24c-4cb9-a60b-10c77650a5e1" />

### Content Available Filters

<img width="808" height="919" alt="image" src="https://github.com/user-attachments/assets/4dc80036-3af9-4096-afa0-b77e16727c38" />
