### PR TITLE
Fix "and new" button behavior

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -533,17 +533,7 @@ public sealed class AdminController : Controller, IUpdateModel
     public async Task<IActionResult> EditAndPublishPOST(
         string contentItemId,
         [Bind(Prefix = "submit.Publish")] string submitPublish,
-        string returnUrl)
-    {
-        if (submitPublish == "submit.PublishAndNew")
-        {
-            var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.Latest);
-
-            returnUrl = Url.Action(nameof(Create), new { id = contentItem.ContentType });
-        }
-
-        return await PublishOrUnpublishAsync(submitPublish == "submit.PublishAndContinue", contentItemId, returnUrl, publish: true);
-    }
+        string returnUrl) => await PublishOrUnpublishAsync(submitPublish, contentItemId, returnUrl, publish: true);
 
     [HttpPost]
     [ActionName(nameof(Edit))]
@@ -551,7 +541,7 @@ public sealed class AdminController : Controller, IUpdateModel
     public async Task<IActionResult> EditAndUnpublishPOST(
     string contentItemId,
     [Bind(Prefix = "submit.Unpublish")] string submitUnpublish,
-    string returnUrl) => await PublishOrUnpublishAsync(submitUnpublish == "submit.UnpublishAndContinue", contentItemId, returnUrl, publish: false);
+    string returnUrl) => await PublishOrUnpublishAsync(submitUnpublish, contentItemId, returnUrl, publish: false);
 
     [HttpPost]
     public async Task<IActionResult> Delete(string contentItemId, string returnUrl)
@@ -931,18 +921,27 @@ public sealed class AdminController : Controller, IUpdateModel
         return RedirectToAction(nameof(List));
     }
 
-    private async Task<IActionResult> PublishOrUnpublishAsync(bool stayOnSamePage, string contentItemId, string returnUrl, bool publish)
+    private async Task<IActionResult> PublishOrUnpublishAsync(string action, string contentItemId, string returnUrl, bool publish)
     {
-        var content = await _contentManager.GetAsync(contentItemId, VersionOptions.Latest);
+        var stayOnSamePage = publish
+            ? action == "submit.PublishAndContinue"
+            : action == "submit.UnpublishAndContinue";
 
-        if (content == null)
+        var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.Latest);
+
+        if (contentItem == null)
         {
             return NotFound();
         }
 
