### PR TITLE
Allow admin themes to customize field hints

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField-Switch.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField-Switch.Edit.cshtml
@@ -15,7 +15,7 @@
             <label asp-for="Value" class="form-check-label">@(string.IsNullOrEmpty(settings.Label) ? localizedFieldName : settings.Label)</label>
             @if (!string.IsNullOrEmpty(settings.Hint))
             {
-                <span class="hint dashed">@settings.Hint</span>
+                @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
             }
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.Edit.cshtml
@@ -16,7 +16,7 @@
                 @(string.IsNullOrEmpty(settings.Label) ? localizedFieldName : settings.Label)
                 @if (!string.IsNullOrEmpty(settings.Hint))
                 {
-                    <span class="hint dashed">@settings.Hint</span>
+                    @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
                 }
             </label>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -64,7 +64,7 @@
                 </vue-multiselect>
                 @if (!string.IsNullOrEmpty(settings.Hint))
                 {
-                    <span class="hint">@settings.Hint</span>
+                    @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
                 }
             </div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField-Localized.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField-Localized.Edit.cshtml
@@ -20,7 +20,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
@@ -20,7 +20,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
@@ -20,7 +20,7 @@
 
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
@@ -18,7 +18,7 @@
         <textarea asp-for="Html" hidden>@Html.Raw(Model.Html)</textarea>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Multiline.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Multiline.Edit.cshtml
@@ -16,7 +16,7 @@
         <textarea asp-for="Html" rows="5" class="form-control content-preview-text shortcode-modal-input" dir="@culture.GetLanguageDirection()"></textarea>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
@@ -43,7 +43,7 @@ else
 
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
@@ -35,7 +35,7 @@
 
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -16,7 +16,7 @@
         <textarea asp-for="Html" rows="5" class="form-control content-preview-text" dir="@culture.GetLanguageDirection()"></textarea>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
@@ -28,7 +28,7 @@
 
                 @if (!string.IsNullOrWhiteSpace(settings.Hint))
                 {
-                    <span class="hint">@settings.Hint</span>
+                    @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
                 }
             </div>
             @if (settings.LinkTextMode == LinkTextMode.Optional || settings.LinkTextMode == LinkTextMode.Required)
@@ -44,7 +44,7 @@
 
                     @if (!string.IsNullOrWhiteSpace(settings.HintLinkText))
                     {
-                        <span class="hint">@settings.HintLinkText</span>
+                        @await DisplayAsync(await New.Hint_Admin(Hint: settings.HintLinkText))
                     }
                 </div>
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
@@ -60,7 +60,7 @@
                 </vue-multiselect>
                 @if (!string.IsNullOrEmpty(settings.Hint))
                 {
-                    <span class="hint">@settings.Hint</span>
+                    @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
                 }
             </div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
@@ -29,7 +29,7 @@
 
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-Picker.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-Picker.Edit.cshtml
@@ -56,7 +56,7 @@
             </div>
             @if (!string.IsNullOrEmpty(settings.Hint))
             {
-                <span class="hint">@settings.Hint</span>
+                @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
             }
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.Edit.cshtml
@@ -23,7 +23,7 @@
         <span asp-validation-for="Values"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -37,7 +37,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
@@ -28,7 +28,7 @@
 
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -49,7 +49,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
@@ -40,7 +40,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
@@ -31,7 +31,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
@@ -30,7 +30,7 @@
         <span asp-validation-for="Text"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Color.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Color.Edit.cshtml
@@ -106,7 +106,7 @@
     <span asp-validation-for="Text"></span>
     @if (!string.IsNullOrEmpty(settings.Hint))
     {
-        <span class="hint">@settings.Hint</span>
+        @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
     }
 </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Email.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Email.Edit.cshtml
@@ -25,7 +25,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
@@ -40,7 +40,7 @@
 
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
@@ -25,7 +25,7 @@
         <span asp-validation-for="Text"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
@@ -51,7 +51,7 @@
         <span asp-validation-for="Text"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Tel.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Tel.Edit.cshtml
@@ -22,7 +22,7 @@
         <span asp-validation-for="Text"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-TextArea.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-TextArea.Edit.cshtml
@@ -28,6 +28,6 @@
             <textarea asp-for="Text" class="form-control content-preview-text" placeholder="@settings.Placeholder" dir="@culture.GetLanguageDirection()" maxlength="@settings.MaxLength" minlength="@settings.MinLength"></textarea>
         }
         <span asp-validation-for="Text"></span>
-        <span class="hint">@settings.Hint</span>
+        @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Url.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Url.Edit.cshtml
@@ -22,7 +22,7 @@
         <span asp-validation-for="Text"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.Edit.cshtml
@@ -23,7 +23,7 @@
         <span asp-validation-for="Text"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
@@ -19,7 +19,7 @@
         </div>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.Edit.cshtml
@@ -57,7 +57,7 @@
                 </vue-multiselect>
                 @if (!string.IsNullOrEmpty(settings.Hint))
                 {
-                    <span class="hint">@settings.Hint</span>
+                    @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
                 }
             </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.Edit.cshtml
@@ -15,7 +15,7 @@
         <span asp-validation-for="RawAddress"></span>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -23,7 +23,7 @@
         <textarea asp-for="Markdown" rows="5" class="form-control content-preview-text"></textarea>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField.Edit.cshtml
