### PR TITLE
Add Meta Conversions API support to the Meta Pixel feature

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Activities/MetaConversionsApiEventTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Activities/MetaConversionsApiEventTask.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.Facebook.Models;
+using OrchardCore.Facebook.Services;
+using OrchardCore.Workflows.Abstractions.Models;
+using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
+
+namespace OrchardCore.Facebook.Activities;
+
+/// <summary>
+/// A workflow task that sends a server-side event to the Meta Conversions API, e.g. to report a
+/// completed order or a captured lead directly from the server, independently of (and optionally
+/// deduplicated with) the browser-side Meta Pixel.
+/// </summary>
+public sealed class MetaConversionsApiEventTask : TaskActivity<MetaConversionsApiEventTask>
+{
+    private readonly IMetaConversionsApiService _metaConversionsApiService;
+    private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+
+    internal readonly IStringLocalizer S;
+
+    public MetaConversionsApiEventTask(
+        IMetaConversionsApiService metaConversionsApiService,
+        IWorkflowExpressionEvaluator expressionEvaluator,
+        IStringLocalizer<MetaConversionsApiEventTask> stringLocalizer)
+    {
+        _metaConversionsApiService = metaConversionsApiService;
+        _expressionEvaluator = expressionEvaluator;
+        S = stringLocalizer;
+    }
+
+    public override LocalizedString DisplayText => S["Meta Conversions API Event Task"];
+
+    public override LocalizedString Category => S["Meta"];
+
+    public WorkflowExpression<string> EventName
+    {
+        get => GetProperty(() => new WorkflowExpression<string>());
+        set => SetProperty(value);
+    }
+
+    public WorkflowExpression<string> EventSourceUrl
+    {
+        get => GetProperty(() => new WorkflowExpression<string>());
+        set => SetProperty(value);
+    }
+
+    public MetaActionSource ActionSource
+    {
+        get => GetProperty(() => MetaActionSource.Website);
+        set => SetProperty(value);
+    }
+
+    public WorkflowExpression<string> EventId
+    {
+        get => GetProperty(() => new WorkflowExpression<string>());
+        set => SetProperty(value);
+    }
+
+    public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        => Outcome(S["Done"], S["Failed"]);
+
+    public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+    {
+        var eventName = await _expressionEvaluator.EvaluateAsync(EventName, workflowContext, null);
+        var eventSourceUrl = await _expressionEvaluator.EvaluateAsync(EventSourceUrl, workflowContext, null);
+        var eventId = await _expressionEvaluator.EvaluateAsync(EventId, workflowContext, null);
+
+        var result = await _metaConversionsApiService.SendEventAsync(new MetaConversionEvent
+        {
+            EventName = eventName,
+            EventSourceUrl = string.IsNullOrWhiteSpace(eventSourceUrl) ? null : eventSourceUrl,
+            ActionSource = ActionSource,
+            EventId = string.IsNullOrWhiteSpace(eventId) ? null : eventId,
+        });
+
+        workflowContext.LastResult = result;
+
+        if (result.Succeeded)
+        {
+            return Outcome("Done");
+        }
+
+        return Outcome("Failed");
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookPixelSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookPixelSettingsDisplayDriver.cs
@@ -1,9 +1,13 @@
+using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Facebook.Settings;
+using OrchardCore.Facebook.ViewModels;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Facebook.Drivers;
@@ -11,15 +15,21 @@ namespace OrchardCore.Facebook.Drivers;
 public sealed class FacebookPixelSettingsDisplayDriver : SiteDisplayDriver<FacebookPixelSettings>
 {
     private readonly IAuthorizationService _authorizationService;
+    private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger _logger;
 
     public FacebookPixelSettingsDisplayDriver(
         IAuthorizationService authorizationService,
-        IHttpContextAccessor httpContextAccessor
+        IDataProtectionProvider dataProtectionProvider,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<FacebookPixelSettingsDisplayDriver> logger
         )
     {
         _authorizationService = authorizationService;
+        _dataProtectionProvider = dataProtectionProvider;
         _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
     }
 
     protected override string SettingsGroupId
@@ -33,9 +43,29 @@ public sealed class FacebookPixelSettingsDisplayDriver : SiteDisplayDriver<Faceb
             return null;
         }
 
-        return Initialize<FacebookPixelSettings>("FacebookPixelSettings_Edit", model =>
+        return Initialize<FacebookPixelSettingsViewModel>("FacebookPixelSettings_Edit", model =>
         {
             model.PixelId = settings.PixelId;
+            model.ConversionsApiTestEventCode = settings.ConversionsApiTestEventCode;
+
+            if (!string.IsNullOrWhiteSpace(settings.ConversionsApiAccessToken))
+            {
+                try
+                {
+                    var protector = _dataProtectionProvider.CreateProtector(FacebookConstants.ConversionsApiProtectorName);
+                    model.ConversionsApiAccessToken = protector.Unprotect(settings.ConversionsApiAccessToken);
+                }
+                catch (CryptographicException)
+                {
+                    _logger.LogError("The Meta Conversions API access token could not be decrypted. It may have been encrypted using a different key.");
+                    model.ConversionsApiAccessToken = string.Empty;
+                    model.HasDecryptionError = true;
+                }
+            }
+            else
+            {
+                model.ConversionsApiAccessToken = string.Empty;
+            }
         }).Location("Content:0")
         .OnGroup(SettingsGroupId);
     }
@@ -47,9 +77,18 @@ public sealed class FacebookPixelSettingsDisplayDriver : SiteDisplayDriver<Faceb
             return null;
         }
 
-        await context.Updater.TryUpdateModelAsync(settings, Prefix);
+        var model = new FacebookPixelSettingsViewModel();
 
-        settings.PixelId = settings.PixelId?.Trim();
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        settings.PixelId = model.PixelId?.Trim();
+        settings.ConversionsApiTestEventCode = model.ConversionsApiTestEventCode?.Trim();
+
+        if (context.Updater.ModelState.IsValid)
+        {
+            var protector = _dataProtectionProvider.CreateProtector(FacebookConstants.ConversionsApiProtectorName);
+            settings.ConversionsApiAccessToken = protector.Protect(model.ConversionsApiAccessToken ?? string.Empty);
+        }
 
         return await EditAsync(site, settings, context);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/MetaConversionsApiEventTaskDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/MetaConversionsApiEventTaskDisplayDriver.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Localization;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Facebook.Activities;
+using OrchardCore.Facebook.ViewModels;
+using OrchardCore.Liquid;
+using OrchardCore.Mvc.ModelBinding;
+using OrchardCore.Workflows.Display;
+using OrchardCore.Workflows.Models;
+
+namespace OrchardCore.Facebook.Drivers;
+
+public sealed class MetaConversionsApiEventTaskDisplayDriver : ActivityDisplayDriver<MetaConversionsApiEventTask, MetaConversionsApiEventTaskViewModel>
+{
+    private readonly ILiquidTemplateManager _liquidTemplateManager;
+
+    internal readonly IStringLocalizer S;
+
+    public MetaConversionsApiEventTaskDisplayDriver(ILiquidTemplateManager liquidTemplateManager, IStringLocalizer<MetaConversionsApiEventTaskDisplayDriver> stringLocalizer)
+    {
+        _liquidTemplateManager = liquidTemplateManager;
+        S = stringLocalizer;
+    }
+
+    protected override void EditActivity(MetaConversionsApiEventTask activity, MetaConversionsApiEventTaskViewModel model)
+    {
+        model.EventName = activity.EventName.Expression;
+        model.EventSourceUrl = activity.EventSourceUrl.Expression;
+        model.ActionSource = activity.ActionSource;
+        model.EventId = activity.EventId.Expression;
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(MetaConversionsApiEventTask activity, UpdateEditorContext context)
+    {
+        var viewModel = new MetaConversionsApiEventTaskViewModel();
+
+        await context.Updater.TryUpdateModelAsync(viewModel, Prefix);
+
+        if (string.IsNullOrWhiteSpace(viewModel.EventName))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(viewModel.EventName), S["Event Name requires a value."]);
+        }
+        else if (!_liquidTemplateManager.Validate(viewModel.EventName, out var eventNameErrors))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(viewModel.EventName), string.Join(' ', eventNameErrors));
+        }
+
+        if (!string.IsNullOrWhiteSpace(viewModel.EventSourceUrl) && !_liquidTemplateManager.Validate(viewModel.EventSourceUrl, out var urlErrors))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(viewModel.EventSourceUrl), string.Join(' ', urlErrors));
+        }
+
+        if (!string.IsNullOrWhiteSpace(viewModel.EventId) && !_liquidTemplateManager.Validate(viewModel.EventId, out var eventIdErrors))
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(viewModel.EventId), string.Join(' ', eventIdErrors));
+        }
+
+        activity.EventName = new WorkflowExpression<string>(viewModel.EventName);
+        activity.EventSourceUrl = new WorkflowExpression<string>(viewModel.EventSourceUrl);
+        activity.ActionSource = viewModel.ActionSource;
+        activity.EventId = new WorkflowExpression<string>(viewModel.EventId);
+
+        return await EditAsync(activity, context);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/FacebookConstants.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/FacebookConstants.cs
@@ -9,6 +9,8 @@ public static class FacebookConstants
 
     public const string PixelSettingsGroupId = "facebook-pixel";
 
