### PR TITLE
Fix SEO image URLs when serving media from a CDN

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/UrlHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/UrlHelperExtensions.cs
@@ -19,8 +19,20 @@ public static class UrlHelperExtensions
 
     public static string ToAbsoluteUrl(this IUrlHelper url, string virtualPath)
     {
+        // The virtual path may already be an absolute URL, e.g. when media is served from a
+        // CDN (IMediaFileStore.MapPathToPublicUrl() prefixes the CDN base URL). In that case,
+        // prefixing it with the site's own base URL would produce an invalid, concatenated URL.
+        // Note: Uri.TryCreate(..., UriKind.Absolute, ...) also accepts rooted paths like
+        // "/media/image.jpg" as a valid "file://" URI, so the scheme must be checked explicitly.
+        if (Uri.TryCreate(virtualPath, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+        {
+            return virtualPath;
+        }
+
         var baseUrl = url.GetBaseUrl();
         var path = url.Content(virtualPath);
+
         return $"{baseUrl}{path}";
     }
 }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/UrlHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/UrlHelperExtensions.cs
@@ -22,10 +22,8 @@ public static class UrlHelperExtensions
         // The virtual path may already be an absolute URL, e.g. when media is served from a
         // CDN (IMediaFileStore.MapPathToPublicUrl() prefixes the CDN base URL). In that case,
         // prefixing it with the site's own base URL would produce an invalid, concatenated URL.
-        // Note: Uri.TryCreate(..., UriKind.Absolute, ...) also accepts rooted paths like
-        // "/media/image.jpg" as a valid "file://" URI, so the scheme must be checked explicitly.
-        if (Uri.TryCreate(virtualPath, UriKind.Absolute, out var uri) &&
-            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+        if (virtualPath.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            virtualPath.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
         {
             return virtualPath;
         }

--- a/test/OrchardCore.Tests/Mvc/UrlHelperExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Mvc/UrlHelperExtensionsTests.cs
@@ -50,10 +50,9 @@ public class UrlHelperExtensionsTests
     }
 
     [Fact]
-    public void ToAbsoluteUrlDoesNotMistakeARootedPathForAFileUri()
+    public void ToAbsoluteUrlDoesNotMistakeARootedPathForAnAbsoluteUrl()
     {
-        // Uri.TryCreate(path, UriKind.Absolute, ...) happily parses a rooted local path like
-        // "/media/image.jpg" as a valid "file://" URI. Guard against treating it as already
+        // Guard against treating an ordinary rooted local path (no scheme) as already
         // absolute, or local/relative media paths would never get the site base URL prefixed.
         var urlHelper = CreateUrlHelper("www.mydomain.com");
         urlHelper.Setup(x => x.Content("/media/image.jpg")).Returns("/media/image.jpg");
@@ -61,6 +60,19 @@ public class UrlHelperExtensionsTests
         var result = urlHelper.Object.ToAbsoluteUrl("/media/image.jpg");
 
         Assert.Equal("https://www.mydomain.com/media/image.jpg", result);
+    }
+
+    [Theory]
+    [InlineData("HTTP://cdn.mydomain.com/media/image.jpg")]
+    [InlineData("HTTPS://cdn.mydomain.com/media/image.jpg")]
+    [InlineData("Https://cdn.mydomain.com/media/image.jpg")]
+    public void ToAbsoluteUrlSchemeCheckIsCaseInsensitive(string absoluteUrl)
+    {
+        var urlHelper = CreateUrlHelper("www.mydomain.com");
+
+        var result = urlHelper.Object.ToAbsoluteUrl(absoluteUrl);
+
+        Assert.Equal(absoluteUrl, result);
     }
 
     private static Mock<IUrlHelper> CreateUrlHelper(string host)

--- a/test/OrchardCore.Tests/Mvc/UrlHelperExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Mvc/UrlHelperExtensionsTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Routing;
+using Moq;
+using OrchardCore.Mvc.Core.Utilities;
+
+namespace OrchardCore.Tests.Mvc;
+
+public class UrlHelperExtensionsTests
+{
+    [Fact]
+    public void ToAbsoluteUrlReturnsInputUnchangedWhenItIsAlreadyAbsolute()
+    {
+        // A CDN base URL (see IMediaFileStore.MapPathToPublicUrl()) produces an already-absolute
+        // URL. ToAbsoluteUrl() must not prefix the site's own base URL onto it (see #12835).
+        var urlHelper = CreateUrlHelper("www.mydomain.com");
+
+        var result = urlHelper.Object.ToAbsoluteUrl("https://cdn.mydomain.com/media/image.jpg");
+
+        Assert.Equal("https://cdn.mydomain.com/media/image.jpg", result);
+    }
+
+    [Theory]
+    [InlineData("http://cdn.mydomain.com/media/image.jpg")]
+    [InlineData("https://cdn.mydomain.com/media/image.jpg")]
+    public void ToAbsoluteUrlPreservesSchemeOfAlreadyAbsoluteUrls(string absoluteUrl)
+    {
+        var urlHelper = CreateUrlHelper("www.mydomain.com");
+
+        var result = urlHelper.Object.ToAbsoluteUrl(absoluteUrl);
+
+        Assert.Equal(absoluteUrl, result);
+    }
+
+    [Fact]
+    public void ToAbsoluteUrlPrefixesBaseUrlForRelativePaths()
+    {
+        var urlHelper = CreateUrlHelper("www.mydomain.com");
+        urlHelper.Setup(x => x.Content("/media/image.jpg")).Returns("/media/image.jpg");
+
+        var baseUrl = urlHelper.Object.GetBaseUrl();
+        var content = urlHelper.Object.Content("/media/image.jpg");
+        var result = urlHelper.Object.ToAbsoluteUrl("/media/image.jpg");
+
+        Assert.Equal("https://www.mydomain.com", baseUrl);
+        Assert.Equal("/media/image.jpg", content);
+        Assert.Equal("https://www.mydomain.com/media/image.jpg", result);
+    }
+
+    [Fact]
+    public void ToAbsoluteUrlDoesNotMistakeARootedPathForAFileUri()
+    {
+        // Uri.TryCreate(path, UriKind.Absolute, ...) happily parses a rooted local path like
+        // "/media/image.jpg" as a valid "file://" URI. Guard against treating it as already
+        // absolute, or local/relative media paths would never get the site base URL prefixed.
+        var urlHelper = CreateUrlHelper("www.mydomain.com");
+        urlHelper.Setup(x => x.Content("/media/image.jpg")).Returns("/media/image.jpg");
+
+        var result = urlHelper.Object.ToAbsoluteUrl("/media/image.jpg");
+
+        Assert.Equal("https://www.mydomain.com/media/image.jpg", result);
+    }
+
+    private static Mock<IUrlHelper> CreateUrlHelper(string host)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString(host);
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.SetupGet(x => x.ActionContext).Returns(actionContext);
+
+        return urlHelper;
+    }
+}


### PR DESCRIPTION
Fixes #12835

### Problem

When OrchardCore is configured to serve media from a CDN (`OrchardCore:OrchardCore_Media:CdnBaseUrl`), the SEO meta tags for `OpenGraphImage` and `TwitterImage` were malformed:

```html
<meta content="https://www.mydomain.comhttps://cdn.mydomain.com/media/image.jpg" property="og:image">
```

### Root cause

`IMediaFileStore.MapPathToPublicUrl()` already returns a full absolute URL when a CDN base URL is configured. That value is then passed into `IUrlHelper.ToAbsoluteUrl()`, which unconditionally prefixed the site's own base URL (scheme + host) onto whatever path it received — with no check for whether the path was already absolute.

### Fix

`UrlHelperExtensions.ToAbsoluteUrl()` now returns the input unchanged when it is already an absolute `http`/`https` URL, instead of re-prefixing it.

Note: a naive `Uri.TryCreate(path, UriKind.Absolute, out _)` check is not sufficient on its own — it also happily parses a rooted local path like `/media/image.jpg` as a valid `file://` URI, which would incorrectly skip the base-URL prefix for ordinary local (non-CDN) media paths. The fix explicitly checks the parsed URI's scheme is `http` or `https`.

### Testing

Added `test/OrchardCore.Tests/Mvc/UrlHelperExtensionsTests.cs` covering:
- an already-absolute (CDN) URL is returned unchanged
- both `http` and `https` absolute URLs are preserved
- a relative/local media path is still correctly prefixed with the site base URL
- a regression case for the `file://` URI misparse of rooted local paths

`dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --filter-class "OrchardCore.Tests.Mvc.UrlHelperExtensionsTests"` — 5/5 passing.