### PR TITLE
docs: fix typo exeption -> exception

### DIFF
--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -1235,7 +1235,7 @@ A new extension has been introduced to simplify the registration of permission p
 * Fix distributed cache document invalidation by @mvarblow in https://github.com/OrchardCMS/OrchardCore/pull/16147
 * Issue management docs, auto-close and triage comment workflow (Lombiq Technologies: OCORE-161) by @Piedone in https://github.com/OrchardCMS/OrchardCore/pull/15820
 * Corrects the mapping of types to features in ITypeFeatureProvider  by @gvkries in https://github.com/OrchardCMS/OrchardCore/pull/15793
-* Show recipe error instead if throwing an exeption by @MikeAlhayek in https://github.com/OrchardCMS/OrchardCore/pull/16148
+* Show recipe error instead if throwing an exception by @MikeAlhayek in https://github.com/OrchardCMS/OrchardCore/pull/16148
 * Fix unreliable unit test by @gvkries in https://github.com/OrchardCMS/OrchardCore/pull/16145
 * Update Jint 3.1.2 by @hishamco in https://github.com/OrchardCMS/OrchardCore/pull/16157
 * Update xunit 2.8.1 by @hishamco in https://github.com/OrchardCMS/OrchardCore/pull/16158


### PR DESCRIPTION
Corrects the misspelling `exeption` -> `exception` in `src/docs/releases/2.0.0.md`.

Documentation only, no behaviour change.