+    public const string ConversionsApiProtectorName = "OrchardCore.Facebook.ConversionsApi";
+
     public static class Features
     {
         public const string Widgets = "OrchardCore.Facebook.Widgets";

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Models/MetaConversionEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Models/MetaConversionEvent.cs
@@ -1,0 +1,48 @@
+namespace OrchardCore.Facebook.Models;
+
+/// <summary>
+/// The value of Meta's <c>action_source</c> event field, describing where the conversion took place.
+/// See https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/action-source.
+/// </summary>
+public enum MetaActionSource
+{
+    Website,
+    Email,
+    App,
+    PhoneCall,
+    Chat,
+    PhysicalStore,
+    SystemGenerated,
+    Other,
+}
+
+/// <summary>
+/// A single Meta Conversions API event, as sent to the <c>/{pixel_id}/events</c> Graph API endpoint.
+/// See https://developers.facebook.com/docs/marketing-api/conversions-api/using-the-api.
+/// </summary>
+public class MetaConversionEvent
+{
+    /// <summary>
+    /// One of Meta's standard event names (e.g. <c>Purchase</c>, <c>Lead</c>) or a custom event name.
+    /// </summary>
+    public string EventName { get; set; }
+
+    /// <summary>
+    /// When the event occurred. Defaults to <see cref="DateTimeOffset.UtcNow"/> when unset.
+    /// </summary>
+    public DateTimeOffset? EventTime { get; set; }
+
+    /// <summary>
+    /// The browser URL where the event happened. Recommended for <see cref="MetaActionSource.Website"/> events.
+    /// </summary>
+    public string EventSourceUrl { get; set; }
+
+    public MetaActionSource ActionSource { get; set; } = MetaActionSource.Website;
+
+    /// <summary>
+    /// A unique id for this event, used by Meta to deduplicate events also sent by the browser pixel
+    /// for the same conversion. Optional, but recommended when both the pixel and the Conversions API
+    /// report the same event.
+    /// </summary>
+    public string EventId { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/OrchardCore.Facebook.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/OrchardCore.Facebook.csproj
@@ -22,15 +22,18 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Deployment.Abstractions\OrchardCore.Deployment.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement.Liquid\OrchardCore.DisplayManagement.Liquid.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Infrastructure.Abstractions\OrchardCore.Infrastructure.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Liquid.Abstractions\OrchardCore.Liquid.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" />
+      <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
       <PackageReference Include="System.IO.Hashing" />
     </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Services/IMetaConversionsApiService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Services/IMetaConversionsApiService.cs
@@ -1,0 +1,17 @@
+using OrchardCore.Facebook.Models;
+using OrchardCore.Infrastructure;
+
+namespace OrchardCore.Facebook.Services;
+
+/// <summary>
+/// Sends server-side events to the Meta Conversions API for the configured pixel.
+/// See https://developers.facebook.com/docs/marketing-api/conversions-api.
+/// </summary>
+public interface IMetaConversionsApiService
+{
+    /// <summary>
+    /// Sends a single event. Returns a failed <see cref="Result"/> when the Meta Pixel or
+    /// Conversions API settings are missing/invalid, or when the Graph API request fails.
+    /// </summary>
+    Task<Result> SendEventAsync(MetaConversionEvent conversionEvent, CancellationToken cancellationToken = default);
+}

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Services/MetaConversionsApiService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Services/MetaConversionsApiService.cs
@@ -1,0 +1,164 @@
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using OrchardCore.Facebook.Models;
+using OrchardCore.Facebook.Settings;
+using OrchardCore.Infrastructure;
+using OrchardCore.Settings;
+
+namespace OrchardCore.Facebook.Services;
+
+public sealed class MetaConversionsApiService : IMetaConversionsApiService
+{
+    // https://developers.facebook.com/docs/graph-api/changelog - bump periodically.
+    private const string GraphApiVersion = "v21.0";
+
+    private static readonly JsonSerializerOptions s_serializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly ISiteService _siteService;
+    private readonly IDataProtectionProvider _dataProtectionProvider;
+    private readonly ILogger _logger;
+    private readonly IStringLocalizer S;
+
+    public MetaConversionsApiService(
+        HttpClient httpClient,
+        ISiteService siteService,
+        IDataProtectionProvider dataProtectionProvider,
+        ILogger<MetaConversionsApiService> logger,
+        IStringLocalizer<MetaConversionsApiService> stringLocalizer)
+    {
+        _httpClient = httpClient;
+        _siteService = siteService;
+        _dataProtectionProvider = dataProtectionProvider;
+        _logger = logger;
+        S = stringLocalizer;
+    }
+
+    public async Task<Result> SendEventAsync(MetaConversionEvent conversionEvent, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(conversionEvent);
+
+        if (string.IsNullOrWhiteSpace(conversionEvent.EventName))
+        {
+            return Result.Failed(S["The event name is required."]);
+        }
+
+        var settings = await _siteService.GetSettingsAsync<FacebookPixelSettings>();
+
+        if (string.IsNullOrWhiteSpace(settings.PixelId))
+        {
+            return Result.Failed(S["The Meta Pixel is not configured. Set the Pixel ID under Settings > Meta Pixel."]);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.ConversionsApiAccessToken))
+        {
+            return Result.Failed(S["The Meta Conversions API access token is not configured. Set it under Settings > Meta Pixel."]);
+        }
+
+        string accessToken;
+        try
+        {
+            var protector = _dataProtectionProvider.CreateProtector(FacebookConstants.ConversionsApiProtectorName);
+            accessToken = protector.Unprotect(settings.ConversionsApiAccessToken);
+        }
+        catch (CryptographicException ex)
+        {
+            _logger.LogError(ex, "The Meta Conversions API access token could not be decrypted. It may have been encrypted using a different key.");
+
+            return Result.Failed(S["The Meta Conversions API access token could not be decrypted. Re-enter it under Settings > Meta Pixel."]);
+        }
+
+        var payload = new MetaConversionsApiRequest
+        {
+            Data =
+            [
+                new MetaConversionsApiEvent
+                {
+                    EventName = conversionEvent.EventName,
+                    EventTime = (conversionEvent.EventTime ?? DateTimeOffset.UtcNow).ToUnixTimeSeconds(),
+                    EventSourceUrl = conversionEvent.EventSourceUrl,
+                    ActionSource = ToActionSourceValue(conversionEvent.ActionSource),
+                    EventId = conversionEvent.EventId,
+                },
+            ],
+            TestEventCode = string.IsNullOrWhiteSpace(settings.ConversionsApiTestEventCode)
+                ? null
+                : settings.ConversionsApiTestEventCode,
+        };
+
+        var requestUri = $"{GraphApiVersion}/{settings.PixelId}/events?access_token={Uri.EscapeDataString(accessToken)}";
+
+        try
+        {
+            using var response = await _httpClient.PostAsJsonAsync(requestUri, payload, s_serializerOptions, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return Result.Success();
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            _logger.LogError(
+                "The Meta Conversions API request failed with status {StatusCode}: {Body}",
+                (int)response.StatusCode,
+                body);
+
+            return Result.Failed(S["The Meta Conversions API request failed with status {0}.", (int)response.StatusCode]);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "An error occurred connecting to the Meta Conversions API.");
+
+            return Result.Failed(S["An error occurred connecting to the Meta Conversions API."]);
+        }
+    }
+
+    private static string ToActionSourceValue(MetaActionSource actionSource)
+        => actionSource switch
+        {
+            MetaActionSource.Website => "website",
+            MetaActionSource.Email => "email",
+            MetaActionSource.App => "app",
+            MetaActionSource.PhoneCall => "phone_call",
+            MetaActionSource.Chat => "chat",
+            MetaActionSource.PhysicalStore => "physical_store",
+            MetaActionSource.SystemGenerated => "system_generated",
+            _ => "other",
+        };
+
+    private sealed class MetaConversionsApiRequest
+    {
+        [JsonPropertyName("data")]
+        public MetaConversionsApiEvent[] Data { get; set; }
+
+        [JsonPropertyName("test_event_code")]
+        public string TestEventCode { get; set; }
+    }
+
+    private sealed class MetaConversionsApiEvent
+    {
+        [JsonPropertyName("event_name")]
+        public string EventName { get; set; }
+
+        [JsonPropertyName("event_time")]
+        public long EventTime { get; set; }
+
+        [JsonPropertyName("event_source_url")]
+        public string EventSourceUrl { get; set; }
+
+        [JsonPropertyName("action_source")]
+        public string ActionSource { get; set; }
+
+        [JsonPropertyName("event_id")]
+        public string EventId { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Settings/FacebookPixelSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Settings/FacebookPixelSettings.cs
@@ -3,4 +3,16 @@ namespace OrchardCore.Facebook.Settings;
 public class FacebookPixelSettings
 {
     public string PixelId { get; set; }
+
+    /// <summary>
+    /// The Meta Conversions API access token, generated from the Events Manager for the pixel's
+    /// dataset. Stored encrypted via <see cref="Microsoft.AspNetCore.DataProtection.IDataProtectionProvider"/>.
+    /// </summary>
+    public string ConversionsApiAccessToken { get; set; }
+
+    /// <summary>
+    /// Optional test event code from the Events Manager "Test Events" tab, sent with every
+    /// Conversions API request so events show up in the test console instead of production data.
+    /// </summary>
+    public string ConversionsApiTestEventCode { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/StartupPixel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/StartupPixel.cs
@@ -47,7 +47,8 @@ public sealed class StartupPixel : StartupBase
     }
 }
 
-[RequireFeatures(FacebookConstants.Features.Pixel, "OrchardCore.Workflows")]
+[Feature(FacebookConstants.Features.Pixel)]
+[RequireFeatures("OrchardCore.Workflows")]
 public sealed class StartupPixelWorkflows : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/StartupPixel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/StartupPixel.cs
@@ -1,11 +1,16 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.Facebook.Activities;
 using OrchardCore.Facebook.Drivers;
 using OrchardCore.Facebook.Filters;
+using OrchardCore.Facebook.Services;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
+using OrchardCore.Workflows.Helpers;
+using Polly;
 
 namespace OrchardCore.Facebook;
 
@@ -22,5 +27,30 @@ public sealed class StartupPixel : StartupBase
         {
             options.Filters.Add<FacebookPixelFilter>();
         });
+
+        services.AddHttpClient<IMetaConversionsApiService, MetaConversionsApiService>(client =>
+        {
+            client.BaseAddress = new Uri("https://graph.facebook.com/");
+        }).AddResilienceHandler("oc-handler", builder => builder
+            .AddRetry(new HttpRetryStrategyOptions
+            {
+                Name = "oc-retry",
+                MaxRetryAttempts = 3,
+                OnRetry = attempt =>
+                {
+                    attempt.RetryDelay.Add(TimeSpan.FromSeconds(0.5 * attempt.AttemptNumber));
+
+                    return ValueTask.CompletedTask;
+                },
+            })
+        );
     }
 }
+
+[RequireFeatures(FacebookConstants.Features.Pixel, "OrchardCore.Workflows")]
+public sealed class StartupPixelWorkflows : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+        => services.AddActivity<MetaConversionsApiEventTask, MetaConversionsApiEventTaskDisplayDriver>();
+}
+

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/FacebookPixelSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/FacebookPixelSettingsViewModel.cs
@@ -1,0 +1,12 @@
+namespace OrchardCore.Facebook.ViewModels;
+
+public class FacebookPixelSettingsViewModel
+{
+    public string PixelId { get; set; }
+
+    public string ConversionsApiAccessToken { get; set; }
+
+    public string ConversionsApiTestEventCode { get; set; }
+
+    public bool HasDecryptionError { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/MetaConversionsApiEventTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/MetaConversionsApiEventTaskViewModel.cs
@@ -1,0 +1,14 @@
+using OrchardCore.Facebook.Models;
+
+namespace OrchardCore.Facebook.ViewModels;
+
+public class MetaConversionsApiEventTaskViewModel
+{
+    public string EventName { get; set; }
+
+    public string EventSourceUrl { get; set; }
+
+    public MetaActionSource ActionSource { get; set; }
+
+    public string EventId { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPixelSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookPixelSettings.Edit.cshtml
@@ -1,6 +1,15 @@
-@using OrchardCore.Facebook.Settings
+@using OrchardCore.Facebook.ViewModels
 
-@model FacebookPixelSettings
+@model FacebookPixelSettingsViewModel
+
+@if (Model.HasDecryptionError)
+{
+    <div class="ocat-wrapper">
+        <div class="ocat-end-offset">
+            <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
+        </div>
+    </div>
+}
 
 <div class="ocat-wrapper" asp-validation-class-for="PixelId">
     <label asp-for="PixelId" class="ocat-label">@T["Pixel Identifier"]</label>
@@ -8,5 +17,30 @@
         <input asp-for="PixelId" class="form-control" autocomplete="off" />
         <span asp-validation-for="PixelId"></span>
         <span class="hint">@T["The Pixel ID found on the Meta Data Sources portal."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <div class="ocat-end-offset">
+        <h3>@T["Conversions API"]</h3>
+        <p class="hint">@T["Optional server-side event delivery to Meta, in addition to the browser-side pixel. Configure this to let workflows send events (e.g. Purchase, Lead) directly from the server."]</p>
+    </div>
+</div>
+
+<div class="ocat-wrapper" asp-validation-class-for="ConversionsApiAccessToken">
+    <label asp-for="ConversionsApiAccessToken" class="ocat-label">@T["Conversions API Access Token"]</label>
+    <div class="ocat-end">
+        <input asp-for="ConversionsApiAccessToken" class="form-control" type="password" value="@Model.ConversionsApiAccessToken" autocomplete="off" />
+        <span asp-validation-for="ConversionsApiAccessToken"></span>
+        <span class="hint">@T["The access token generated for this dataset in the Events Manager's Conversions API settings."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper" asp-validation-class-for="ConversionsApiTestEventCode">
+    <label asp-for="ConversionsApiTestEventCode" class="ocat-label">@T["Test Event Code"]</label>
+    <div class="ocat-end">
+        <input asp-for="ConversionsApiTestEventCode" class="form-control" autocomplete="off" />
+        <span asp-validation-for="ConversionsApiTestEventCode"></span>
+        <span class="hint">@T["Optional. Found on the Events Manager's Test Events tab. When set, every Conversions API event includes it, so events show up in the test console instead of counting as production data. Remove it before going live."]</span>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/Items/MetaConversionsApiEventTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/Items/MetaConversionsApiEventTask.Fields.Design.cshtml
@@ -1,0 +1,12 @@
+@using OrchardCore.Workflows.ViewModels
+@using OrchardCore.Facebook.Activities
+@using OrchardCore.Workflows.Helpers
+
+@model ActivityViewModel<MetaConversionsApiEventTask>
+
+<header>
+    <h4>
+        <i class="fa-brands fa-meta" aria-hidden="true"></i>@Model.Activity.GetTitleOrDefault(() => T["Meta Conversions API Event"])
+    </h4>
+</header>
+<em>@Model.Activity.EventName</em>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/Items/MetaConversionsApiEventTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/Items/MetaConversionsApiEventTask.Fields.Edit.cshtml
@@ -1,0 +1,50 @@
+@using OrchardCore.Facebook.ViewModels
+@using OrchardCore.Facebook.Models
+
+@model MetaConversionsApiEventTaskViewModel
+
+<div class="ocat-wrapper" asp-validation-class-for="EventName">
+    <label asp-for="EventName" class="ocat-label">@T["Event Name"]</label>
+    <div class="ocat-end">
+        <input type="text" asp-for="EventName" class="form-control" list="metaStandardEventNames" />
+        <datalist id="metaStandardEventNames">
+            <option value="Purchase"></option>
+            <option value="Lead"></option>
+            <option value="CompleteRegistration"></option>
+            <option value="AddToCart"></option>
+            <option value="InitiateCheckout"></option>
+            <option value="AddPaymentInfo"></option>
+            <option value="Contact"></option>
+            <option value="Subscribe"></option>
+            <option value="StartTrial"></option>
+        </datalist>
+        <span asp-validation-for="EventName"></span>
+        <span class="hint">@T["A Meta standard event name (e.g. Purchase, Lead) or a custom event name. With Liquid support."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <label asp-for="ActionSource" class="ocat-label">@T["Action Source"]</label>
+    <div class="ocat-end">
+        <select asp-for="ActionSource" class="form-select" asp-items="Html.GetEnumSelectList<MetaActionSource>()"></select>
+        <span class="hint">@T["Where the conversion took place. Most server-side events triggered from a website workflow should use Website."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper" asp-validation-class-for="EventSourceUrl">
+    <label asp-for="EventSourceUrl" class="ocat-label">@T["Event Source URL"]</label>
+    <div class="ocat-end">
+        <input type="text" asp-for="EventSourceUrl" class="form-control" />
+        <span asp-validation-for="EventSourceUrl"></span>
+        <span class="hint">@T["Optional. The browser URL where the event happened. With Liquid support."]</span>
+    </div>
+</div>
+
+<div class="ocat-wrapper" asp-validation-class-for="EventId">
+    <label asp-for="EventId" class="ocat-label">@T["Event ID"]</label>
+    <div class="ocat-end">
+        <input type="text" asp-for="EventId" class="form-control" />
+        <span asp-validation-for="EventId"></span>
+        <span class="hint">@T["Optional. A unique id for this event, used to deduplicate it against the same event reported by the browser Meta Pixel. With Liquid support."]</span>
+    </div>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/Items/MetaConversionsApiEventTask.Fields.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/Items/MetaConversionsApiEventTask.Fields.Thumbnail.cshtml
@@ -1,0 +1,4 @@
+<h4 class="card-title">
+    <i class="fa-brands fa-meta" aria-hidden="true"></i>@T["Meta Conversions API Event"]
+</h4>
+<p>@T["Send a server-side conversion event to Meta (e.g. Purchase, Lead)."]</p>

--- a/src/docs/reference/modules/Facebook/README.md
+++ b/src/docs/reference/modules/Facebook/README.md
@@ -65,6 +65,28 @@ It defines the following widgets:
 
 This feature provides you a way to add Meta Pixel tracking to your site. Simply navigate to _Settings -> Integrations -> Meta Pixel_ settings and provide your `Pixel Identifier`.
 
+### Meta Conversions API
+
+The Meta Pixel feature also lets you configure the [Meta Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api), which sends events to Meta directly from the server instead of (or in addition to) the browser-side pixel. This is useful for events that should not depend on client-side JavaScript, such as events triggered from a background process or ones affected by ad blockers/browser tracking prevention.
+
+From the _Settings -> Integrations -> Meta Pixel_ settings page, in addition to the `Pixel Identifier`, you can configure:
+
+- **Conversions API Access Token**: The access token generated from the [Events Manager](https://business.facebook.com/events_manager2) for the pixel's dataset. This value is stored encrypted.
+- **Test Event Code**: Optional. The test event code from the Events Manager's "Test Events" tab. When set, events are sent tagged for testing and show up in the test console instead of counting as production data. Remove it before going live.
+
+#### Meta Conversions API Event workflow task
+
+When the `OrchardCore.Workflows` feature is also enabled, a **Meta Conversions API Event** task becomes available in the workflow editor, under the **Meta** category. Add it to any workflow to send a server-side event (e.g. `Purchase`, `Lead`) to Meta when that workflow runs.
+
+The task accepts:
+
+- **Event Name**: The [standard or custom event name](https://developers.facebook.com/docs/meta-pixel/reference) to send (e.g. `Purchase`, `Lead`). Supports workflow expressions.
+- **Event Source URL**: Optional. The URL of the page or resource associated with the event. Supports workflow expressions.
+- **Action Source**: Where the event happened, e.g. `Website`, `App`, `Email`, etc., as required by the Conversions API.
+- **Event ID**: Optional. A unique identifier for the event, used to [deduplicate](https://developers.facebook.com/docs/meta-pixel/implementation/conversions-api-deduplicate) events also sent by the browser-side Meta Pixel for the same action. Supports workflow expressions.
+
+The task produces two outcomes, `Done` and `Failed`, depending on whether the API call succeeded.
+
 ## Recipe Configuration
 
 Facebook settings can be configured using the `Settings` recipe step:
@@ -85,6 +107,11 @@ Facebook settings can be configured using the `Settings` recipe step:
       "FacebookLoginSettings": {
         "CallbackPath": "/signin-facebook",
         "SaveTokens": false
+      },
+      "FacebookPixelSettings": {
+        "PixelId": "your-pixel-id",
+        "ConversionsApiAccessToken": "your-conversions-api-access-token",
+        "ConversionsApiTestEventCode": "TEST12345"
       }
     }
   ]
@@ -108,6 +135,14 @@ Facebook settings can be configured using the `Settings` recipe step:
 |----------------|---------|------------------------------------------------------------------------------|
 | `CallbackPath` | String  | The request path where the user-agent will be returned after authentication. |
 | `SaveTokens`   | Boolean | Whether to save the access and refresh tokens.                               |
+
+### Pixel Settings
+
+| Property                      | Type   | Description                                                                                          |
+|-------------------------------|--------|--------------------------------------------------------------------------------------------------------|
+| `PixelId`                     | String | The Meta Pixel identifier.                                                                             |
+| `ConversionsApiAccessToken`   | String | The Meta Conversions API access token, generated from the Events Manager. Stored encrypted.            |
+| `ConversionsApiTestEventCode` | String | Optional test event code from the Events Manager "Test Events" tab. Remove it before going live.       |
 
 ## Meta Settings Configuration
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Facebook/MetaConversionsApiServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Facebook/MetaConversionsApiServiceTests.cs
@@ -27,7 +27,7 @@ public class MetaConversionsApiServiceTests
             ConversionsApiAccessToken = Protect("token"),
         });
 
-        var result = await service.SendEventAsync(new MetaConversionEvent());
+        var result = await service.SendEventAsync(new MetaConversionEvent(), TestContext.Current.CancellationToken);
 
         Assert.False(result.Succeeded);
     }
@@ -40,7 +40,7 @@ public class MetaConversionsApiServiceTests
             ConversionsApiAccessToken = Protect("token"),
         });
 
-        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" }, TestContext.Current.CancellationToken);
 
         Assert.False(result.Succeeded);
     }
@@ -53,7 +53,7 @@ public class MetaConversionsApiServiceTests
             PixelId = "123",
         });
 
-        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" }, TestContext.Current.CancellationToken);
 
         Assert.False(result.Succeeded);
     }
@@ -76,7 +76,7 @@ public class MetaConversionsApiServiceTests
             EventSourceUrl = "https://example.com/checkout",
             ActionSource = MetaActionSource.Website,
             EventId = "order-42",
-        });
+        }, TestContext.Current.CancellationToken);
 
         Assert.True(result.Succeeded);
         Assert.NotNull(handler.LastRequest);
