### PR TITLE
Escape NTFS-invalid characters in the remote media cache paths

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/MediaEndpointHelpers.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/MediaEndpointHelpers.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OrchardCore.FileStorage;
 using OrchardCore.Media.Services;
 using OrchardCore.Media.ViewModels;
@@ -215,14 +216,24 @@ internal static class MediaEndpointHelpers
             return;
         }
 
-        var stream = await mediaFileStore.GetFileStreamAsync(mediaFile);
+        // Pre-caching is an optimization; a cache failure must not fail the upload or move
+        // that already succeeded in the remote store.
         try
         {
-            await mediaFileStoreCache.SetCacheAsync(stream, mediaFile, httpContext.RequestAborted);
+            var stream = await mediaFileStore.GetFileStreamAsync(mediaFile);
+            try
+            {
+                await mediaFileStoreCache.SetCacheAsync(stream, mediaFile, httpContext.RequestAborted);
+            }
+            finally
+            {
+                stream?.Dispose();
+            }
         }
-        finally
+        catch (Exception ex)
         {
-            stream?.Dispose();
+            var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(MediaEndpointHelpers));
+            logger.LogError(ex, "Error pre-caching remote media with path {Path}.", mediaFile.Path);
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/MediaEndpointHelpers.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/MediaEndpointHelpers.cs
@@ -206,11 +206,11 @@ internal static class MediaEndpointHelpers
 
     public static async Task PreCacheRemoteMediaAsync(
         IFileStoreEntry mediaFile,
-        IServiceProvider serviceProvider,
         IMediaFileStore mediaFileStore,
-        HttpContext httpContext)
+        IMediaFileStoreCache mediaFileStoreCache,
+        HttpContext httpContext,
+        ILogger logger)
     {
-        var mediaFileStoreCache = serviceProvider.GetService<IMediaFileStoreCache>();
         if (mediaFileStoreCache == null)
         {
             return;
@@ -232,7 +232,6 @@ internal static class MediaEndpointHelpers
         }
         catch (Exception ex)
         {
-            var logger = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(MediaEndpointHelpers));
             logger.LogError(ex, "Error pre-caching remote media with path {Path}.", mediaFile.Path);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/MoveMediaEndpoint.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/MoveMediaEndpoint.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Media.Endpoints.Api;
@@ -37,6 +38,7 @@ public static class MoveMediaEndpoint
         IMediaFileStore mediaFileStore,
         IOptions<MediaOptions> options,
         IServiceProvider serviceProvider,
+        ILogger<MediaApiEndpoints> logger,
         IStringLocalizer<MediaApiEndpoints> localizer,
         string oldPath,
         string newPath)
@@ -73,7 +75,12 @@ public static class MoveMediaEndpoint
         await mediaFileStore.MoveFileAsync(oldPath, newPath);
 
         var movedFile = await mediaFileStore.GetFileInfoAsync(newPath);
-        await MediaEndpointHelpers.PreCacheRemoteMediaAsync(movedFile, serviceProvider, mediaFileStore, httpContext);
+        await MediaEndpointHelpers.PreCacheRemoteMediaAsync(
+            movedFile,
+            mediaFileStore,
+            serviceProvider.GetService(typeof(IMediaFileStoreCache)) as IMediaFileStoreCache,
+            httpContext,
+            logger);
 
         return TypedResults.Ok();
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/UploadMediaEndpoint.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/UploadMediaEndpoint.cs
@@ -135,7 +135,12 @@ public static class UploadMediaEndpoint
 
                         var mediaFile = await mediaFileStore.GetFileInfoAsync(mediaFilePath);
 
-                        await MediaEndpointHelpers.PreCacheRemoteMediaAsync(mediaFile, serviceProvider, mediaFileStore, httpContext);
+                        await MediaEndpointHelpers.PreCacheRemoteMediaAsync(
+                            mediaFile,
+                            mediaFileStore,
+                            serviceProvider.GetService(typeof(IMediaFileStoreCache)) as IMediaFileStoreCache,
+                            httpContext,
+                            logger);
 
                         result.Add(new UploadFileResultDto(MediaEndpointHelpers.CreateFileResult(mediaFile, httpContext, contentTypeProvider, fileVersionProvider, mediaFileStore)));
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/RemoteMediaCacheBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/RemoteMediaCacheBackgroundTask.cs
@@ -68,7 +68,8 @@ public sealed class RemoteMediaCacheBackgroundTask : IBackgroundTask
                     continue;
                 }
 
-                var path = Path.GetRelativePath(_cachePath, directoryInfo.FullName);
+                // Cached names are escaped for the local file system, unescape to get the media path.
+                var path = MediaCachePathEscaper.Unescape(Path.GetRelativePath(_cachePath, directoryInfo.FullName));
 
                 // Check if the remote directory doesn't exist.
                 var entry = await _mediaFileStore.GetDirectoryInfoAsync(path);
@@ -89,7 +90,8 @@ public sealed class RemoteMediaCacheBackgroundTask : IBackgroundTask
                     continue;
                 }
 
-                var path = Path.GetRelativePath(_cachePath, fileInfo.FullName);
+                // Cached names are escaped for the local file system, unescape to get the media path.
+                var path = MediaCachePathEscaper.Unescape(Path.GetRelativePath(_cachePath, fileInfo.FullName));
 
                 // Check if the remote media doesn't exist or was updated.
                 var entry = await _mediaFileStore.GetFileInfoAsync(path);

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.FileProviders.Physical;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using OrchardCore.FileStorage;
 
 namespace OrchardCore.Media.Core;
@@ -45,7 +46,14 @@ public class DefaultMediaFileStoreCacheFileProvider : PhysicalFileProvider, IMed
 
     /// <inheritdoc cref="GetFileInfo"/>
     public new IDirectoryContents GetDirectoryContents(string subpath)
-        => base.GetDirectoryContents(MediaCachePathEscaper.Escape(subpath));
+    {
+        var contents = base.GetDirectoryContents(MediaCachePathEscaper.Escape(subpath));
+        return contents.Exists ? new UnescapedDirectoryContents(contents) : contents;
+    }
+
+    /// <inheritdoc cref="GetFileInfo"/>
+    public new IChangeToken Watch(string filter)
+        => base.Watch(MediaCachePathEscaper.EscapeGlob(filter));
 
     public Task<bool> IsCachedAsync(string path)
     {
@@ -181,10 +189,45 @@ public class DefaultMediaFileStoreCacheFileProvider : PhysicalFileProvider, IMed
                 _logger.LogError(ex, "Error deleting cache file {Path}", fileInfo.PhysicalPath);
                 return Task.FromResult(false);
             }
