### PR TITLE
Add start/end terminal sentinels to FlatPositionComparer

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -57,11 +57,11 @@ public sealed class AdminMenu : AdminNavigationProvider
         }
 
         builder
-            .Add(S["Tools"], "after.50", tools => tools
+            .Add(S["Tools"], "end.50", tools => tools
                 .Id("tools")
                 .AddClass("tools")
             , priority: 1)
-            .Add(S["Settings"], "after.100", settings => settings
+            .Add(S["Settings"], "end.100", settings => settings
                 .Id("settings")
                 .AddClass("settings")
                 .Add(S["General"], "before", general => general

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/FlatPositionComparer.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/FlatPositionComparer.cs
@@ -1,5 +1,19 @@
 namespace OrchardCore.DisplayManagement.Zones;
 
+/// <summary>
+/// Compares dot/colon separated position strings.
+/// <para>
+/// The total order, from first to last, is:
+/// <c>start</c> &lt; <c>before</c> &lt; numbers &lt; <c>after</c> &lt; free-text &lt; <c>end</c>.
+/// </para>
+/// <para>
+/// <c>before</c> and <c>after</c> are anchors within the numeric range (they normalize to very low
+/// and very high numbers), so a free-text position such as one produced by <c>PrefixPosition()</c>
+/// still sorts after <c>after</c>. Use the terminal sentinels <c>start</c> and <c>end</c> when an
+/// item must sort truly first or truly last regardless of any other position, including free text.
+/// Both sentinels support sub-ordering, e.g. <c>end.50</c> sorts before <c>end.100</c>.
+/// </para>
+/// </summary>
 public sealed class FlatPositionComparer : IComparer<IPositioned>, IComparer<string>
 {
     private static readonly char[] s_splitChars = ['.', ':'];
@@ -74,6 +88,24 @@ public sealed class FlatPositionComparer : IComparer<IPositioned>, IComparer<str
             var yPart = yParts.Current;
 #endif
 
+            // Terminal sentinels: `start` always sorts before everything else and `end` always
+            // sorts after everything else, regardless of numbers, `before`/`after`, or free text.
+            var xTier = GetSentinelTier(xPart);
+            var yTier = GetSentinelTier(yPart);
+
+            if (xTier != yTier)
+            {
+                return xTier < yTier ? -1 : 1;
+            }
+
+            if (xTier != 0)
+            {
+                // Both partitions are the same terminal sentinel (e.g. `end` vs `end.100`); the
+                // ordering is decided by the remaining partitions.
+                partIndex++;
+                continue;
+            }
+
             // Normalize known partitions
             var xIsInt = TryNormalizeKnownPartitions(xPart, out var xPos);
             var yIsInt = TryNormalizeKnownPartitions(yPart, out var yPos);
@@ -135,6 +167,23 @@ public sealed class FlatPositionComparer : IComparer<IPositioned>, IComparer<str
         span = span.TrimEnd('.');
 
         return span;
+    }
+
+    private static int GetSentinelTier(ReadOnlySpan<char> partition)
+    {
+        // `start` sorts before every non-sentinel position, `end` sorts after every non-sentinel
+        // position (including free text). Everything else lives in the middle tier.
+        if (partition.Equals("start", StringComparison.OrdinalIgnoreCase))
+        {
+            return -1;
+        }
+
+        if (partition.Equals("end", StringComparison.OrdinalIgnoreCase))
+        {
+            return 1;
+        }
+
+        return 0;
     }
 
     private static bool TryNormalizeKnownPartitions(ReadOnlySpan<char> partition, out int position)

--- a/src/docs/guides/add-admin-menu/README.md
+++ b/src/docs/guides/add-admin-menu/README.md
@@ -148,6 +148,25 @@ public sealed class AdminMenu : INavigationProvider
 !!! note
     We suggest to use the `PrefixPosition` extension method for the second parameter (`position`) if you want to keep an alphabetical sort when the strings will be translated in other languages.
 
+### Positioning menu items
+
+The second parameter of `Add(...)` is the **position**, the same position mechanism used everywhere in Orchard Core (for example, [shape placement](../../reference/modules/Placement/README.md#position-ordering-rules)). Menu items — at every level of the tree — are sorted by it. The full ordering, from first to last, is:
+
+```
+start  <  before  <  numbers  <  after  <  free-text (PrefixPosition)  <  end
+```
+
+- **Numeric positions** (`"1"`, `"2.5"`, `"10"`) are compared numerically and give you precise, explicit placement. Use them for top-level items and for pinning a specific item to a known slot.
+- **`before` / `after`** are anchors *within* the numeric range: `before` sorts ahead of all numbers, `after` sorts after all numbers. They both support sub-ordering, e.g. `"after.50"` then `"after.100"`.
+- **`PrefixPosition()`** produces a **non-numeric** value that alphabetizes an item against its siblings (surviving translation). Because it is not a number, it sorts **after `after`**. This is exactly what you want for leaf items in a shared submenu (they line up alphabetically after any pinned, numbered items), which is why the guide uses it above.
+- **`start` / `end`** are true terminals: `start` sorts before *everything* (including `before`), and `end` sorts after *everything* (including `PrefixPosition()` values). They also support sub-ordering (`"end.50"` before `"end.100"`).
+
+!!! warning "`after` is not the last position; `end` is"
+    Because `PrefixPosition()` values sort after `after`, an item positioned with `"after"` (or `"after.100"`) is **not** guaranteed to be last — any sibling using `PrefixPosition()` will come after it. If you need an item to be genuinely first or last regardless of its siblings, use `start` / `end` instead of `before` / `after`. For this reason the built-in **Settings** and **Tools** top-level menus use `"end.100"` and `"end.50"`, so custom top-level items added with `PrefixPosition()` appear *before* them.
+
+!!! tip
+    For a **top-level** menu item you almost always want a deterministic slot, so prefer a numeric or `end`/`start` position over `PrefixPosition()`. Reserve `PrefixPosition()` for the leaf items inside a submenu, where alphabetical ordering is the goal.
+
 Then you have to register this service in the `Startup.cs` file of the module.
 
 At the top of the `Startup.cs` file, add this `using` statement:

--- a/src/docs/reference/modules/Placement/README.md
+++ b/src/docs/reference/modules/Placement/README.md
@@ -178,8 +178,10 @@ Examples:
 | `Content`        | Content | *(empty, treated as 0)* | Places in Content zone at default position               |
 | `Content:5`      | Content | 5                       | Places in Content zone at position 5                     |
 | `Content:5.1`    | Content | 5.1                     | Places in Content zone at position 5.1 (between 5 and 6) |
-| `Content:before` | Content | before                  | Places at the very beginning of the zone                 |
-| `Content:after`  | Content | after                   | Places at the very end of the zone                       |
+| `Content:before` | Content | before                  | Places before all numbered positions                     |
+| `Content:after`  | Content | after                   | Places after all numbered positions                      |
+| `Content:start`  | Content | start                   | Places truly first, before everything (including `before`) |
+| `Content:end`    | Content | end                     | Places truly last, after everything (including free text) |
 
 ##### Position ordering rules
 
@@ -189,10 +191,27 @@ Shapes within a zone are sorted by their position using these rules:
 - **Dot notation** is supported for sub-positioning: `1.1` comes after `1` but before `2`. Positions like `1.5` can be used to insert shapes between `1` and `2`.
 - The special keyword **`before`** places a shape before all numbered positions (internally mapped to `-9999`).
 - The special keyword **`after`** places a shape after all numbered positions (internally mapped to `9999`).
+- The special keyword **`start`** places a shape truly first — before *every* other position, including `before`.
+- The special keyword **`end`** places a shape truly last — after *every* other position, including non-numeric (free-text) positions.
 - A shape with **no position** (empty string) is treated as position `0`.
 - When multiple shapes share the **same position**, they maintain their registration order (stable sort).
 
-The full ordering is: `before`, `0` (empty), `1`, `1.1`, `1.2`, `2`, `10`, then `after`.
+The full ordering is:
+
+```
+start  <  before  <  0 (empty)  <  1  <  1.1  <  2  <  10  <  after  <  free-text  <  end
+```
+
+###### `after` vs `end`, and `before` vs `start`
+
+`before` and `after` are anchors **within the numeric range** — they behave like a very small and a very large number. Any **non-numeric** position (for example a value produced by the admin-menu `PrefixPosition()` helper, which alphabetizes sibling items) is *not* a number, so it sorts **after `after`**. Likewise, nothing sorts before `before` in the numeric range, but `before` is still just the low end of that range.
+
+Use the **terminal sentinels** when an item must sort truly first or truly last regardless of *any* other position, including free text:
+
+- **`end`** always sorts after everything, including free-text positions — use it when `after` is "not last enough."
+- **`start`** always sorts before everything, including `before` — use it when `before` is "not first enough."
+
+Like `before`/`after`, the sentinels support sub-ordering: `end.50` sorts before `end.100`, and a bare `end` sorts before both (the same way bare `after` sorts before `after.50`).
 
 !!! note
     Position ordering within a zone is determined solely by the position value. The module or project name does not affect the order of shapes within a zone.

--- a/src/docs/topics/display/shapes.md
+++ b/src/docs/topics/display/shapes.md
@@ -382,8 +382,22 @@ await garage.AddAsync(firstCar, "1");
 
 The `Items` collection is sorted lazily when it is read. Positions use numeric,
 hierarchical ordering rather than string ordering: `1`, `1.1`, `2`, and `10`
-appear in that order. `before` and `after` place items at the beginning and end,
-and an empty position is treated as `0`.
+appear in that order. `before` and `after` place items at the beginning and end
+of the numeric range, and an empty position is treated as `0`.
+
+Any non-numeric position (for example the value produced by `PrefixPosition()`,
+which alphabetizes sibling menu items) sorts *after* `after`, because `before`
+and `after` are anchors within the numeric range rather than absolute terminals.
+When an item must sort truly first or truly last regardless of every other
+position — including free text — use the `start` and `end` sentinels. The full
+order is:
+
+```
+start  <  before  <  numbers  <  after  <  free-text  <  end
+```
+
+Like `before`/`after`, the sentinels support sub-ordering, so `end.50` sorts
+before `end.100`, and a bare `end` sorts before both.
 
 A container binding normally renders each item:
 

--- a/test/OrchardCore.Tests/DisplayManagement/Zones/FlatPositionComparerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Zones/FlatPositionComparerTests.cs
@@ -565,4 +565,191 @@ public class FlatPositionComparerTests
     }
 
     #endregion
+
+    #region Terminal Sentinel Tests (start / end)
+
+    [Theory]
+    // `start` sorts before every non-sentinel position.
+    [InlineData("start", "before", -1)]
+    [InlineData("before", "start", 1)]
+    [InlineData("start", "0", -1)]
+    [InlineData("0", "start", 1)]
+    [InlineData("start", "1", -1)]
+    [InlineData("start", "after", -1)]
+    [InlineData("after", "start", 1)]
+    [InlineData("start", "end", -1)]
+    [InlineData("end", "start", 1)]
+    // `end` sorts after every non-sentinel position.
+    [InlineData("end", "before", 1)]
+    [InlineData("before", "end", -1)]
+    [InlineData("end", "0", 1)]
+    [InlineData("end", "999", 1)]
+    [InlineData("end", "after", 1)]
+    [InlineData("after", "end", -1)]
+    public void Compare_TerminalSentinels_OrderAtTheExtremes(string x, string y, int expected)
+    {
+        // Act
+        var result = _comparer.Compare(x, y);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    // Free-text positions (e.g. what PrefixPosition() produces) sort after `after` but the
+    // terminal sentinels still bracket them: `start` < text < `end`.
+    [InlineData("start", "am-workspace", -1)]
+    [InlineData("am-workspace", "start", 1)]
+    [InlineData("am-workspace", "end", -1)]
+    [InlineData("end", "am-workspace", 1)]
+    [InlineData("after", "am-workspace", -1)] // documents the pre-existing wart: text sorts after `after`.
+    public void Compare_TerminalSentinels_BracketFreeText(string x, string y, int expected)
+    {
+        // Act
+        var result = _comparer.Compare(x, y);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("start", "START", 0)]
+    [InlineData("end", "END", 0)]
+    [InlineData("EnD", "end", 0)]
+    [InlineData("StArT", "end", -1)]
+    [InlineData("END", "start", 1)]
+    public void Compare_TerminalSentinels_AreCaseInsensitive(string x, string y, int expected)
+    {
+        // Act
+        var result = _comparer.Compare(x, y);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    // Sentinels support sub-ordering just like `before`/`after`.
+    [InlineData("end.50", "end.100", -1)]
+    [InlineData("end.100", "end.50", 1)]
+    [InlineData("end.50", "end.50", 0)]
+    [InlineData("end", "end.1", -1)]
+    [InlineData("end.1", "end", 1)]
+    [InlineData("start.1", "start.2", -1)]
+    [InlineData("start.2", "start.1", 1)]
+    [InlineData("start", "start.1", -1)]
+    public void Compare_TerminalSentinels_SubOrderNumerically(string x, string y, int expected)
+    {
+        // Act
+        var result = _comparer.Compare(x, y);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void OrderBy_FullOrdering_StartBeforeAfterTextEnd()
+    {
+        // Arrange - one value from every band, shuffled.
+        var positions = new[] { "end", "after", "am-beta", "before", "1.5", "start", "10", "0", "am-alpha", "1" };
+
+        // Act
+        var ordered = positions.OrderBy(x => x, _comparer).ToArray();
+
+        // Assert - start < before < numbers < after < free-text (alphabetical) < end.
+        Assert.Equal(
+            ["start", "before", "0", "1", "1.5", "10", "after", "am-alpha", "am-beta", "end"],
+            ordered);
+    }
+
+    [Fact]
+    public void OrderBy_AdminMenuScenario_CustomMenuLandsBeforeToolsAndSettings()
+    {
+        // Arrange - simulates root admin-menu positions: numbered built-ins, a module contributing a
+        // top-level item via PrefixPosition() ("am-..."), and Tools/Settings pinned to the end.
+        var positions = new[] { "end.100", "am-SMS Workspace", "1", "end.50", "2", "100" };
+
+        // Act
+        var ordered = positions.OrderBy(x => x, _comparer).ToArray();
+
+        // Assert - the custom (free-text) item now sorts before Tools (end.50) and Settings (end.100).
+        Assert.Equal(
+            ["1", "2", "100", "am-SMS Workspace", "end.50", "end.100"],
+            ordered);
+    }
+
+    #endregion
+
+    #region Comparer Honesty (total order) Tests
+
+    // A representative value from every band, in strictly ascending canonical order.
+    // Within a band, a bare sentinel sorts before its sub-positions (e.g. `end` < `end.50`),
+    // mirroring how bare `after` sorts before `after.50`.
+    private static readonly string[] s_ascending =
+    [
+        "start", "start.1", "start.2", "before", "before.5", "0", "1", "1.5", "2", "10",
+        "after", "after.50", "am-alpha", "am-beta", "end", "end.50", "end.100",
+    ];
+
+    [Fact]
+    public void Compare_IsAntisymmetric_AcrossEveryBand()
+    {
+        // For any pair, sign(Compare(a, b)) must equal -sign(Compare(b, a)).
+        for (var i = 0; i < s_ascending.Length; i++)
+        {
+            for (var j = 0; j < s_ascending.Length; j++)
+            {
+                var a = s_ascending[i];
+                var b = s_ascending[j];
+
+                var ab = Math.Sign(_comparer.Compare(a, b));
+                var ba = Math.Sign(_comparer.Compare(b, a));
+
+                Assert.True(ab == -ba, $"Antisymmetry violated for '{a}' vs '{b}': {ab} / {ba}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Compare_IsReflexive_AcrossEveryBand()
+    {
+        foreach (var value in s_ascending)
+        {
+            // Use distinct string instances to avoid the ReferenceEquals fast path.
+            var copy = new string(value.ToCharArray());
+            Assert.Equal(0, _comparer.Compare(value, copy));
+        }
+    }
+
+    [Fact]
+    public void Compare_IsTransitive_AcrossEveryBand()
+    {
+        // The canonical array is strictly ascending, so every earlier item must compare less than
+        // every later item (which, with antisymmetry, guarantees a consistent transitive order).
+        for (var i = 0; i < s_ascending.Length; i++)
+        {
+            for (var j = i + 1; j < s_ascending.Length; j++)
+            {
+                var earlier = s_ascending[i];
+                var later = s_ascending[j];
+
+                Assert.True(_comparer.Compare(earlier, later) < 0, $"Expected '{earlier}' < '{later}'.");
+                Assert.True(_comparer.Compare(later, earlier) > 0, $"Expected '{later}' > '{earlier}'.");
+            }
+        }
+    }
+
+    [Fact]
+    public void OrderBy_ShuffledCanonicalList_RestoresCanonicalOrder()
+    {
+        // Arrange - a deterministic shuffle of the canonical order.
+        var shuffled = s_ascending.OrderBy(x => x.Length).ThenByDescending(x => x, StringComparer.Ordinal).ToArray();
+
+        // Act
+        var ordered = shuffled.OrderBy(x => x, _comparer).ToArray();
+
+        // Assert
+        Assert.Equal(s_ascending, ordered);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Problem

`FlatPositionComparer` treats `before`/`after` as anchors **within the numeric range** (they normalize to `-9999`/`9999`). Because any non-numeric partition sorts *after* any integer, a free-text position — notably the value produced by `PrefixPosition()`, which alphabetizes sibling menu items — sorts **after `after`**.

The practical symptom: a top-level admin menu item added with `S["…"].PrefixPosition()` renders **after `Settings`** (`after.100`), even though `after.100` was intended to be last. There was no way to force an item truly first or truly last when free-text siblings are present.

## Change

Add two **additive, backward-compatible** terminal sentinels that bracket every other position, including free text:

```
start  <  before  <  numbers  <  after  <  free-text  <  end
```

- Existing positions keep their exact ordering — only the new `start`/`end` keywords change behavior.
- A codebase scan confirmed no shipped position string used `"start"` or `"end"` as a value, so nothing is silently reclassified.
- Sentinels support sub-ordering like `before`/`after`: `end` < `end.50` < `end.100`.

`Settings` and `Tools` in `OrchardCore.Settings` move from `after.100`/`after.50` to `end.100`/`end.50`, so custom top-level items positioned via `PrefixPosition()` now sort **before** them. Their relative order is unchanged.

### Why not just make `after` a true terminal?

That would silently reorder existing shapes, zones, titles, and menus across the whole product (`FlatPositionComparer` is the sort authority for all of them). The sentinel approach is opt-in and risk-free for existing content. See the discussion in the commit message.

## Notes for reviewers

- `before` remains the effective "first" for the numeric range; `start` is included for symmetry and for cases needing an absolute first ahead of `before`.
- Docs updated in `src/docs/topics/display/shapes.md` to document the full order and the `after` vs `end` distinction (the footgun).

## Tests

Extended `FlatPositionComparerTests` with sentinel ordering, case-insensitivity, sub-ordering, the admin-menu scenario, and **comparer-honesty** tests (antisymmetry, reflexivity, transitivity, and round-trip sort) across every band. All 144 tests in the class pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
