### PR TITLE
Revert "Add "and new" option for publish and save draft"

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -402,12 +402,6 @@ public sealed class AdminController : Controller, IUpdateModel
         string returnUrl)
     {
         var stayOnSamePage = submitSave == "submit.SaveAndContinue";
-
-        if (submitSave == "submit.SaveAndNew")
-        {
-            returnUrl = Url.Action(nameof(Create), new { returnUrl });
-        }
-
         return CreateInternalAsync(id, returnUrl, stayOnSamePage, async contentItem =>
         {
             await _contentManager.SaveDraftAsync(contentItem);
@@ -440,11 +434,6 @@ public sealed class AdminController : Controller, IUpdateModel
         if (!await _authorizationService.AuthorizeContentTypeAsync(User, CommonPermissions.PublishContent, id, CurrentUserId()))
         {
             return Forbid();
-        }
-
-        if (submitPublish == "submit.PublishAndNew")
-        {
-            returnUrl = Url.Action(nameof(Create), new { returnUrl });
         }
 
         return await CreateInternalAsync(id, returnUrl, stayOnSamePage, async contentItem =>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.PublishButton.cshtml
@@ -14,7 +14,6 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
-            <button class="dropdown-item publish-new" type="submit" name="submit.Publish" value="submit.PublishAndNew">@T["and new"]</button>
             <button class="dropdown-item publish-continue" type="submit" name="submit.Publish" value="submit.PublishAndContinue">@T["and continue"]</button>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SaveDraftButton.cshtml
@@ -14,7 +14,6 @@ else
             <span class="visually-hidden">@T["Toggle Dropdown"]</span>
         </button>
         <div class="dropdown-menu">
-            <button class="dropdown-item draft-new" type="submit" name="submit.Save" value="submit.SaveAndNew">@T["and new"]</button>
             <button class="dropdown-item draft-continue" type="submit" name="submit.Save" value="submit.SaveAndContinue">@T["and continue"]</button>
         </div>
     </div>


### PR DESCRIPTION
Reverts OrchardCMS/OrchardCore#19729

The **"and new"** button is not functioning correctly, and fixing it has proven more complex than expected. I recommend reverting the change for now and reassessing whether this functionality provides enough value to warrant the additional complexity.

Fixes #19781
Replaces #19783 