@@ -19,7 +19,7 @@
         <textarea asp-for="Markdown" rows="5" class="form-control content-preview-text shortcode-modal-input" dir="@culture.GetLanguageDirection()"></textarea>
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <span class="hint">@settings.Hint</span>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
@@ -24,7 +24,7 @@
     <div class="ocat-end" id="@fieldId" data-for="@Html.IdFor(m => m.Paths)">
         @if (!string.IsNullOrWhiteSpace(settings.Hint))
         {
-            <div class="hint mt-lg-2">@settings.Hint</div>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
 
         <div id="@fieldId"

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Gallery.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Gallery.Edit.cshtml
@@ -20,7 +20,7 @@
     <div class="ocat-end" id="@fieldId" data-for="@Html.IdFor(m => m.Paths)">
         @if (!string.IsNullOrWhiteSpace(settings.Hint))
         {
-            <div class="hint mt-lg-2">@settings.Hint</div>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
 
         <div id="@fieldId"

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
@@ -20,7 +20,7 @@
     <div class="ocat-end" id="@Html.IdFor(m => m)" data-for="@Html.IdFor(m => m.Paths)">
         @if (!string.IsNullOrWhiteSpace(settings.Hint))
         {
-            <div class="hint mt-lg-2">@settings.Hint</div>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
 
         <div id="@fieldId"

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField-Leaflet.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField-Leaflet.Edit.cshtml
@@ -14,7 +14,7 @@
             <input asp-for="Latitude" type="number" min="-90.000000" max="90.000000" step=".000001" placeholder="00.000000" class="form-control content-preview-text" required="@settings.Required" data-latitude />
             @if (!string.IsNullOrEmpty(settings.Hint))
             {
-                <span class="hint">@settings.Hint</span>
+                @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
             }
         </div>
     </div>
@@ -24,7 +24,7 @@
             <input asp-for="Longitude" type="number" min="-180.000000" max="180.000000" step=".000001" placeholder="00.000000" class="form-control content-preview-text" required="@settings.Required" data-longitude />
             @if (!string.IsNullOrEmpty(settings.Hint))
             {
-                <span class="hint">@settings.Hint</span>
+                @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
             }
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField.Edit.cshtml
@@ -16,7 +16,7 @@
                 <input asp-for="Latitude" type="number" min="-90.000000" max="90.000000" step=".000001" placeholder="00.000000" class="form-control content-preview-text" required="@settings.Required" />
                 @if (!string.IsNullOrEmpty(settings.Hint))
                 {
-                    <span class="hint">@settings.Hint</span>
+                    @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
                 }
             </div>
             <div class="col-md-6">
@@ -24,7 +24,7 @@
                 <input asp-for="Longitude" type="number" min="-180.000000" max="180.000000" step=".000001" placeholder="00.000000" class="form-control content-preview-text" required="@settings.Required" />
                 @if (!string.IsNullOrEmpty(settings.Hint))
                 {
-                    <span class="hint">@settings.Hint</span>
+                    @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
                 }
             </div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
@@ -35,7 +35,7 @@
     <div class="ocat-end">
         @if (!string.IsNullOrEmpty(taxonomySettings.Hint))
         {
-            <div class="hint dashed mt-lg-2">@taxonomySettings.Hint</div>
+            @await DisplayAsync(await New.Hint_Admin(Hint: taxonomySettings.Hint))
         }
 
         @if (Model.Taxonomy == null)

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
@@ -18,7 +18,7 @@
 
         @if (!string.IsNullOrEmpty(settings.Hint))
         {
-            <div class="hint dashed mt-lg-2">@settings.Hint</div>
+            @await DisplayAsync(await New.Hint_Admin(Hint: settings.Hint))
         }
 
         @if (Model.Taxonomy == null)

--- a/src/OrchardCore.Themes/TheAdmin/Views/Hint.Admin.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Hint.Admin.cshtml
@@ -1,0 +1,1 @@
+<span class="hint dashed">@Model.Hint</span>

--- a/src/docs/reference/themes/admin-theme.md
+++ b/src/docs/reference/themes/admin-theme.md
@@ -76,6 +76,33 @@ When building custom admin editor views, use the `ocat-*` classes so your views 
 </div>
 ```
 
+### Customizing Content Field Hints
+
+Content field editors render their configured hint with the `Hint_Admin` shape. The default
+`Hint.Admin.cshtml` template displays the hint as text:
+
+```cshtml
+<span class="hint dashed">@Model.Hint</span>
+```
+
+To customize all content field hints, add a `Views/Hint.Admin.cshtml` template to your custom
+admin theme. For example, the following template renders an accessible button with a Bootstrap
+tooltip:
+
+```cshtml
+<button type="button"
+        class="btn btn-link p-0 align-baseline"
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="@Model.Hint"
+        aria-label="@Model.Hint">
+    <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
+</button>
+```
+
+The shape exposes the configured hint through `Model.Hint`. The default admin theme initializes
+Bootstrap tooltips for elements with the `data-bs-toggle="tooltip"` attribute.
+
 ### Creating a Horizontal Form Layout
 
 To achieve a horizontal form layout, override the `ocat-*` classes in your custom admin theme CSS or SCSS. Here's a pure CSS example:


### PR DESCRIPTION
## Summary

- introduce a `Hint_Admin` shape in `TheAdmin` while preserving the existing hint markup by default
- render configurable content field hints through the shape so custom admin themes can override their presentation
- document the new admin theme extension point and an accessible tooltip example

## Testing

- `dotnet build OrchardCore.slnx -c Release`
- `dotnet build src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj -c Release --no-restore`
- manually verified the default hint rendering and custom shape override

Fixes #18826