-        if (!await IsAuthorizedAsync(CommonPermissions.PublishContent, content))
+        if (!await IsAuthorizedAsync(CommonPermissions.PublishContent, contentItem))
         {
             return Forbid();
+        }
+
+        if (publish && action == "submit.PublishAndNew")
+        {
+            returnUrl = Url.Action(nameof(Create), new { id = contentItem.ContentType });
         }
 
         return await EditInternalAsync(contentItemId, returnUrl, stayOnSamePage, async contentItem =>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -428,6 +428,7 @@ public sealed class AdminController : Controller, IUpdateModel
     public async Task<IActionResult> CreateAndPublishPOST(
         string id,
         [Bind(Prefix = "submit.Publish")] string submitPublish,
+        string queryString,
         string returnUrl)
     {
         if (string.IsNullOrEmpty(id))
@@ -444,7 +445,7 @@ public sealed class AdminController : Controller, IUpdateModel
 
         if (submitPublish == "submit.PublishAndNew")
         {
-            returnUrl = Url.Action(nameof(Create), new { returnUrl });
+            returnUrl = Url.Action(nameof(Create)) + queryString;
         }
 
         return await CreateInternalAsync(id, returnUrl, stayOnSamePage, async contentItem =>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -4,7 +4,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using OrchardCore.Admin;
@@ -399,16 +401,21 @@ public sealed class AdminController : Controller, IUpdateModel
     public Task<IActionResult> CreatePOST(
         string id,
         [Bind(Prefix = "submit.Save")] string submitSave,
-        string returnUrl)
+        string returnUrl,
+        string createUrl)
     {
         var stayOnSamePage = submitSave == "submit.SaveAndContinue";
 
-        if (submitSave == "submit.SaveAndNew")
+        if (submitSave == "submit.SaveAndNew" && !string.IsNullOrEmpty(createUrl) && Url.IsLocalUrl(createUrl))
         {
-            returnUrl = Url.Action(nameof(Create), new { returnUrl });
+            returnUrl = QueryHelpers.AddQueryString(createUrl, new[]
+            {
+                new KeyValuePair<string, string>("createUrl", createUrl),
+                new KeyValuePair<string, string>("returnUrl", returnUrl),
+            });
         }
 
-        return CreateInternalAsync(id, returnUrl, stayOnSamePage, async contentItem =>
+        return CreateInternalAsync(id, returnUrl, createUrl, stayOnSamePage, async contentItem =>
         {
             await _contentManager.SaveDraftAsync(contentItem);
 
@@ -428,27 +435,32 @@ public sealed class AdminController : Controller, IUpdateModel
     public async Task<IActionResult> CreateAndPublishPOST(
         string id,
         [Bind(Prefix = "submit.Publish")] string submitPublish,
-        string queryString,
-        string returnUrl)
+        string returnUrl,
+        string createUrl)
     {
         if (string.IsNullOrEmpty(id))
         {
             return NotFound();
         }
 
-        var stayOnSamePage = submitPublish == "submit.PublishAndContinue";
         // Pass a dummy content item to the authorization check to check for "own" variations permissions.
         if (!await _authorizationService.AuthorizeContentTypeAsync(User, CommonPermissions.PublishContent, id, CurrentUserId()))
         {
             return Forbid();
         }
 
-        if (submitPublish == "submit.PublishAndNew")
+        var stayOnSamePage = submitPublish == "submit.PublishAndContinue";
+
+        if (submitPublish == "submit.PublishAndNew" && !string.IsNullOrEmpty(createUrl) && Url.IsLocalUrl(createUrl))
         {
-            returnUrl = Url.Action(nameof(Create)) + queryString;
+            returnUrl = QueryHelpers.AddQueryString(createUrl, new[]
+            {
+                new KeyValuePair<string, string>("createUrl", createUrl),
+                new KeyValuePair<string, string>("returnUrl", returnUrl),
+            });
         }
 
-        return await CreateInternalAsync(id, returnUrl, stayOnSamePage, async contentItem =>
+        return await CreateInternalAsync(id, returnUrl, createUrl, stayOnSamePage, async contentItem =>
         {
             if (await _contentManager.PublishAsync(contentItem))
             {
@@ -511,10 +523,10 @@ public sealed class AdminController : Controller, IUpdateModel
     public Task<IActionResult> EditPOST(
         string contentItemId,
         [Bind(Prefix = "submit.Save")] string submitSave,
-        string returnUrl)
+        string returnUrl,
+        string createUrl)
     {
-        var stayOnSamePage = submitSave == "submit.SaveAndContinue";
-        return EditInternalAsync(submitSave, contentItemId, returnUrl, stayOnSamePage, async contentItem =>
+        return EditInternalAsync(submitSave, contentItemId, returnUrl, createUrl, async contentItem =>
         {
             await _contentManager.SaveDraftAsync(contentItem);
 
@@ -534,15 +546,19 @@ public sealed class AdminController : Controller, IUpdateModel
     public async Task<IActionResult> EditAndPublishPOST(
         string contentItemId,
         [Bind(Prefix = "submit.Publish")] string submitPublish,
-        string returnUrl) => await PublishOrUnpublishAsync(submitPublish, contentItemId, returnUrl, publish: true);
+        string returnUrl,
+        string createUrl)
+        => await PublishOrUnpublishAsync(submitPublish, contentItemId, returnUrl, createUrl, publish: true);
 
     [HttpPost]
     [ActionName(nameof(Edit))]
     [FormValueRequired("submit.Unpublish")]
     public async Task<IActionResult> EditAndUnpublishPOST(
-    string contentItemId,
-    [Bind(Prefix = "submit.Unpublish")] string submitUnpublish,
-    string returnUrl) => await PublishOrUnpublishAsync(submitUnpublish, contentItemId, returnUrl, publish: false);
+        string contentItemId,
+        [Bind(Prefix = "submit.Unpublish")] string submitUnpublish,
+        string returnUrl,
+        string createUrl)
+        => await PublishOrUnpublishAsync(submitUnpublish, contentItemId, returnUrl, createUrl, publish: false);
 
     [HttpPost]
     public async Task<IActionResult> Delete(string contentItemId, string returnUrl)
@@ -756,6 +772,7 @@ public sealed class AdminController : Controller, IUpdateModel
     private async Task<IActionResult> CreateInternalAsync(
         string id,
         string returnUrl,
+        string createUrl,
         bool stayOnSamePage,
         Func<ContentItem, Task<bool>> conditionallyPublish)
     {
@@ -791,6 +808,11 @@ public sealed class AdminController : Controller, IUpdateModel
             adminRouteValues.Add("returnUrl", returnUrl);
         }
 
+        if (!string.IsNullOrEmpty(createUrl))
+        {
+            adminRouteValues.Add("createUrl", createUrl);
+        }
+
         return RedirectToRoute(adminRouteValues);
     }
 
@@ -798,7 +820,7 @@ public sealed class AdminController : Controller, IUpdateModel
         string action,
         string contentItemId,
         string returnUrl,
-        bool stayOnSamePage,
+        string createUrl,
         Func<ContentItem, Task<bool>> conditionallyPublish)
     {
         var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.DraftRequired);
@@ -813,9 +835,16 @@ public sealed class AdminController : Controller, IUpdateModel
             return Forbid();
         }
 
-        if (action == "submit.SaveAndNew")
+        var stayOnSamePage = action == "submit.SaveAndContinue";
+
+        if (action == "submit.SaveAndNew" && !string.IsNullOrEmpty(createUrl) && Url.IsLocalUrl(createUrl))
         {
-            returnUrl = Url.Action(nameof(Create), new { id = contentItem.ContentType });
+            returnUrl = QueryHelpers.AddQueryString(createUrl, new[]
+            {
+                new KeyValuePair<string, string>("id", contentItem.ContentType),
+                new KeyValuePair<string, string>("createUrl", createUrl),
+                new KeyValuePair<string, string>("returnUrl", returnUrl),
+            });
         }
 
         var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, false);
@@ -836,6 +865,7 @@ public sealed class AdminController : Controller, IUpdateModel
             return RedirectToAction(nameof(Edit), new RouteValueDictionary
             {
                 { "ContentItemId", contentItem.ContentItemId },
+                { "createUrl", createUrl },
             });
         }
 
@@ -845,6 +875,7 @@ public sealed class AdminController : Controller, IUpdateModel
             {
                 { "ContentItemId", contentItem.ContentItemId },
                 { "returnUrl", returnUrl },
+                { "createUrl", createUrl },
             });
         }
 
@@ -928,7 +959,7 @@ public sealed class AdminController : Controller, IUpdateModel
         return RedirectToAction(nameof(List));
     }
 
-    private async Task<IActionResult> PublishOrUnpublishAsync(string action, string contentItemId, string returnUrl, bool publish)
+    private async Task<IActionResult> PublishOrUnpublishAsync(string action, string contentItemId, string returnUrl, string createUrl, bool publish)
     {
         var stayOnSamePage = publish
             ? action == "submit.PublishAndContinue"
@@ -948,10 +979,10 @@ public sealed class AdminController : Controller, IUpdateModel
 
         if (publish && action == "submit.PublishAndNew")
         {
-            returnUrl = Url.Action(nameof(Create), new { id = contentItem.ContentType });
+            action = "submit.SaveAndNew";
         }
 
-        return await EditInternalAsync(action, contentItemId, returnUrl, stayOnSamePage, async contentItem =>
+        return await EditInternalAsync(action, contentItemId, returnUrl, createUrl, async contentItem =>
         {
             var hasBeenPublishedOrUnpublished = publish
                 ? await _contentManager.PublishAsync(contentItem)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -513,7 +513,7 @@ public sealed class AdminController : Controller, IUpdateModel
         string returnUrl)
     {
         var stayOnSamePage = submitSave == "submit.SaveAndContinue";
-        return EditInternalAsync(contentItemId, returnUrl, stayOnSamePage, async contentItem =>
+        return EditInternalAsync(submitSave, contentItemId, returnUrl, stayOnSamePage, async contentItem =>
         {
             await _contentManager.SaveDraftAsync(contentItem);
 
@@ -794,6 +794,7 @@ public sealed class AdminController : Controller, IUpdateModel
     }
 
     private async Task<IActionResult> EditInternalAsync(
+        string action,
         string contentItemId,
         string returnUrl,
         bool stayOnSamePage,
@@ -809,6 +810,11 @@ public sealed class AdminController : Controller, IUpdateModel
         if (!await IsAuthorizedAsync(CommonPermissions.EditContent, contentItem))
         {
             return Forbid();
+        }
+
+        if (action == "submit.SaveAndNew")
+        {
+            returnUrl = Url.Action(nameof(Create), new { id = contentItem.ContentType });
         }
 
         var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, false);
@@ -944,7 +950,7 @@ public sealed class AdminController : Controller, IUpdateModel
             returnUrl = Url.Action(nameof(Create), new { id = contentItem.ContentType });
         }
 
-        return await EditInternalAsync(contentItemId, returnUrl, stayOnSamePage, async contentItem =>
+        return await EditInternalAsync(action, contentItemId, returnUrl, stayOnSamePage, async contentItem =>
         {
             var hasBeenPublishedOrUnpublished = publish
                 ? await _contentManager.PublishAsync(contentItem)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -533,7 +533,17 @@ public sealed class AdminController : Controller, IUpdateModel
     public async Task<IActionResult> EditAndPublishPOST(
         string contentItemId,
         [Bind(Prefix = "submit.Publish")] string submitPublish,
-        string returnUrl) => await PublishOrUnpublishAsync(submitPublish == "submit.PublishAndContinue", contentItemId, returnUrl, publish: true);
+        string returnUrl)
+    {
+        if (submitPublish == "submit.PublishAndNew")
+        {
+            var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.Latest);
+
+            returnUrl = Url.Action(nameof(Create), new { id = contentItem.ContentType });
+        }
+
+        return await PublishOrUnpublishAsync(submitPublish == "submit.PublishAndContinue", contentItemId, returnUrl, publish: true);
+    }
 
     [HttpPost]
     [ActionName(nameof(Edit))]

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
@@ -16,7 +16,7 @@
 
 <zone Name="Title"><h1>@RenderTitleSegments(T["New {0}", localizedTypeDisplayName])</h1></zone>
 
-<form asp-action="Create" asp-route-returnUrl="@Context.Request.Query["ReturnUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
+<form asp-action="Create" asp-route-queryString="@Context.Request.QueryString.Value" asp-route-returnUrl="@Context.Request.Query["ReturnUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
     @if (!ViewContext.ModelState.IsValid)
     {
         @Html.ValidationSummary()

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
@@ -16,7 +16,7 @@
 
 <zone Name="Title"><h1>@RenderTitleSegments(T["New {0}", localizedTypeDisplayName])</h1></zone>
 
-<form asp-action="Create" asp-route-queryString="@Context.Request.QueryString.Value" asp-route-returnUrl="@Context.Request.Query["ReturnUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
+<form asp-action="Create" asp-route-returnUrl="@Context.Request.Query["ReturnUrl"]" asp-route-createUrl="@Context.Request.Query["CreateUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
     @if (!ViewContext.ModelState.IsValid)
     {
         @Html.ValidationSummary()

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
@@ -16,7 +16,7 @@
 
 <zone Name="Title"><h1>@RenderTitleSegments(T["Edit {0}", localizedTypeDisplayName])</h1></zone>
 
-<form asp-action="Edit" asp-route-contentitemid="@contentItem.ContentItemId" asp-route-returnUrl="@Context.Request.Query["returnUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
+<form asp-action="Edit" asp-route-contentitemid="@contentItem.ContentItemId" asp-route-returnUrl="@Context.Request.Query["returnUrl"]" asp-route-createUrl="@Context.Request.Query["createUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
     @if (!ViewContext.ModelState.IsValid)
     {
         @Html.ValidationSummary()

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
@@ -1,5 +1,6 @@
 @{
     var returnUrl = Context.Request.Query["returnUrl"];
+    var createUrl = Context.Request.Query["createUrl"];
 }
 
 @if (string.IsNullOrWhiteSpace(returnUrl))
@@ -14,7 +15,10 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
-            <button class="dropdown-item publish-new" type="submit" name="submit.Publish" value="submit.PublishAndNew">@T["and new"]</button>
+            @if (!string.IsNullOrEmpty(createUrl) && Url.IsLocalUrl(createUrl))
+            {
+                <button class="dropdown-item publish-new" type="submit" name="submit.Publish" value="submit.PublishAndNew">@T["and new"]</button>
+            }
             <button class="dropdown-item publish-continue" type="submit" name="submit.Publish" value="submit.PublishAndContinue">@T["and continue"]</button>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
@@ -1,5 +1,6 @@
 @{
     var returnUrl = Context.Request.Query["returnUrl"];
+    var createUrl = Context.Request.Query["createUrl"];
 }
 
 @if (string.IsNullOrWhiteSpace(returnUrl))
@@ -14,7 +15,10 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
-            <button class="dropdown-item draft-new" type="submit" name="submit.Save" value="submit.SaveAndNew">@T["and new"]</button>
+            @if (!string.IsNullOrEmpty(createUrl) && Url.IsLocalUrl(createUrl))
+            {
+                <button class="dropdown-item draft-new" type="submit" name="submit.Save" value="submit.SaveAndNew">@T["and new"]</button>
+            }
             <button class="dropdown-item draft-continue" type="submit" name="submit.Save" value="submit.SaveAndContinue">@T["and continue"]</button>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListCreate.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListCreate.cshtml
@@ -22,7 +22,7 @@ else
         <ul class="dropdown-menu dropdown-menu-end scrollable">
             @foreach (var item in Model.CreatableTypes)
             {
-                <li><a class="dropdown-item" href="@Url.RouteUrl(new { area = "OrchardCore.Contents", controller = "Admin", action = "Create", id = @item.Value, returnUrl = FullRequestPath })">@D[item.Text, "Content Types"]</a></li>
+                <li><a class="dropdown-item" href="@Url.RouteUrl(new { area = "OrchardCore.Contents", controller = "Admin", action = "Create", id = @item.Value, returnUrl = FullRequestPath, createUrl = Url.Action("Create", "Admin", new { id = item.Value }) })">@D[item.Text, "Content Types"]</a></li>
             }
         </ul>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsButtonEdit_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsButtonEdit_SummaryAdmin.cshtml
@@ -10,7 +10,7 @@
 
 @if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem))
 {
-    <a edit-for="@contentItem" asp-route-returnUrl="@FullRequestPath" class="btn btn-sm btn-primary edit"><span>@T["Edit"]</span></a>
+    <a edit-for="@contentItem" asp-route-returnUrl="@FullRequestPath" asp-route-createUrl="@Url.Action("Create", "Admin", new { id = contentItem.ContentType })" class="btn btn-sm btn-primary edit"><span>@T["Edit"]</span></a>
 }
 
 @if (hasPublished)

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
@@ -1,9 +1,10 @@
-@using Microsoft.AspNetCore.Authorization
-@using OrchardCore.ContentManagement
-@using OrchardCore.Contents
-@using OrchardCore.ContentTypes
-@using OrchardCore.Localization.Data
 @using System.Security.Claims
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Routing
+@using OrchardCore.ContentManagement
+@using OrchardCore.ContentTypes
+@using OrchardCore.Contents
+@using OrchardCore.Localization.Data
 @model OrchardCore.Lists.ViewModels.ListPartNavigationAdminViewModel
 @inject IContentManager ContentManager
 @inject IAuthorizationService AuthorizationService
@@ -39,7 +40,12 @@
 
             @if (actionName != "Edit" && await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, Model.Container))
             {
-                <a class="btn btn-primary me-1" asp-action="Edit" asp-controller="Admin" asp-route-contentItemId="@Model.Container.ContentItemId" asp-route-area="OrchardCore.Contents">
+                <a class="btn btn-primary me-1" 
+                    asp-action="Edit" 
+                    asp-controller="Admin" 
+                    asp-route-contentItemId="@Model.Container.ContentItemId" 
+                    asp-route-area="OrchardCore.Contents"
+                   asp-route-createUrl="@Url.Action("Create", "Admin", new { id = Model.ContainerContentTypeDefinition?.Name, returnUrl = FullRequestPath })">
                     @T["Edit {0}", D[Model.ContainerContentTypeDefinition?.DisplayName, DataLocalizationContext.ContentType]]
                 </a>
             }
@@ -48,7 +54,17 @@
             {
                 var contentTypeDefinition = authorizedContentTypeDefinitions.FirstOrDefault();
 
-                <a class="btn btn-secondary" asp-action="Create" asp-controller="Admin" asp-route-id="@contentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.Container.ContentItemId" asp-route-ListPart.ContainerContentType="@Model.ContainerContentTypeDefinition?.Name" asp-route-ListPart.ContentType="@contentTypeDefinition.Name" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
+                <a class="btn btn-secondary" 
+                    asp-action="Create" 
+                    asp-controller="Admin" 
+                    asp-route-id="@contentTypeDefinition.Name" 
+                    asp-route-area="OrchardCore.Contents" 
+                    asp-route-ListPart.ContainerId="@Model.Container.ContentItemId" 
+                    asp-route-ListPart.ContainerContentType="@Model.ContainerContentTypeDefinition?.Name" 
+                    asp-route-ListPart.ContentType="@contentTypeDefinition.Name" 
+                    asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" 
+                    asp-route-returnUrl="@FullRequestPath"
+                    asp-route-createUrl="@Url.Action("Create", "Admin", new RouteValueDictionary { ["id"] = contentTypeDefinition.Name, ["ListPart.ContainerId"] = Model.Container.ContentItemId, ["ListPart.ContainerContentType"] = Model.ContainerContentTypeDefinition?.Name, ["ListPart.ContentType"] = contentTypeDefinition.Name, ["ListPart.EnableOrdering"] = Model.EnableOrdering })">
                     @T["Create {0}", D[contentTypeDefinition.DisplayName, DataLocalizationContext.ContentType]]
                 </a>
             }
@@ -61,7 +77,17 @@
                     @foreach (var containedContentTypeDefinition in authorizedContentTypeDefinitions)
                     {
                         <li>
-                            <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.Container.ContentItemId" asp-route-ListPart.ContainerContentType="@Model.ContainerContentTypeDefinition?.Name" asp-route-ListPart.ContentType="@containedContentTypeDefinition.Name" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
+                            <a class="dropdown-item" 
+                                asp-action="Create" 
+                                asp-controller="Admin" 
+                                asp-route-id="@containedContentTypeDefinition.Name" 
+                                asp-route-area="OrchardCore.Contents" 
+                                asp-route-ListPart.ContainerId="@Model.Container.ContentItemId" 
+                                asp-route-ListPart.ContainerContentType="@Model.ContainerContentTypeDefinition?.Name" 
+                                asp-route-ListPart.ContentType="@containedContentTypeDefinition.Name" 
+                                asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" 
+                                asp-route-returnUrl="@FullRequestPath"
+                                asp-route-createUrl="@Url.Action("Create", "Admin", new RouteValueDictionary { ["id"] = containedContentTypeDefinition.Name, ["ListPart.ContainerId"] = Model.Container.ContentItemId, ["ListPart.ContainerContentType"] = Model.ContainerContentTypeDefinition?.Name, ["ListPart.ContentType"] = containedContentTypeDefinition.Name, ["ListPart.EnableOrdering"] = Model.EnableOrdering })">  
                                 @D[containedContentTypeDefinition.DisplayName, "Content Types"]
                             </a>
                         </li>


### PR DESCRIPTION
#### PR Classification
New feature: enhances the content management admin UI to support a createUrl parameter for improved navigation and workflow.

#### PR Summary
This pull request introduces a createUrl parameter to streamline "create new" workflows in the OrchardCore admin UI, ensuring consistent navigation and context preservation when creating or editing content items.
- AdminController.cs: Adds and propagates the createUrl parameter in controller actions, redirects, and internal logic for create/edit operations.
- Create.cshtml and Edit.cshtml: Updates forms to include asp-route-createUrl for proper parameter passing.
- Content.SaveDraftButton.cshtml and Content.PublishButton.cshtml: Conditionally displays "and new" dropdown actions based on the presence of createUrl.
- ContentsAdminListCreate.cshtml, ContentsButtonEdit_SummaryAdmin.cshtml, ListPartNavigationAdmin.cshtml: Updates links and buttons to include createUrl, supporting context-aware content creation.