@@ -109,7 +109,7 @@ public class MetaConversionsApiServiceTests
             ConversionsApiAccessToken = Protect("token"),
         });
 
-        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" }, TestContext.Current.CancellationToken);
 
         Assert.True(result.Succeeded);
 
@@ -129,7 +129,7 @@ public class MetaConversionsApiServiceTests
             ConversionsApiAccessToken = Protect("token"),
         });
 
-        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" }, TestContext.Current.CancellationToken);
 
         Assert.False(result.Succeeded);
     }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Facebook/MetaConversionsApiServiceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Facebook/MetaConversionsApiServiceTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OrchardCore.Entities;
+using OrchardCore.Facebook;
+using OrchardCore.Facebook.Models;
+using OrchardCore.Facebook.Services;
+using OrchardCore.Facebook.Settings;
+using OrchardCore.Settings;
+using Xunit;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Facebook;
+
+public class MetaConversionsApiServiceTests
+{
+    private static readonly EphemeralDataProtectionProvider s_dataProtectionProvider = new();
+
+    [Fact]
+    public async Task SendEventAsyncFailsWhenEventNameIsMissing()
+    {
+        var service = CreateService(new FakeHttpMessageHandler(HttpStatusCode.OK, "{}"), new FacebookPixelSettings
+        {
+            PixelId = "123",
+            ConversionsApiAccessToken = Protect("token"),
+        });
+
+        var result = await service.SendEventAsync(new MetaConversionEvent());
+
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task SendEventAsyncFailsWhenPixelIdIsMissing()
+    {
+        var service = CreateService(new FakeHttpMessageHandler(HttpStatusCode.OK, "{}"), new FacebookPixelSettings
+        {
+            ConversionsApiAccessToken = Protect("token"),
+        });
+
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task SendEventAsyncFailsWhenAccessTokenIsMissing()
+    {
+        var service = CreateService(new FakeHttpMessageHandler(HttpStatusCode.OK, "{}"), new FacebookPixelSettings
+        {
+            PixelId = "123",
+        });
+
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task SendEventAsyncSendsExpectedPayloadAndSucceedsOnOk()
+    {
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, "{\"events_received\":1}");
+
+        var service = CreateService(handler, new FacebookPixelSettings
+        {
+            PixelId = "123456",
+            ConversionsApiAccessToken = Protect("my-access-token"),
+            ConversionsApiTestEventCode = "TEST12345",
+        });
+
+        var result = await service.SendEventAsync(new MetaConversionEvent
+        {
+            EventName = "Purchase",
+            EventSourceUrl = "https://example.com/checkout",
+            ActionSource = MetaActionSource.Website,
+            EventId = "order-42",
+        });
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(handler.LastRequest);
+
+        Assert.Equal(HttpMethod.Post, handler.LastRequest.Method);
+        Assert.StartsWith("v21.0/123456/events", handler.LastRequest.RequestUri.PathAndQuery.TrimStart('/'), StringComparison.Ordinal);
+        Assert.Contains("access_token=my-access-token", handler.LastRequest.RequestUri.Query, StringComparison.Ordinal);
+
+        using var document = JsonDocument.Parse(handler.LastRequestBody);
+        var root = document.RootElement;
+
+        Assert.Equal("TEST12345", root.GetProperty("test_event_code").GetString());
+
+        var evt = root.GetProperty("data")[0];
+        Assert.Equal("Purchase", evt.GetProperty("event_name").GetString());
+        Assert.Equal("https://example.com/checkout", evt.GetProperty("event_source_url").GetString());
+        Assert.Equal("website", evt.GetProperty("action_source").GetString());
+        Assert.Equal("order-42", evt.GetProperty("event_id").GetString());
+        Assert.True(evt.GetProperty("event_time").GetInt64() > 0);
+    }
+
+    [Fact]
+    public async Task SendEventAsyncOmitsTestEventCodeWhenNotConfigured()
+    {
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, "{}");
+
+        var service = CreateService(handler, new FacebookPixelSettings
+        {
+            PixelId = "123456",
+            ConversionsApiAccessToken = Protect("token"),
+        });
+
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+
+        Assert.True(result.Succeeded);
+
+        using var document = JsonDocument.Parse(handler.LastRequestBody);
+
+        Assert.False(document.RootElement.TryGetProperty("test_event_code", out _));
+    }
+
+    [Fact]
+    public async Task SendEventAsyncFailsWhenGraphApiReturnsAnError()
+    {
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.BadRequest, "{\"error\":{\"message\":\"Invalid parameter\"}}");
+
+        var service = CreateService(handler, new FacebookPixelSettings
+        {
+            PixelId = "123456",
+            ConversionsApiAccessToken = Protect("token"),
+        });
+
+        var result = await service.SendEventAsync(new MetaConversionEvent { EventName = "Lead" });
+
+        Assert.False(result.Succeeded);
+    }
+
+    private static string Protect(string value)
+        => s_dataProtectionProvider.CreateProtector(FacebookConstants.ConversionsApiProtectorName).Protect(value);
+
+    private static MetaConversionsApiService CreateService(HttpMessageHandler handler, FacebookPixelSettings settings)
+    {
+        var siteService = new Mock<ISiteService>();
+        var site = new SiteSettings();
+        site.Put(settings);
+
+        siteService.Setup(x => x.GetSiteSettingsAsync()).ReturnsAsync(site);
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://graph.facebook.com/"),
+        };
+
+        return new MetaConversionsApiService(
+            httpClient,
+            siteService.Object,
+            s_dataProtectionProvider,
+            NullLogger<MetaConversionsApiService>.Instance,
+            new Mock<IStringLocalizer<MetaConversionsApiService>>().Object.OrFallback());
+    }
+}
+
+file static class StringLocalizerExtensions
+{
+    // Moq doesn't implement the indexer by default; provide a trivial pass-through localizer.
+    public static IStringLocalizer<T> OrFallback<T>(this IStringLocalizer<T> _)
+        => new FallbackStringLocalizer<T>();
+}
+
+file sealed class FallbackStringLocalizer<T> : IStringLocalizer<T>
+{
+    public LocalizedString this[string name] => new(name, name);
+
+    public LocalizedString this[string name, params object[] arguments] => new(name, string.Format(name, arguments));
+
+    public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+}
+
+internal sealed class FakeHttpMessageHandler(HttpStatusCode statusCode, string responseBody) : HttpMessageHandler
+{
+    public HttpRequestMessage LastRequest { get; private set; }
+
+    public string LastRequestBody { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        LastRequestBody = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(responseBody),
+        };
+    }
+}


