### PR TITLE
Remove unnecessary UrlDecode of blob/object names in Azure and S3 stores

### DIFF
--- a/src/OrchardCore/OrchardCore.FileStorage.AmazonS3/AwsFileStorage.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AmazonS3/AwsFileStorage.cs
@@ -86,7 +86,7 @@ public class AwsFileStore : IFileStore
 
         foreach (var file in listObjectsResponse.S3Objects ?? [])
         {
-            var itemName = Path.GetFileName(WebUtility.UrlDecode(file.Key));
+            var itemName = Path.GetFileName(file.Key);
 
             if (includeSubDirectories || !string.IsNullOrEmpty(itemName))
             {

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.Mime;
 using Azure;
 using Azure.Storage.Blobs;
@@ -305,7 +304,7 @@ public class BlobFileStore : IFileStore
                 continue;
             }
 
-            var itemName = Path.GetFileName(WebUtility.UrlDecode(blob.Blob.Name)).Trim('/');
+            var itemName = Path.GetFileName(blob.Blob.Name).Trim('/');
 
             // Gen2 (HNS) empty directories are returned as a blob at exactly the directory's path
             // (nothing exists beneath them to be grouped into a prefix), identified by this metadata flag.
@@ -387,7 +386,7 @@ public class BlobFileStore : IFileStore
         var flatPage = _blobContainer.GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, prefix, CancellationToken.None);
         await foreach (var blob in flatPage)
         {
-            var name = WebUtility.UrlDecode(blob.Name);
+            var name = blob.Name;
 
             // A flat blob listing does not return a folder hierarchy.
             // We can infer a hierarchy by examining the paths returned for the file contents

--- a/test/OrchardCore.Tests.Integration/AmazonS3/AwsFileStoreTests.cs
+++ b/test/OrchardCore.Tests.Integration/AmazonS3/AwsFileStoreTests.cs
@@ -305,5 +305,23 @@ public sealed class AwsFileStoreTests : IAsyncLifetime
         Assert.Contains(entries, e => e.Name == "root-file.txt" && !e.IsDirectory);
         Assert.Contains(entries, e => e.Name == "sub-dir" && e.IsDirectory);
     }
+
+    [DockerFact]
+    public async Task GetDirectoryContent_PreservesPlusSignInFileName()
+    {
+        // Regression test for #17764: AwsFileStore used to run object keys through
+        // WebUtility.UrlDecode(), which turns a literal "+" into a space, corrupting the
+        // reported entry name for files such as "My+File.jpg".
+        await CreateTestFileAsync("plus-test/My+File.jpg");
+
+        var entries = new List<IFileStoreEntry>();
+        await foreach (var entry in _store.GetDirectoryContentAsync("plus-test"))
+        {
+            entries.Add(entry);
+        }
+
+        Assert.Contains(entries, e => !e.IsDirectory && e.Name == "My+File.jpg");
+        Assert.DoesNotContain(entries, e => !e.IsDirectory && e.Name == "My File.jpg");
+    }
 }
 

--- a/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreTestsBase.cs
+++ b/test/OrchardCore.Tests.Integration/AzureBlob/BlobFileStoreTestsBase.cs
@@ -363,6 +363,39 @@ public abstract class BlobFileStoreTestsBase : IAsyncLifetime
     }
 
     [AzuriteFact]
+    public async Task GetDirectoryContent_PreservesPlusSignInFileName()
+    {
+        // Regression test for #17764: BlobFileStore used to run blob names through
+        // WebUtility.UrlDecode(), which turns a literal "+" into a space, corrupting the
+        // reported entry name for files such as "My+File.jpg".
+        await CreateTestFileAsync("plus-test/My+File.jpg");
+
+        var entries = new List<IFileStoreEntry>();
+        await foreach (var entry in _store.GetDirectoryContentAsync("plus-test"))
+        {
+            entries.Add(entry);
+        }
+
+        Assert.Contains(entries, e => !e.IsDirectory && e.Name == "My+File.jpg");
+        Assert.DoesNotContain(entries, e => !e.IsDirectory && e.Name == "My File.jpg");
+    }
+
+    [AzuriteFact]
+    public async Task GetDirectoryContent_Flat_PreservesPlusSignInFileName()
+    {
+        await CreateTestFileAsync("plus-flat/My+File.jpg");
+
+        var entries = new List<IFileStoreEntry>();
+        await foreach (var entry in _store.GetDirectoryContentAsync("plus-flat", includeSubDirectories: true))
+        {
+            entries.Add(entry);
+        }
+
+        Assert.Contains(entries, e => !e.IsDirectory && e.Name == "My+File.jpg");
+        Assert.DoesNotContain(entries, e => !e.IsDirectory && e.Name == "My File.jpg");
+    }
+
+    [AzuriteFact]
     public async Task CreateDirectory_AlreadyExists_ReturnsFalse()
     {
         await _store.TryCreateDirectoryAsync("existing-dir");


### PR DESCRIPTION
Fixes #17764

### Problem

`BlobFileStore` (Azure) and `AwsFileStore` (S3) both ran the storage provider's file/blob name through `WebUtility.UrlDecode()` before returning it as an `IFileStoreEntry` name. Neither the Azure Blob SDK nor the AWS S3 SDK URL-encodes names in their listing responses, so this decoding step corrupted names containing characters that are coincidentally valid percent-encoding sequences — most visibly `+`, which `UrlDecode` turns into a space:

- Upload `My+File.jpg`
- Listing/preview reports it as `My File.jpg`
- Any subsequent read/link for that reported name 404s, because the actual stored blob/object is still named `My+File.jpg`

### Fix

Removed the unnecessary `WebUtility.UrlDecode()` calls from:
- `BlobFileStore.GetDirectoryContentByHierarchyAsync` and `GetDirectoryContentFlatAsync` (Azure, both flat/Gen1 and flat-fallback-of-HNS listing paths)
- `AwsFileStore.GetDirectoryContentAsync` (S3)

### Related issue

#17985 ("cache busting version parameter won't be appended for files with spaces in their names") looked related but turned out to be a separate, already-fixed issue — merged via #19488 (query params being stripped from media URLs, a different code path in `OrchardCore.Media`'s Razor/Liquid/TagHelper URL builders). No further action needed there; it's included in this PR description for cross-reference only.

### Testing

Added regression tests asserting a file named `My+File.jpg` is listed with its name intact (not decoded to `My File.jpg`):
- Azure: both the flat (Gen1) and hierarchical-namespace (Gen2/HNS) listing code paths, run against an Azurite emulator
- S3: run against a Testcontainers-managed LocalStack instance

Full suite results:
- `test/OrchardCore.Tests.Integration/AzureBlob/*` — 68/68 passing (Gen1 + Gen2)
- `test/OrchardCore.Tests.Integration/AmazonS3/*` — 30/30 passing