### PR TITLE
Fix default content filter term restoration

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListQueryService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListQueryService.cs
@@ -90,7 +90,7 @@ public sealed class DefaultContentsAdminListQueryService : IContentsAdminListQue
 
         if (hasFilterResult &&
             defaultTermNode is not null &&
-            (defaultTermName != defaultTermNode.TermName || defaultOperator != defaultTermNode.Operation))
+            (defaultTermName != defaultTermNode?.TermName || defaultOperator != defaultTermNode?.Operation))
         {
             // Restore the original 'defaultTermNode'.
             model.FilterResult.TryRemove(defaultTermName);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListQueryService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListQueryService.cs
@@ -88,7 +88,9 @@ public sealed class DefaultContentsAdminListQueryService : IContentsAdminListQue
         await _contentsAdminListFilters
             .InvokeAsync((filter, model, query, updater) => filter.FilterAsync(model, query, updater), model, query, updater, _logger);
 
-        if (hasFilterResult && defaultOperator != defaultTermNode?.Operation)
+        if (hasFilterResult &&
+            defaultTermNode is not null &&
+            (defaultTermName != defaultTermNode.TermName || defaultOperator != defaultTermNode.Operation))
         {
             // Restore the original 'defaultTermNode'.
             model.FilterResult.TryRemove(defaultTermName);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/DefaultContentsAdminListQueryServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/DefaultContentsAdminListQueryServiceTests.cs
@@ -18,6 +18,7 @@ public class DefaultContentsAdminListQueryServiceTests
     [Fact]
     public async Task QueryAsync_NameOnlyDefaultTermRewrite_RestoresOriginalNode()
     {
+       // Arrange
         var query = Mock.Of<IQuery<ContentItem>>();
         var rootQuery = new Mock<IQuery>();
         rootQuery

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/DefaultContentsAdminListQueryServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/DefaultContentsAdminListQueryServiceTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using OrchardCore.ContentManagement;
+using OrchardCore.Contents;
+using OrchardCore.Contents.Services;
+using OrchardCore.Contents.ViewModels;
+using OrchardCore.DisplayManagement.ModelBinding;
+using YesSql;
+using YesSql.Filters.Nodes;
+using YesSql.Filters.Query;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Contents;
+
+public class DefaultContentsAdminListQueryServiceTests
+{
+    [Fact]
+    public async Task QueryAsync_NameOnlyDefaultTermRewrite_RestoresOriginalNode()
+    {
+        var query = Mock.Of<IQuery<ContentItem>>();
+        var rootQuery = new Mock<IQuery>();
+        rootQuery
+            .Setup(value => value.For<ContentItem>(It.IsAny<bool>()))
+            .Returns(query);
+
+        var session = new Mock<YesSql.ISession>();
+        session
+            .Setup(value => value.Query(It.IsAny<string>()))
+            .Returns(rootQuery.Object);
+
+        using var services = new ServiceCollection().BuildServiceProvider();
+
+        var options = new ContentsAdminListFilterOptions();
+        options.DefaultTermNames["Article"] = "customText";
+
+        var service = new DefaultContentsAdminListQueryService(
+            session.Object,
+            services,
+            [],
+            Options.Create(options),
+            NullLogger<DefaultContentsAdminListQueryService>.Instance);
+
+        var filterResult = CreateFilterResult();
+        var originalNode = Assert.Single(filterResult.OfType<DefaultTermNode>());
+        var model = new ContentOptionsViewModel
+        {
+            SelectedContentType = "Article",
+            FilterResult = filterResult,
+        };
+
+        await service.QueryAsync(model, Mock.Of<IUpdateModel>());
+
+        var restoredNode = Assert.Single(model.FilterResult.OfType<DefaultTermNode>());
+        Assert.Equal(ContentsAdminListFilterOptions.DefaultTermName, restoredNode.TermName);
+        Assert.Same(originalNode, restoredNode);
+    }
+
+    private static QueryFilterResult<ContentItem> CreateFilterResult()
+    {
+        static IQuery<ContentItem> Apply(string _, IQuery<ContentItem> query) => query;
+
+        var builder = new QueryEngineBuilder<ContentItem>();
+        builder
+            .WithDefaultTerm(ContentsAdminListFilterOptions.DefaultTermName, term => term
+                .ManyCondition(Apply, Apply))
+            .WithDefaultTerm("customText", term => term
+                .ManyCondition(Apply, Apply));
+
+        var result = builder.Build().Parse("does-not-exist");
+        var parsedNode = Assert.Single(result.OfType<DefaultTermNode>());
+
+        result.TryRemove(parsedNode.TermName);
+        result.TryAddOrReplace(new DefaultTermNode(
+            ContentsAdminListFilterOptions.DefaultTermName,
+            parsedNode.Operation));
+
+        return result;
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/DefaultContentsAdminListQueryServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/DefaultContentsAdminListQueryServiceTests.cs
@@ -52,6 +52,7 @@ public class DefaultContentsAdminListQueryServiceTests
 
         await service.QueryAsync(model, Mock.Of<IUpdateModel>());
 
+        // Assert
         var restoredNode = Assert.Single(model.FilterResult.OfType<DefaultTermNode>());
         Assert.Equal(ContentsAdminListFilterOptions.DefaultTermName, restoredNode.TermName);
         Assert.Same(originalNode, restoredNode);


### PR DESCRIPTION
Fixes #19792

## Changes

- Restore the original `DefaultTermNode` when either its resolved term name or operator was temporarily rewritten for query execution.
- Add a regression test covering a content-type-specific, name-only default-term rewrite.

This keeps the caller-owned `ContentOptionsViewModel.FilterResult` in its original user-facing state after `QueryAsync()` returns.

## Tests

- `dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --no-restore --filter-class "*DefaultContentsAdminListQueryServiceTests"`
- `dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --no-restore --filter-class "OrchardCore.Tests.Modules.OrchardCore.Contents.*"` — 12 passed

The regression test was also verified to fail against the original condition and pass with this change.