+
         }
         else
         {
             return Task.FromResult(false);
         }
+    }
+
+    private sealed class UnescapedDirectoryContents : IDirectoryContents
+    {
+        private readonly IDirectoryContents _contents;
+
+        public UnescapedDirectoryContents(IDirectoryContents contents) => _contents = contents;
+
+        public bool Exists => _contents.Exists;
+
+        public IEnumerator<IFileInfo> GetEnumerator()
+        {
+            foreach (var fileInfo in _contents)
+            {
+                yield return new UnescapedFileInfo(fileInfo);
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class UnescapedFileInfo : IFileInfo
+    {
+        private readonly IFileInfo _fileInfo;
+
+        public UnescapedFileInfo(IFileInfo fileInfo) => _fileInfo = fileInfo;
+
+        public bool Exists => _fileInfo.Exists;
+        public bool IsDirectory => _fileInfo.IsDirectory;
+        public DateTimeOffset LastModified => _fileInfo.LastModified;
+        public long Length => _fileInfo.Length;
+        public string Name => MediaCachePathEscaper.Unescape(_fileInfo.Name);
+        public string PhysicalPath => _fileInfo.PhysicalPath;
+        public Stream CreateReadStream() => _fileInfo.CreateReadStream();
     }
 }

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -33,6 +33,20 @@ public class DefaultMediaFileStoreCacheFileProvider : PhysicalFileProvider, IMed
 
     public PathString VirtualPathBase { get; }
 
+    /// <summary>
+    /// Resolves a media path to its cache location, escaping characters that are invalid on the
+    /// local file system (e.g. ':' on NTFS) so any remote media path can be mirrored locally.
+    /// <see cref="PhysicalFileProvider.GetFileInfo"/> is not virtual, so this relies on interface
+    /// re-implementation: all consumers resolve this class through <see cref="IFileProvider"/> or
+    /// call it directly, and both bind to this method.
+    /// </summary>
+    public new IFileInfo GetFileInfo(string subpath)
+        => base.GetFileInfo(MediaCachePathEscaper.Escape(subpath));
+
+    /// <inheritdoc cref="GetFileInfo"/>
+    public new IDirectoryContents GetDirectoryContents(string subpath)
+        => base.GetDirectoryContents(MediaCachePathEscaper.Escape(subpath));
+
     public Task<bool> IsCachedAsync(string path)
     {
         // Opportunity here to save metadata and/or provide cache validation / integrity checks.
@@ -45,18 +59,21 @@ public class DefaultMediaFileStoreCacheFileProvider : PhysicalFileProvider, IMed
     {
         // File store semantics may include a leading slash.
         // Trailing slash would create an empty directory instead of a file.
-        var cachePath = Path.Combine(Root, fileStoreEntry.Path.Trim('/'));
-        var directory = Path.GetDirectoryName(cachePath);
-
-        if (!Directory.Exists(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
+        // Characters that are invalid on the local file system are escaped, so remote paths
+        // that NTFS rejects (e.g. 'test:asdf') can still be cached.
+        var cachePath = Path.Combine(Root, MediaCachePathEscaper.Escape(fileStoreEntry.Path.Trim('/')));
 
         // A file download may fail, so a partially downloaded file should be deleted so the next request can reprocess.
         // All exceptions here are recaught by the MediaFileStoreResolverMiddleware.
         try
         {
+            var directory = Path.GetDirectoryName(cachePath);
+
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
             if (File.Exists(cachePath))
             {
                 File.Delete(cachePath);

--- a/src/OrchardCore/OrchardCore.Media.Core/MediaCachePathEscaper.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/MediaCachePathEscaper.cs
@@ -16,6 +16,8 @@ namespace OrchardCore.Media.Core;
 public static class MediaCachePathEscaper
 {
     private const char EscapeCharacter = '%';
+    private const string CompactEscapePrefix = "%~";
+    private const int MaximumComponentLength = 255;
 
     // Characters that are invalid in NTFS/FAT file names (except '/', which is the path
     // delimiter), plus the escape character itself. Control characters are escaped too.
@@ -27,6 +29,7 @@ public static class MediaCachePathEscaper
         "CON", "PRN", "AUX", "NUL",
         "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
         "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        "COM¹", "COM²", "COM³", "LPT¹", "LPT²", "LPT³",
     ];
 
     /// <summary>
@@ -34,8 +37,17 @@ public static class MediaCachePathEscaper
     /// Returns the original instance when nothing needs escaping, which is the common case.
     /// </summary>
     public static string Escape(string path)
+        => Escape(path, preserveGlobPatterns: false);
+
+    /// <summary>
+    /// Escapes a file-provider glob pattern while retaining glob wildcards.
+    /// </summary>
+    public static string EscapeGlob(string pattern)
+        => Escape(pattern, preserveGlobPatterns: true);
+
+    private static string Escape(string path, bool preserveGlobPatterns)
     {
-        if (string.IsNullOrEmpty(path) || !NeedsEscaping(path))
+        if (string.IsNullOrEmpty(path) || !NeedsEscaping(path, preserveGlobPatterns))
         {
             return path;
         }
@@ -46,7 +58,7 @@ public static class MediaCachePathEscaper
         {
             var separatorIndex = path.IndexOf('/', start);
             var end = separatorIndex >= 0 ? separatorIndex : path.Length;
-            AppendEscapedSegment(builder, path.AsSpan(start, end - start));
+            AppendEscapedSegment(builder, path.AsSpan(start, end - start), preserveGlobPatterns);
             if (separatorIndex < 0)
             {
                 return builder.ToString();
@@ -58,7 +70,7 @@ public static class MediaCachePathEscaper
     }
 
     /// <summary>
-    /// Reverses <see cref="Escape"/>. A '%' that is not followed by two hex digits is kept as-is,
+    /// Reverses <see cref="Escape(string)"/>. A '%' that is not followed by two hex digits is kept as-is,
     /// so paths that were never escaped unescape to themselves.
     /// </summary>
     public static string Unescape(string path)
@@ -68,44 +80,45 @@ public static class MediaCachePathEscaper
             return path;
         }
 
-        var index = path.IndexOf(EscapeCharacter);
-        if (index < 0)
+        if (path.IndexOf(EscapeCharacter) < 0)
         {
             return path;
         }
 
         var builder = new StringBuilder(path.Length);
-        var lastCopied = 0;
-        while (index >= 0)
+        var start = 0;
+        while (true)
         {
-            builder.Append(path, lastCopied, index - lastCopied);
-            if (index + 2 < path.Length && Uri.IsHexDigit(path[index + 1]) && Uri.IsHexDigit(path[index + 2]))
+            var separatorIndex = path.IndexOf('/', start);
+            var end = separatorIndex >= 0 ? separatorIndex : path.Length;
+            var segment = path.AsSpan(start, end - start);
+            if (TryUnescapeCompactSegment(segment, out var unescaped))
             {
-                builder.Append((char)((Uri.FromHex(path[index + 1]) << 4) | Uri.FromHex(path[index + 2])));
-                lastCopied = index + 3;
+                builder.Append(unescaped);
             }
             else
             {
-                builder.Append(EscapeCharacter);
-                lastCopied = index + 1;
+                AppendUnescapedSegment(builder, segment);
             }
 
-            index = path.IndexOf(EscapeCharacter, lastCopied);
+            if (separatorIndex < 0)
+            {
+                return builder.ToString();
+            }
+
+            builder.Append('/');
+            start = separatorIndex + 1;
         }
-
-        builder.Append(path, lastCopied, path.Length - lastCopied);
-
-        return builder.ToString();
     }
 
-    private static bool NeedsEscaping(string path)
+    private static bool NeedsEscaping(string path, bool preserveGlobPatterns)
     {
         var start = 0;
         while (true)
         {
             var separatorIndex = path.IndexOf('/', start);
             var end = separatorIndex >= 0 ? separatorIndex : path.Length;
-            if (SegmentNeedsEscaping(path.AsSpan(start, end - start)))
+            if (SegmentNeedsEscaping(path.AsSpan(start, end - start), preserveGlobPatterns))
             {
                 return true;
             }
@@ -119,16 +132,19 @@ public static class MediaCachePathEscaper
         }
     }
 
-    private static bool SegmentNeedsEscaping(ReadOnlySpan<char> segment)
+    private static bool SegmentNeedsEscaping(ReadOnlySpan<char> segment, bool preserveGlobPatterns)
     {
         if (segment.IsEmpty)
         {
             return false;
         }
 
-        if (segment.IndexOfAny(s_escapedCharacters) >= 0)
+        foreach (var c in segment)
         {
-            return true;
+            if (s_escapedCharacters.Contains(c) && (!preserveGlobPatterns || (c != '*' && c != '?')))
+            {
+                return true;
+            }
         }
 
         foreach (var c in segment)
@@ -150,7 +166,7 @@ public static class MediaCachePathEscaper
         return IsReservedName(segment);
     }
 
-    private static void AppendEscapedSegment(StringBuilder builder, ReadOnlySpan<char> segment)
+    private static void AppendEscapedSegment(StringBuilder builder, ReadOnlySpan<char> segment, bool preserveGlobPatterns)
     {
         if (segment.IsEmpty)
         {
@@ -164,21 +180,103 @@ public static class MediaCachePathEscaper
             trailingStart--;
         }
 
+        var escaped = new StringBuilder(segment.Length + 8);
+
         // Escaping the first character is enough to void a reserved device name.
         var escapeFirst = IsReservedName(segment);
 
         for (var i = 0; i < segment.Length; i++)
         {
             var c = segment[i];
-            if (c < ' ' || s_escapedCharacters.Contains(c) || i >= trailingStart || (i == 0 && escapeFirst))
+            if (c < ' ' ||
+                (s_escapedCharacters.Contains(c) && (!preserveGlobPatterns || (c != '*' && c != '?'))) ||
+                i >= trailingStart ||
+                (i == 0 && escapeFirst))
             {
-                builder.Append(EscapeCharacter);
-                builder.Append(((int)c).ToString("X2", CultureInfo.InvariantCulture));
+                escaped.Append(EscapeCharacter);
+                escaped.Append(((int)c).ToString("X2", CultureInfo.InvariantCulture));
             }
             else
             {
-                builder.Append(c);
+                escaped.Append(c);
             }
+        }
+
+        if (escaped.Length > MaximumComponentLength)
+        {
+            builder.Append(CompactEscapePrefix);
+            builder.Append(segment.Length.ToString(CultureInfo.InvariantCulture));
+            builder.Append(EscapeCharacter);
+            builder.Append(ToBase64Url(Encoding.UTF8.GetBytes(segment.ToString())));
+        }
+        else
+        {
+            builder.Append(escaped);
+        }
+    }
+
+    private static void AppendUnescapedSegment(StringBuilder builder, ReadOnlySpan<char> segment)
+    {
+        var index = segment.IndexOf(EscapeCharacter);
+        var lastCopied = 0;
+        while (index >= 0)
+        {
+            builder.Append(segment[lastCopied..index]);
+            if (index + 2 < segment.Length && Uri.IsHexDigit(segment[index + 1]) && Uri.IsHexDigit(segment[index + 2]))
+            {
+                builder.Append((char)((Uri.FromHex(segment[index + 1]) << 4) | Uri.FromHex(segment[index + 2])));
+                lastCopied = index + 3;
+            }
+            else
+            {
+                builder.Append(EscapeCharacter);
+                lastCopied = index + 1;
+            }
+
+            index = segment[lastCopied..].IndexOf(EscapeCharacter);
+            if (index >= 0)
+            {
+                index += lastCopied;
+            }
+        }
+
+        builder.Append(segment[lastCopied..]);
+    }
+
+    private static string ToBase64Url(byte[] bytes)
+        => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static bool TryUnescapeCompactSegment(ReadOnlySpan<char> segment, out string value)
+    {
+        try
+        {
+            value = null;
+            if (!segment.StartsWith(CompactEscapePrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var separatorIndex = segment[CompactEscapePrefix.Length..].IndexOf(EscapeCharacter);
+            if (separatorIndex < 1 ||
+                !int.TryParse(segment.Slice(CompactEscapePrefix.Length, separatorIndex), CultureInfo.InvariantCulture, out var length))
+            {
+                return false;
+            }
+
+            var base64 = segment[(CompactEscapePrefix.Length + separatorIndex + 1)..].ToString().Replace('-', '+').Replace('_', '/');
+            var bytes = Convert.FromBase64String(base64.PadRight(base64.Length + ((4 - base64.Length % 4) % 4), '='));
+            value = new UTF8Encoding(false, true).GetString(bytes);
+            return value.Length == length;
+        }
+        catch (FormatException)
+        {
+            value = null;
+            return false;
+        }
+        catch (DecoderFallbackException)
+        {
+            value = null;
+            return false;
         }
     }
 

--- a/src/OrchardCore/OrchardCore.Media.Core/MediaCachePathEscaper.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/MediaCachePathEscaper.cs
@@ -1,0 +1,205 @@
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+
+namespace OrchardCore.Media.Core;
+
+/// <summary>
+/// Maps media file store paths to names that are valid on the local file system, so remote
+/// stores (e.g. Azure Blob Storage, Amazon S3) whose paths may contain characters or names
+/// that are invalid on Windows/NTFS (e.g. ':', '*', trailing dots, reserved device names)
+/// can still be mirrored inside the local media cache.
+/// Offending characters are escaped as '%XX' (invariant uppercase hex). The mapping is
+/// deterministic, collision free and reversible, and is applied on every platform so the
+/// cache layout does not depend on the operating system.
+/// </summary>
+public static class MediaCachePathEscaper
+{
+    private const char EscapeCharacter = '%';
+
+    // Characters that are invalid in NTFS/FAT file names (except '/', which is the path
+    // delimiter), plus the escape character itself. Control characters are escaped too.
+    private static readonly SearchValues<char> s_escapedCharacters = SearchValues.Create("\"*:<>?\\|%");
+
+    // Windows reserved device names, invalid as a file or directory name, alone or with any extension.
+    private static readonly string[] s_reservedNames =
+    [
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+
+    /// <summary>
+    /// Escapes a '/'-delimited media path so that every segment is a valid file system name.
+    /// Returns the original instance when nothing needs escaping, which is the common case.
+    /// </summary>
+    public static string Escape(string path)
+    {
+        if (string.IsNullOrEmpty(path) || !NeedsEscaping(path))
+        {
+            return path;
+        }
+
+        var builder = new StringBuilder(path.Length + 8);
+        var start = 0;
+        while (true)
+        {
+            var separatorIndex = path.IndexOf('/', start);
+            var end = separatorIndex >= 0 ? separatorIndex : path.Length;
+            AppendEscapedSegment(builder, path.AsSpan(start, end - start));
+            if (separatorIndex < 0)
+            {
+                return builder.ToString();
+            }
+
+            builder.Append('/');
+            start = separatorIndex + 1;
+        }
+    }
+
+    /// <summary>
+    /// Reverses <see cref="Escape"/>. A '%' that is not followed by two hex digits is kept as-is,
+    /// so paths that were never escaped unescape to themselves.
+    /// </summary>
+    public static string Unescape(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        var index = path.IndexOf(EscapeCharacter);
+        if (index < 0)
+        {
+            return path;
+        }
+
+        var builder = new StringBuilder(path.Length);
+        var lastCopied = 0;
+        while (index >= 0)
+        {
+            builder.Append(path, lastCopied, index - lastCopied);
+            if (index + 2 < path.Length && Uri.IsHexDigit(path[index + 1]) && Uri.IsHexDigit(path[index + 2]))
+            {
+                builder.Append((char)((Uri.FromHex(path[index + 1]) << 4) | Uri.FromHex(path[index + 2])));
+                lastCopied = index + 3;
+            }
+            else
+            {
+                builder.Append(EscapeCharacter);
+                lastCopied = index + 1;
+            }
+
+            index = path.IndexOf(EscapeCharacter, lastCopied);
+        }
+
+        builder.Append(path, lastCopied, path.Length - lastCopied);
+
+        return builder.ToString();
+    }
+
+    private static bool NeedsEscaping(string path)
+    {
+        var start = 0;
+        while (true)
+        {
+            var separatorIndex = path.IndexOf('/', start);
+            var end = separatorIndex >= 0 ? separatorIndex : path.Length;
+            if (SegmentNeedsEscaping(path.AsSpan(start, end - start)))
+            {
+                return true;
+            }
+
+            if (separatorIndex < 0)
+            {
+                return false;
+            }
+
+            start = separatorIndex + 1;
+        }
+    }
+
+    private static bool SegmentNeedsEscaping(ReadOnlySpan<char> segment)
+    {
+        if (segment.IsEmpty)
+        {
+            return false;
+        }
+
+        if (segment.IndexOfAny(s_escapedCharacters) >= 0)
+        {
+            return true;
+        }
+
+        foreach (var c in segment)
+        {
+            if (c < ' ')
+            {
+                return true;
+            }
+        }
+
+        // Windows strips trailing dots and spaces, which would make the cached name
+        // differ from the requested one.
+        var last = segment[^1];
+        if (last == '.' || last == ' ')
+        {
+            return true;
+        }
+
+        return IsReservedName(segment);
+    }
+
+    private static void AppendEscapedSegment(StringBuilder builder, ReadOnlySpan<char> segment)
+    {
+        if (segment.IsEmpty)
+        {
+            return;
+        }
+
+        // Escape the whole trailing run of dots and spaces, Windows strips them all.
+        var trailingStart = segment.Length;
+        while (trailingStart > 0 && (segment[trailingStart - 1] == '.' || segment[trailingStart - 1] == ' '))
+        {
+            trailingStart--;
+        }
+
+        // Escaping the first character is enough to void a reserved device name.
+        var escapeFirst = IsReservedName(segment);
+
+        for (var i = 0; i < segment.Length; i++)
+        {
+            var c = segment[i];
+            if (c < ' ' || s_escapedCharacters.Contains(c) || i >= trailingStart || (i == 0 && escapeFirst))
+            {
+                builder.Append(EscapeCharacter);
+                builder.Append(((int)c).ToString("X2", CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                builder.Append(c);
+            }
+        }
+    }
+
+    private static bool IsReservedName(ReadOnlySpan<char> segment)
+    {
+        // A reserved name is reserved with any extension too, e.g. 'con.txt'.
+        var dotIndex = segment.IndexOf('.');
+        var name = (dotIndex >= 0 ? segment[..dotIndex] : segment).TrimEnd(' ');
+        if (name.Length is < 3 or > 4)
+        {
+            return false;
+        }
+
+        foreach (var reserved in s_reservedNames)
+        {
+            if (name.Equals(reserved, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/OrchardCore.Tests.Integration/AmazonS3/AwsFileStoreTests.cs
+++ b/test/OrchardCore.Tests.Integration/AmazonS3/AwsFileStoreTests.cs
@@ -1,8 +1,11 @@
 using Amazon.S3;
 using Amazon.S3.Model;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using OrchardCore.FileStorage;
 using OrchardCore.FileStorage.AmazonS3;
+using OrchardCore.Media.Core;
 using OrchardCore.Modules;
 using OrchardCore.Tests.Integration.Infrastructure;
 using Xunit;
@@ -304,6 +307,73 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
 
         Assert.Contains(entries, e => e.Name == "root-file.txt" && !e.IsDirectory);
         Assert.Contains(entries, e => e.Name == "sub-dir" && e.IsDirectory);
+    }
+
+    // -- NTFS-incompatible names, see https://github.com/OrchardCMS/OrchardCore/issues/17644 --
+
+    private const string NtfsInvalidFolder = "test:asdf";
+
+    [DockerFact]
+    public async Task CreateFile_FolderWithNtfsInvalidCharacters_RoundTrips()
+    {
+        // S3 object keys allow names that are invalid on NTFS, such as ':'.
+        var path = $"{NtfsInvalidFolder}/file.txt";
+        await CreateTestFileAsync(path, "ntfs invalid");
+
+        var info = await _store.GetFileInfoAsync(path);
+        Assert.NotNull(info);
+        Assert.Equal(path, info.Path);
+        Assert.Equal("ntfs invalid", await ReadFileContentAsync(path));
+
+        var entries = new List<IFileStoreEntry>();
+        await foreach (var entry in _store.GetDirectoryContentAsync(NtfsInvalidFolder))
+        {
+            entries.Add(entry);
+        }
+
+        Assert.Contains(entries, e => e.Name == "file.txt" && !e.IsDirectory);
+    }
+
+    [DockerFact]
+    public async Task SetCache_FolderWithNtfsInvalidCharacters_CachesServesAndDeletes()
+    {
+        // The remote-store to local media cache flow from issue #17644: the cache must be able
+        // to mirror a remote folder name that the local file system (NTFS) rejects.
+        var path = $"{NtfsInvalidFolder}/cached.txt";
+        await CreateTestFileAsync(path, "cache me");
+        var entry = await _store.GetFileInfoAsync(path);
+        Assert.NotNull(entry);
+
+        var cacheRoot = Directory.CreateTempSubdirectory("ms-cache-tests").FullName;
+        try
+        {
+            using var cache = new DefaultMediaFileStoreCacheFileProvider(
+                NullLogger<DefaultMediaFileStoreCacheFileProvider>.Instance,
+                "/media",
+                cacheRoot);
+
+            await using (var stream = await _store.GetFileStreamAsync(entry))
+            {
+                await cache.SetCacheAsync(stream, entry, CancellationToken.None);
+            }
+
+            Assert.True(await cache.IsCachedAsync(path));
+
+            // The static file middleware serves cached media through IFileProvider.
+            var fileInfo = ((IFileProvider)cache).GetFileInfo('/' + path);
+            Assert.True(fileInfo.Exists);
+            using (var reader = new StreamReader(fileInfo.CreateReadStream()))
+            {
+                Assert.Equal("cache me", await reader.ReadToEndAsync());
+            }
+
+            Assert.True(await cache.TryDeleteDirectoryAsync(NtfsInvalidFolder));
+            Assert.False(await cache.IsCachedAsync(path));
+        }
+        finally
+        {
+            Directory.Delete(cacheRoot, true);
+        }
     }
 }
 

--- a/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreTestsBase.cs
+++ b/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreTestsBase.cs
@@ -1,8 +1,11 @@
 using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using OrchardCore.FileStorage;
 using OrchardCore.FileStorage.AzureBlob;
+using OrchardCore.Media.Core;
 using OrchardCore.Modules;
 using Xunit;
 
@@ -435,6 +438,73 @@ public abstract class BlobFileStoreTestsBase : IAsyncLifetime
 
         var actual = await ReadFileContentAsync("moved-preserve.txt");
         Assert.Equal(content, actual);
+    }
+
+    // -- NTFS-incompatible names, see https://github.com/OrchardCMS/OrchardCore/issues/17644 --
+
+    private const string NtfsInvalidFolder = "test:asdf";
+
+    [AzuriteFact]
+    public async Task CreateFile_FolderWithNtfsInvalidCharacters_RoundTrips()
+    {
+        // Blob storage allows names that are invalid on NTFS, such as ':'.
+        var path = $"{NtfsInvalidFolder}/file.txt";
+        await CreateTestFileAsync(path, "ntfs invalid");
+
+        var info = await GetFileInfoAsync(path);
+        Assert.NotNull(info);
+        Assert.Equal(path, info.Path);
+        Assert.Equal("ntfs invalid", await ReadFileContentAsync(path));
+
+        var entries = new List<IFileStoreEntry>();
+        await foreach (var entry in GetDirectoryContentAsync(NtfsInvalidFolder))
+        {
+            entries.Add(entry);
+        }
+
+        Assert.Contains(entries, e => e.Name == "file.txt" && !e.IsDirectory);
+    }
+
+    [AzuriteFact]
+    public async Task SetCache_FolderWithNtfsInvalidCharacters_CachesServesAndDeletes()
+    {
+        // The remote-store to local media cache flow from issue #17644: the cache must be able
+        // to mirror a remote folder name that the local file system (NTFS) rejects.
+        var path = $"{NtfsInvalidFolder}/cached.txt";
+        await CreateTestFileAsync(path, "cache me");
+        var entry = await GetFileInfoAsync(path);
+        Assert.NotNull(entry);
+
+        var cacheRoot = Directory.CreateTempSubdirectory("ms-cache-tests").FullName;
+        try
+        {
+            using var cache = new DefaultMediaFileStoreCacheFileProvider(
+                NullLogger<DefaultMediaFileStoreCacheFileProvider>.Instance,
+                "/media",
+                cacheRoot);
+
+            await using (var stream = await Store.GetFileStreamAsync(entry))
+            {
+                await cache.SetCacheAsync(stream, entry, CancellationToken.None);
+            }
+
+            Assert.True(await cache.IsCachedAsync(path));
+
+            // The static file middleware serves cached media through IFileProvider.
+            var fileInfo = ((IFileProvider)cache).GetFileInfo('/' + path);
+            Assert.True(fileInfo.Exists);
+            using (var reader = new StreamReader(fileInfo.CreateReadStream()))
+            {
+                Assert.Equal("cache me", await reader.ReadToEndAsync());
+            }
+
+            Assert.True(await cache.TryDeleteDirectoryAsync(NtfsInvalidFolder));
+            Assert.False(await cache.IsCachedAsync(path));
+        }
+        finally
+        {
+            Directory.Delete(cacheRoot, true);
+        }
     }
 }
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.FileStorage/FileSystemStoreTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.FileStorage/FileSystemStoreTests.cs
@@ -1,0 +1,102 @@
+using OrchardCore.FileStorage;
+using OrchardCore.FileStorage.FileSystem;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.FileStorage;
+
+/// <summary>
+/// Tests for the local file system media storage, focused on folder names containing
+/// characters that NTFS rejects (e.g. ':'), see https://github.com/OrchardCMS/OrchardCore/issues/17644.
+/// Unlike remote stores, local storage is bound by the rules of the underlying file system:
+/// such names work on Linux and fail with a <see cref="FileStoreException"/> on Windows.
+/// </summary>
+public class FileSystemStoreTests : IDisposable
+{
+    private const string NtfsInvalidFolder = "test:asdf";
+
+    private readonly string _root;
+    private readonly FileSystemStore _store;
+
+    public FileSystemStoreTests()
+    {
+        _root = Directory.CreateTempSubdirectory("fs-store-tests").FullName;
+        _store = new FileSystemStore(_root, NullLogger<FileSystemStore>.Instance);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_root, true);
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<string> CreateFileAsync(string path, string content = "test content")
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        return await _store.CreateFileFromStreamAsync(path, stream);
+    }
+
+    private async Task<string> ReadFileContentAsync(string path)
+    {
+        using var stream = await _store.GetFileStreamAsync(path);
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync();
+    }
+
+    [Fact]
+    public async Task CreateFile_ValidFolder_RoundTrips()
+    {
+        var result = await CreateFileAsync("folder/file.txt", "hello");
+
+        Assert.Equal("folder/file.txt", result);
+        Assert.Equal("hello", await ReadFileContentAsync("folder/file.txt"));
+
+        var info = await _store.GetFileInfoAsync("folder/file.txt");
+        Assert.NotNull(info);
+        Assert.Equal("file.txt", info.Name);
+    }
+
+    [Fact]
+    public async Task CreateFile_FolderWithNtfsInvalidCharacters_DependsOnFileSystem()
+    {
+        var path = $"{NtfsInvalidFolder}/file.txt";
+
+        if (OperatingSystem.IsWindows())
+        {
+            // NTFS rejects ':' in names; the store surfaces it as a FileStoreException.
+            await Assert.ThrowsAsync<FileStoreException>(() => CreateFileAsync(path));
+        }
+        else
+        {
+            await CreateFileAsync(path, "ntfs invalid");
+
+            var info = await _store.GetFileInfoAsync(path);
+            Assert.NotNull(info);
+            Assert.Equal(path, info.Path);
+            Assert.Equal("ntfs invalid", await ReadFileContentAsync(path));
+
+            Assert.True(await _store.TryDeleteDirectoryAsync(NtfsInvalidFolder));
+            Assert.Null(await _store.GetFileInfoAsync(path));
+        }
+    }
+
+    [Fact]
+    public async Task CreateDirectory_FolderWithNtfsInvalidCharacters_DependsOnFileSystem()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            await Assert.ThrowsAsync<FileStoreException>(() => _store.TryCreateDirectoryAsync(NtfsInvalidFolder));
+        }
+        else
+        {
+            Assert.True(await _store.TryCreateDirectoryAsync(NtfsInvalidFolder));
+            Assert.NotNull(await _store.GetDirectoryInfoAsync(NtfsInvalidFolder));
+
+            var entries = new List<IFileStoreEntry>();
+            await foreach (var entry in _store.GetDirectoryContentAsync())
+            {
+                entries.Add(entry);
+            }
+
+            Assert.Contains(entries, e => e.IsDirectory && e.Name == NtfsInvalidFolder);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/DefaultMediaFileStoreCacheFileProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/DefaultMediaFileStoreCacheFileProviderTests.cs
@@ -73,6 +73,17 @@ public class DefaultMediaFileStoreCacheFileProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task GetDirectoryContents_NtfsInvalidPath_ReturnsTraversableLogicalName()
+    {
+        await SetCacheAsync("test:asdf/pic.png");
+
+        var directory = Assert.Single(_provider.GetDirectoryContents(string.Empty));
+
+        Assert.Equal("test:asdf", directory.Name);
+        Assert.True(_provider.GetFileInfo(directory.Name + "/pic.png").Exists);
+    }
+
+    [Fact]
     public async Task SetCache_ValidPath_KeepsVerbatimLayout()
     {
         await SetCacheAsync("folder/pic.png");

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/DefaultMediaFileStoreCacheFileProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/DefaultMediaFileStoreCacheFileProviderTests.cs
@@ -1,0 +1,144 @@
+using OrchardCore.FileStorage;
+using OrchardCore.Media.Core;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+/// <summary>
+/// Verifies that the local media cache can mirror any remote media path, including folder
+/// names that are invalid on the local file system, e.g. 'test:asdf' on Windows/NTFS.
+/// See https://github.com/OrchardCMS/OrchardCore/issues/17644.
+/// These tests run on every platform; the CI Windows runners exercise the NTFS behavior.
+/// </summary>
+public class DefaultMediaFileStoreCacheFileProviderTests : IDisposable
+{
+    private readonly string _root;
+    private readonly DefaultMediaFileStoreCacheFileProvider _provider;
+
+    public DefaultMediaFileStoreCacheFileProviderTests()
+    {
+        _root = Directory.CreateTempSubdirectory("ms-cache-tests").FullName;
+        _provider = new DefaultMediaFileStoreCacheFileProvider(
+            NullLogger<DefaultMediaFileStoreCacheFileProvider>.Instance,
+            "/media",
+            _root);
+    }
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        Directory.Delete(_root, true);
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task SetCacheAsync(string path, string content = "cached content")
+    {
+        var entry = Mock.Of<IFileStoreEntry>(e => e.Path == path);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        await _provider.SetCacheAsync(stream, entry, CancellationToken.None);
+    }
+
+    [Theory]
+    [InlineData("test:asdf/pic.png")] // Issue #17644.
+    [InlineData("weird*folder/what?.png")]
+    [InlineData("quote\"pipe|/less<more>.png")]
+    [InlineData("trailing./file.png")]
+    [InlineData("con/nul.txt")]
+    [InlineData("100%/50%off.png")]
+    public async Task SetCache_NtfsInvalidPath_CachesAndServesFile(string path)
+    {
+        await SetCacheAsync(path, "hello");
+
+        Assert.True(await _provider.IsCachedAsync(path));
+
+        // The resolver middleware and the static file middleware use a leading slash.
+        Assert.True(await _provider.IsCachedAsync('/' + path));
+
+        var fileInfo = ((IFileProvider)_provider).GetFileInfo('/' + path);
+        Assert.True(fileInfo.Exists);
+
+        using var reader = new StreamReader(fileInfo.CreateReadStream());
+        Assert.Equal("hello", await reader.ReadToEndAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SetCache_NtfsInvalidPath_EscapesPhysicalLocation()
+    {
+        await SetCacheAsync("test:asdf/pic.png");
+
+        var directories = Directory.GetDirectories(_root).Select(Path.GetFileName).ToList();
+
+        Assert.Contains("test%3Aasdf", directories);
+        // Even on file systems that would allow it, the raw name must not be used.
+        Assert.DoesNotContain("test:asdf", directories);
+    }
+
+    [Fact]
+    public async Task SetCache_ValidPath_KeepsVerbatimLayout()
+    {
+        await SetCacheAsync("folder/pic.png");
+
+        Assert.True(File.Exists(Path.Combine(_root, "folder", "pic.png")));
+    }
+
+    [Fact]
+    public async Task IsCached_UncachedNtfsInvalidPath_ReturnsFalse()
+    {
+        await SetCacheAsync("test:asdf/pic.png");
+
+        Assert.False(await _provider.IsCachedAsync("missing:folder/none.png"));
+    }
+
+    [Fact]
+    public async Task TryDeleteFile_NtfsInvalidPath_DeletesCachedFile()
+    {
+        await SetCacheAsync("test:asdf/pic.png");
+
+        Assert.True(await _provider.TryDeleteFileAsync("test:asdf/pic.png"));
+        Assert.False(await _provider.IsCachedAsync("test:asdf/pic.png"));
+        Assert.False(await _provider.TryDeleteFileAsync("test:asdf/pic.png"));
+    }
+
+    [Fact]
+    public async Task TryDeleteDirectory_NtfsInvalidPath_DeletesCachedDirectory()
+    {
+        await SetCacheAsync("test:asdf/pic.png");
+
+        Assert.True(await _provider.TryDeleteDirectoryAsync("test:asdf"));
+        Assert.False(await _provider.IsCachedAsync("test:asdf/pic.png"));
+    }
+
+    [Fact]
+    public async Task Purge_WithNtfsInvalidPaths_RemovesEverything()
+    {
+        await SetCacheAsync("test:asdf/pic.png");
+        await SetCacheAsync("normal/pic.png");
+
+        var hasErrors = await _provider.PurgeAsync();
+
+        Assert.False(hasErrors);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(_root));
+    }
+
+    [Fact]
+    public async Task CachedPaths_UnescapedRelativePhysicalPath_RoundTripsToMediaPath()
+    {
+        // Mirrors how RemoteMediaCacheBackgroundTask maps physical cache paths back to
+        // remote media paths when cleaning stale entries.
+        var paths = new[] { "test:asdf/pic.png", "folder/pic.png", "100%/50%off.png" };
+        foreach (var path in paths)
+        {
+            await SetCacheAsync(path);
+        }
+
+        var roundTripped = Directory.GetFiles(_root, "*", SearchOption.AllDirectories)
+            .Select(file => MediaCachePathEscaper
+                .Unescape(Path.GetRelativePath(_root, file))
+                .Replace(Path.DirectorySeparatorChar, '/'))
+            .ToList();
+
+        foreach (var path in paths)
+        {
+            Assert.Contains(path, roundTripped);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCachePathEscaperTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCachePathEscaperTests.cs
@@ -1,0 +1,57 @@
+using OrchardCore.Media.Core;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+public class MediaCachePathEscaperTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("images/photo.png")]
+    [InlineData("sub/dir/file.jpg")]
+    [InlineData("with space/foo bar.png")]
+    [InlineData("bàr/日本語.jpg")]
+    public void Escape_SafePath_ReturnsSameInstance(string path)
+        => Assert.Same(path, MediaCachePathEscaper.Escape(path));
+
+    [Theory]
+    [InlineData("test:asdf/pic.png", "test%3Aasdf/pic.png")] // Issue #17644.
+    [InlineData("a<b>c", "a%3Cb%3Ec")]
+    [InlineData("what?.png", "what%3F.png")]
+    [InlineData("star*quote\"pipe|.txt", "star%2Aquote%22pipe%7C.txt")]
+    [InlineData("100%.png", "100%25.png")]
+    [InlineData("back\\slash.png", "back%5Cslash.png")]
+    [InlineData("tab\tname.png", "tab%09name.png")]
+    [InlineData("trailing./file.png", "trailing%2E/file.png")]
+    [InlineData("trailing /file.png", "trailing%20/file.png")]
+    [InlineData("dots.../x", "dots%2E%2E%2E/x")]
+    [InlineData("CON", "%43ON")]
+    [InlineData("con.txt", "%63on.txt")]
+    [InlineData("lpt1.config.json", "%6Cpt1.config.json")]
+    [InlineData("CONSOLE.txt", "CONSOLE.txt")]
+    [InlineData("COM10.txt", "COM10.txt")]
+    public void Escape_NtfsInvalidName_EscapesOffendingCharacters(string path, string expected)
+        => Assert.Equal(expected, MediaCachePathEscaper.Escape(path));
+
+    [Theory]
+    [InlineData("test:asdf/pic.png")]
+    [InlineData("a<b>c")]
+    [InlineData("what?.png")]
+    [InlineData("star*quote\"pipe|.txt")]
+    [InlineData("100%/50%off.png")]
+    [InlineData("%25already/escaped%3A.png")]
+    [InlineData("trailing./file.png")]
+    [InlineData("dots.../x")]
+    [InlineData("CON/aux.txt")]
+    [InlineData("images/photo.png")]
+    public void Unescape_EscapedPath_RoundTrips(string path)
+        => Assert.Equal(path, MediaCachePathEscaper.Unescape(MediaCachePathEscaper.Escape(path)));
+
+    [Theory]
+    [InlineData("50%off.png", "50%off.png")] // '%' not followed by two hex digits stays literal.
+    [InlineData("a%3a.png", "a:.png")] // Lowercase hex is accepted.
+    [InlineData("%", "%")]
+    [InlineData("%2", "%2")]
+    [InlineData("test%3Aasdf/pic.png", "test:asdf/pic.png")]
+    public void Unescape_Input_ReturnsExpected(string path, string expected)
+        => Assert.Equal(expected, MediaCachePathEscaper.Unescape(path));
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCachePathEscaperTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaCachePathEscaperTests.cs
@@ -27,6 +27,8 @@ public class MediaCachePathEscaperTests
     [InlineData("CON", "%43ON")]
     [InlineData("con.txt", "%63on.txt")]
     [InlineData("lpt1.config.json", "%6Cpt1.config.json")]
+    [InlineData("COM¹", "%43OM¹")]
+    [InlineData("lpt³.txt", "%6Cpt³.txt")]
     [InlineData("CONSOLE.txt", "CONSOLE.txt")]
     [InlineData("COM10.txt", "COM10.txt")]
     public void Escape_NtfsInvalidName_EscapesOffendingCharacters(string path, string expected)
@@ -42,6 +44,7 @@ public class MediaCachePathEscaperTests
     [InlineData("trailing./file.png")]
     [InlineData("dots.../x")]
     [InlineData("CON/aux.txt")]
+    [InlineData("COM¹/lpt³.txt")]
     [InlineData("images/photo.png")]
     public void Unescape_EscapedPath_RoundTrips(string path)
         => Assert.Equal(path, MediaCachePathEscaper.Unescape(MediaCachePathEscaper.Escape(path)));
@@ -51,7 +54,23 @@ public class MediaCachePathEscaperTests
     [InlineData("a%3a.png", "a:.png")] // Lowercase hex is accepted.
     [InlineData("%", "%")]
     [InlineData("%2", "%2")]
+    [InlineData("%~invalid", "%~invalid")]
     [InlineData("test%3Aasdf/pic.png", "test:asdf/pic.png")]
     public void Unescape_Input_ReturnsExpected(string path, string expected)
         => Assert.Equal(expected, MediaCachePathEscaper.Unescape(path));
+
+    [Fact]
+    public void Escape_ExpandedSegmentExceedsLimit_UsesBoundedRoundTrippableName()
+    {
+        var path = new string('%', 86);
+
+        var escaped = MediaCachePathEscaper.Escape(path);
+
+        Assert.True(escaped.Length <= 255);
+        Assert.Equal(path, MediaCachePathEscaper.Unescape(escaped));
+    }
+
+    [Fact]
+    public void EscapeGlob_InvalidCharactersAndWildcards_MapsOnlyInvalidCharacters()
+        => Assert.Equal("folder%25/*%3A?.png", MediaCachePathEscaper.EscapeGlob("folder%/*:?.png"));
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEndpointHelpersTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEndpointHelpersTests.cs
@@ -11,6 +11,42 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media;
 public class MediaEndpointHelpersTests
 {
     [Fact]
+    public async Task PreCacheRemoteMedia_StreamRetrievalFails_DoesNotPropagate()
+    {
+        var entry = Mock.Of<IFileStoreEntry>(item => item.Path == "file.txt");
+        var mediaFileStore = new Mock<IMediaFileStore>();
+        var cache = new Mock<IMediaFileStoreCache>();
+        mediaFileStore.Setup(store => store.GetFileStreamAsync(entry)).ThrowsAsync(new IOException());
+
+        await MediaEndpointHelpers.PreCacheRemoteMediaAsync(
+            entry,
+            mediaFileStore.Object,
+            cache.Object,
+            new DefaultHttpContext(),
+            NullLogger.Instance);
+    }
+
+    [Fact]
+    public async Task PreCacheRemoteMedia_CacheWritingFails_DisposesStreamAndDoesNotPropagate()
+    {
+        var entry = Mock.Of<IFileStoreEntry>(item => item.Path == "file.txt");
+        var stream = new MemoryStream();
+        var mediaFileStore = new Mock<IMediaFileStore>();
+        var cache = new Mock<IMediaFileStoreCache>();
+        mediaFileStore.Setup(store => store.GetFileStreamAsync(entry)).ReturnsAsync(stream);
+        cache.Setup(item => item.SetCacheAsync(stream, entry, It.IsAny<CancellationToken>())).ThrowsAsync(new IOException());
+
+        await MediaEndpointHelpers.PreCacheRemoteMediaAsync(
+            entry,
+            mediaFileStore.Object,
+            cache.Object,
+            new DefaultHttpContext(),
+            NullLogger.Instance);
+
+        Assert.Throws<ObjectDisposedException>(() => stream.ReadByte());
+    }
+
+    [Fact]
     public async Task ToDtoAsync_UnauthorizedDescendants_FiltersTree()
     {
         var user = new ClaimsPrincipal();


### PR DESCRIPTION
### Summary

The media file store cache mirrors remote media paths verbatim onto the local disk. A remote folder name that is legal in Azure Blob Storage or Amazon S3 but invalid on the local file system — e.g. `test:asdf` on Windows/NTFS — made `DefaultMediaFileStoreCacheFileProvider.SetCacheAsync` throw "The directory name is invalid", breaking uploads (`PreCacheRemoteMedia`) and downloads (`MediaFileStoreResolverMiddleware`).

### What changed

- New `MediaCachePathEscaper` (OrchardCore.Media.Core): reversible `%XX` escaping of NTFS-invalid characters (`: * ? " < > | \`), control characters, trailing dots/spaces, and reserved device names (`CON`, `com1.txt`, …). Applied on every platform, so the cache layout does not depend on the OS and the Windows behavior is exercised by Linux CI too. Safe paths pass through as the same string instance.
- `DefaultMediaFileStoreCacheFileProvider`: `SetCacheAsync` writes to the escaped path; `GetFileInfo`/`GetDirectoryContents` are re-implemented (interface re-implementation over the non-virtual `PhysicalFileProvider` members) so the static file middleware, image processing, `IsCachedAsync`, purge, and the delete operations all resolve through the same mapping — cached files under such names are also served, not just written.
- `RemoteMediaCacheBackgroundTask`: unescapes cached names before checking the remote store, keeping the stale-cache cleanup round-trip correct.
- `PreCacheRemoteMediaAsync`: a cache failure is now logged instead of failing an upload/move that already succeeded in the remote store.

Folder-name validation is intentionally unchanged: these characters are legal in remote stores and on Linux, so the cache adapts instead of restricting media names. With local storage on Windows, `FileSystemStore` surfaces the file system's own rejection as a `FileStoreException`.

### Tests

- Unit (run on the Linux and Windows CI matrix, covering local disk/NTFS): `MediaCachePathEscaperTests`, `DefaultMediaFileStoreCacheFileProviderTests` (cache, serve, delete, purge, physical layout, background-task path round-trip), and new `FileSystemStoreTests` with OS-conditional assertions for local file storage.
- Integration: NTFS-invalid folder round-trip plus the full remote-store → local-cache → serve → delete flow, added to `BlobFileStoreTestsBase` (runs against Azurite in both flat/Gen1 and ADLS Gen2 hierarchical-namespace modes) and `AwsFileStoreTests` (Amazon S3 via LocalStack).

All suites pass locally: Gen1 vs stock Azurite 31/31, Gen1+Gen2 vs the HNS-enabled Azurite image 68/68, S3 21/21, full integration suite 113/113, Media/FileStorage unit tests 365/365.

Fixes #17644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