### PR DESCRIPTION
### Summary

Extends the existing Meta Pixel feature (`OrchardCore.Facebook.Pixel`) with server-side event delivery via the [Meta Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api), in addition to the existing browser-side pixel script.

### What changed

- **`FacebookPixelSettings`** gains `ConversionsApiAccessToken` (encrypted at rest via `IDataProtectionProvider`, following the same pattern as the Twitter module's `ConsumerSecret`) and an optional `ConversionsApiTestEventCode`. Both are editable on the existing Meta Pixel settings screen (Settings > Integrations > Meta Pixel), alongside the Pixel ID.
- **`IMetaConversionsApiService` / `MetaConversionsApiService`**: sends a single event (`event_name`, `event_time`, `event_source_url`, `action_source`, `event_id`) to the Graph API's `/{pixel_id}/events` endpoint, registered with the project's standard `HttpClient` resilience handler (retry). Returns a `Result` so callers branch on success/failure without exceptions.
- **`MetaConversionsApiEventTask`**: a workflow `Task` activity, only registered when both the Meta Pixel and Workflows features are enabled (`[RequireFeatures(FacebookConstants.Features.Pixel, "OrchardCore.Workflows")]`). Lets authors fire standard (Purchase, Lead, CompleteRegistration, AddToCart, …) or custom events from any workflow, with Liquid-evaluated Event Name / Event Source URL / Event ID fields and an Action Source dropdown.

### Explicitly out of scope for this change

Per discussion, this PR intentionally does **not** include:
- User data hashing (email/phone → SHA-256, client IP/user agent) for Advanced Matching
- `custom_data` fields (value, currency, arbitrary key/value)

Both extend naturally on top of `MetaConversionEvent` and the service in a follow-up.

### Testing

`MetaConversionsApiServiceTests` (6 tests) covers:
- Failure when the pixel/access token/event name is missing
- The exact JSON payload sent to the Graph API (event fields, `action_source` value mapping, optional `test_event_code`)
- Graph API error responses surfaced as a failed `Result`

Uses a fake `HttpMessageHandler` (same pattern as `TwitterClientTests`) and a real `EphemeralDataProtectionProvider` protect/unprotect round-trip.

`dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj --filter-class "OrchardCore.Tests.Modules.OrchardCore.Facebook.MetaConversionsApiServiceTests"` — 6/6 passing.

Full solution build (`OrchardCore.Cms.Web`, including Razor view discovery for the new workflow activity views) — clean, 0 warnings, 0 errors.