### PR TITLE
Remove legacy admin menu format and sort main menu alphabetically

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenu.cs
@@ -22,24 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Configuration"], configuration => configuration
-                .Add(S["Settings"], settings => settings
-                    .Add(S["Admin"], S["Admin"].PrefixPosition(), admin => admin
-                        .AddClass("admin")
-                        .Id("admin")
-                        .Action("Index", "Admin", s_routeValues)
-                        .Permission(AdminPermissions.ManageAdminSettings)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Admin"], S["Admin"].PrefixPosition(), admin => admin

--- a/src/OrchardCore.Modules/OrchardCore.Admin/Views/NavigationItemText-admin.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/Views/NavigationItemText-admin.Id.cshtml
@@ -1,15 +1,3 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-tachometer" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none">
 </span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminMenu.cs
@@ -20,30 +20,15 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            // Configuration and settings menus for the AdminMenu module.
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Admin menus"], S["Admin menus"].PrefixPosition(), adminMenu => adminMenu
-                        .Permission(AdminMenuPermissions.ManageAdminMenu)
-                        .Action("List", "Menu", "OrchardCore.AdminMenu")
-                        .LocalNav()
-                    )
-                );
-        }
-        else
-        {
-            // Configuration and settings menus for the AdminMenu module.
-            builder
-                .Add(S["Tools"], tools => tools
-                    .Add(S["Admin Menus"], S["Admin Menus"].PrefixPosition(), adminMenu => adminMenu
-                        .Permission(AdminMenuPermissions.ManageAdminMenu)
-                        .Action("List", "Menu", "OrchardCore.AdminMenu")
-                        .LocalNav()
-                    )
-                );
-        }
+        // Configuration and settings menus for the AdminMenu module.
+        builder
+            .Add(S["Tools"], tools => tools
+                .Add(S["Admin Menus"], S["Admin Menus"].PrefixPosition(), adminMenu => adminMenu
+                    .Permission(AdminMenuPermissions.ManageAdminMenu)
+                    .Action("List", "Menu", "OrchardCore.AdminMenu")
+                    .LocalNav()
+                )
+            );
 
         // This is the entry point for the adminMenu: dynamically generated custom admin menus.
         return _adminMenuNavigationProviderCoordinator.BuildNavigationAsync(NavigationConstants.AdminMenuId, builder);

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/AdminMenu.cs
@@ -14,20 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["GraphiQL"], S["GraphiQL"].PrefixPosition(), graphiQL => graphiQL
-                        .Action("Index", "Admin", "OrchardCore.Apis.GraphQL")
-                        .Permission(GraphQLPermissions.ExecuteGraphQL)
-                        .LocalNav()
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["GraphiQL"], S["GraphiQL"].PrefixPosition(), graphiQL => graphiQL

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Navigation/AuditTrailAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Navigation/AuditTrailAdminMenu.cs
@@ -29,31 +29,6 @@ public sealed class AuditTrailAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Audit Trail"], NavigationConstants.AdminMenuAuditTrailPosition, configuration => configuration
-                    .AddClass("audittrail")
-                    .Id("audittrail")
-                    .Action(nameof(AdminController.Index), "Admin", s_routeValues)
-                    .Permission(AuditTrailPermissions.ViewAuditTrail)
-                    .LocalNav()
-                , priority: 1)
-                .Add(S["Configuration"], configuration => configuration
-                     .Add(S["Settings"], settings => settings
-                        .Add(S["Audit Trail"], S["Audit Trail"].PrefixPosition(), auditTrail => auditTrail
-                            .AddClass("audittrail")
-                            .Id("audittrailSettings")
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(AuditTrailPermissions.ManageAuditTrailSettings)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Audit Trail"], S["Audit Trail"].PrefixPosition(), configuration => configuration

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/NavigationItemText-audittrail.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/NavigationItemText-audittrail.Id.cshtml
@@ -1,14 +1,2 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-history" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none"></span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/AdminMenu.cs
@@ -1,10 +1,10 @@
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
-using OrchardCore.Indexing.Core;
-using OrchardCore.Navigation;
 using OrchardCore.AzureAI.Drivers;
 using OrchardCore.AzureAI.Models;
+using OrchardCore.Indexing.Core;
+using OrchardCore.Navigation;
 
 namespace OrchardCore.AzureAI;
 
@@ -32,24 +32,6 @@ public sealed class AdminMenu : AdminNavigationProvider
     {
         if (_azureAISearchSettings.CurrentValue.DisableUIConfiguration)
         {
-            return ValueTask.CompletedTask;
-        }
-
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Configuration"], configuration => configuration
-                   .Add(S["Settings"], settings => settings
-                       .Add(S["Azure AI Search"], S["Azure AI Search"].PrefixPosition(), azureAISearch => azureAISearch
-                       .AddClass("azure-ai-search")
-                           .Id("azureaisearch")
-                           .Action("Index", "Admin", s_routeValues)
-                           .Permission(AzureAISearchPermissions.ManageAzureAISearchISettings)
-                           .LocalNav()
-                       )
-                   )
-               );
-
             return ValueTask.CompletedTask;
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/Views/NavigationItemText-azureaisearch.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/Views/NavigationItemText-azureaisearch.Id.cshtml
@@ -1,13 +1,3 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-brands fa-microsoft" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-}
-
 <span class="icon icon-none">
 </span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/AdminMenu.cs
@@ -14,22 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Tasks"], S["Tasks"].PrefixPosition(), tasks => tasks
-                        .Add(S["Background Tasks"], S["Background Tasks"].PrefixPosition(), backgroundTasks => backgroundTasks
-                            .Action("Index", "BackgroundTask", "OrchardCore.BackgroundTasks")
-                            .Permission(Permissions.ManageBackgroundTasks)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Background Tasks"], S["Background Tasks"].PrefixPosition(), backgroundTasks => backgroundTasks

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
@@ -28,33 +28,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Configuration"], configuration => configuration
-                .Add(S["Settings"], settings => settings
-                    .Add(S["Localization"], localization => localization
-                        .Add(S["Content Request Culture Provider"], S["Content Request Culture Provider"].PrefixPosition(), provider => provider
-                            .AddClass("contentrequestcultureprovider")
-                            .Id("contentrequestcultureprovider")
-                            .Action("Index", "Admin", s_providersRouteValues)
-                            .Permission(ContentLocalizationPermissions.ManageContentCulturePicker)
-                            .LocalNav()
-                        )
-                        .Add(S["Content Culture Picker"], S["Content Culture Picker"].PrefixPosition(), picker => picker
-                            .AddClass("contentculturepicker")
-                            .Id("contentculturepicker")
-                            .Action("Index", "Admin", s_pickerRouteValues)
-                            .Permission(ContentLocalizationPermissions.ManageContentCulturePicker)
-                            .LocalNav()
-                        )
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Localization"], S["Localization"].PrefixPosition(), localization => localization

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
@@ -19,25 +19,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Content"], content => content
-                    .Add(S["Content Definition"], S["Content Definition"].PrefixPosition("9"), contentDefinition => contentDefinition
-                        .Add(S["Content Types"], S["Content Types"].PrefixPosition("1"), contentTypes => contentTypes
-                            .Action(nameof(AdminController.List), s_adminControllerName, "OrchardCore.ContentTypes")
-                            .Permission(ContentTypesPermissions.ViewContentTypes)
-                            .LocalNav()
-                        )
-                        .Add(S["Content Parts"], S["Content Parts"].PrefixPosition("2"), contentParts => contentParts
-                            .Action(nameof(AdminController.ListParts), s_adminControllerName, "OrchardCore.ContentTypes")
-                            .Permission(ContentTypesPermissions.ViewContentTypes)
-                            .LocalNav()
-                        )
-                    )
-                );
-        }
-
         builder
             .Add(S["Design"], content => content
                 .Add(S["Content Definition"], S["Content Definition"].PrefixPosition(), contentDefinition => contentDefinition

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -62,7 +62,7 @@ public sealed class AdminMenu : AdminNavigationProvider
 
         var contentTypeDefinitions = await _contentDefinitionManager.ListTypeDefinitionsAsync();
         var listableContentTypes = contentTypeDefinitions.Where(ctd => ctd.IsListable());
-        await builder.AddAsync(S["Content"], NavigationConstants.AdminMenuContentPosition, async content =>
+        await builder.AddAsync(S["Content"], S["Content"].PrefixPosition(), async content =>
         {
             content.AddClass("content").Id("content");
             await content.AddAsync(S["Content Items"], "before", async contentItems =>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ExportContentToDeploymentTarget/ExportContentToDeploymentTargetAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ExportContentToDeploymentTarget/ExportContentToDeploymentTargetAdminMenu.cs
@@ -22,24 +22,6 @@ public sealed class ExportContentToDeploymentTargetAdminMenu : AdminNavigationPr
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Configuration"], configuration => configuration
-                .Add(S["Import/Export"], S["Import/Export"].PrefixPosition(), import => import
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["Export target"], S["Export target"].PrefixPosition(), targetSettings => targetSettings
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(DeploymentPermissions.ManageDeploymentPlan)
-                            .LocalNav()
-                        )
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Deployment Targets"], S["Deployment Targets"].PrefixPosition(), targetSettings => targetSettings

--- a/src/OrchardCore.Modules/OrchardCore.Contents/VersionPruning/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/VersionPruning/AdminMenu.cs
@@ -22,22 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["Content Version Pruning"], S["Content Version Pruning"], pruning => pruning
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(ContentVersionPruningPermissions.ManageContentVersionPruningSettings)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Content Version Pruning"], S["Content Version Pruning"].PrefixPosition(), pruning => pruning

--- a/src/OrchardCore.Modules/OrchardCore.Cors/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Cors/AdminMenu.cs
@@ -14,24 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                        .Add(S["CORS"], S["CORS"].PrefixPosition(), entry => entry
-                            .AddClass("cors")
-                            .Id("cors")
-                            .Action("Index", "Admin", "OrchardCore.Cors")
-                            .Permission(Permissions.ManageCorsSettings)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
@@ -40,25 +40,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
             var htmlName = type.Name.HtmlClassify();
 
-            if (NavigationHelper.UseLegacyFormat())
-            {
-                builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                        .Add(new LocalizedString(type.DisplayName, type.DisplayName), type.DisplayName.PrefixPosition(), customSettings => customSettings
-                            .Action("Index", "Admin", routeValues)
-                            .AddClass(htmlName)
-                            .Id(htmlName)
-                            .Permission(Permissions.CreatePermissionForType(type))
-                            .Resource(type.Name)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-                continue;
-            }
-
             builder
                 .Add(S["Settings"], settings => settings
                     .Add(new LocalizedString(type.DisplayName, type.DisplayName), type.DisplayName.PrefixPosition(), layers => layers

--- a/src/OrchardCore.Modules/OrchardCore.DataLocalization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataLocalization/AdminMenu.cs
@@ -26,26 +26,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["Localization"], localization => localization
-                            .Add(S["Translations"], S["Translations"].PrefixPosition(), translations => translations
-                                .AddClass("translations")
-                                .Id("translations")
-                                .Permission(DataLocalizationPermissions.ViewDynamicTranslations)
-                                .Action(s_routeValues["action"].ToString(), s_routeValues["controller"].ToString(), s_routeValues)
-                                .LocalNav()
-                            )
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Localization"], S["Localization"].PrefixPosition(), localization => localization

--- a/src/OrchardCore.Modules/OrchardCore.Demo/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/AdminMenu.cs
@@ -15,7 +15,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
         builder
-            .Add(S["Demo"], "10", demo => demo
+            .Add(S["Demo"], S["Demo"].PrefixPosition(), demo => demo
                 .AddClass("demo").Id("demo")
                 .Add(S["This Menu Item 1"], "0", item => item
                     .Add(S["This is Menu Item 1.1"], subItem => subItem

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
@@ -14,27 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Import/Export"], import => import
-                        .Add(S["Remote Instances"], S["Remote Instances"].PrefixPosition(), remote => remote
-                            .Action("Index", "RemoteInstance", "OrchardCore.Deployment.Remote")
-                            .Permission(DeploymentPermissions.ManageRemoteInstances)
-                            .LocalNav()
-                        )
-                        .Add(S["Remote Clients"], S["Remote Clients"].PrefixPosition(), remote => remote
-                            .Action("Index", "RemoteClient", "OrchardCore.Deployment.Remote")
-                            .Permission(DeploymentPermissions.ManageRemoteClients)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Deployments"], import => import

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
@@ -14,32 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Import/Export"], S["Import/Export"].PrefixPosition(), import => import
-                        .Add(S["Deployment Plans"], S["Deployment Plans"].PrefixPosition(), deployment => deployment
-                            .Action("Index", "DeploymentPlan", "OrchardCore.Deployment")
-                            .Permission(DeploymentPermissions.Export)
-                            .LocalNav()
-                        )
-                        .Add(S["Package Import"], S["Package Import"].PrefixPosition(), deployment => deployment
-                            .Action("Index", "Import", "OrchardCore.Deployment")
-                            .Permission(DeploymentPermissions.Import)
-                            .LocalNav()
-                        )
-                        .Add(S["JSON Import"], S["JSON Import"].PrefixPosition(), deployment => deployment
-                            .Action("Json", "Import", "OrchardCore.Deployment")
-                            .Permission(DeploymentPermissions.Import)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Deployments"], S["Deployments"].PrefixPosition(), import => import

--- a/src/OrchardCore.Modules/OrchardCore.Elasticsearch/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Elasticsearch/AdminMenu.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
-using OrchardCore.Navigation;
 using OrchardCore.Elasticsearch.Core.Models;
+using OrchardCore.Navigation;
 
 namespace OrchardCore.Elasticsearch;
 
@@ -27,7 +27,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         }
 
         builder
-            .Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
+            .Add(S["Search"], S["Search"].PrefixPosition(), search => search
                 .AddClass("search")
                 .Id("search")
                 .Add(S["Queries"], S["Queries"].PrefixPosition(), import => import

--- a/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
@@ -23,31 +23,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                       .Add(S["Email"], S["Email"].PrefixPosition(), entry => entry
-                          .AddClass("email")
-                          .Id("email")
-                          .Action("Index", "Admin", s_routeValues)
-                          .Permission(EmailPermissions.ManageEmailSettings)
-                          .LocalNav()
-                        )
-                       .Add(S["Email Test"], S["Email Test"].PrefixPosition(), entry => entry
-                          .AddClass("emailtest")
-                          .Id("emailtest")
-                          .Action(nameof(AdminController.Test), typeof(AdminController).ControllerName(), "OrchardCore.Email")
-                          .Permission(EmailPermissions.ManageEmailSettings)
-                          .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Testing"], S["Testing"].PrefixPosition(), testing => testing

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenu.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["Meta App"], S["Meta App"].PrefixPosition(), metaApp => metaApp
-                            .AddClass("facebookApp")
-                            .Id("facebookApp")
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(Permissions.ManageFacebookApp)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Integrations"], S["Integrations"].PrefixPosition(), integrations => integrations

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuLogin.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuLogin.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenuLogin : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Authentication"], S["Authentication"].PrefixPosition(), authentication => authentication
-                        .Add(S["Meta"], S["Meta"].PrefixPosition(), meta => meta
-                            .AddClass("facebook")
-                            .Id("facebook")
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(Permissions.ManageFacebookApp)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuPixel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuPixel.cs
@@ -22,24 +22,6 @@ public sealed class AdminMenuPixel : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Configuration"], configuration => configuration
-                   .Add(S["Settings"], settings => settings
-                       .Add(S["Meta Pixel"], S["Meta Pixel"].PrefixPosition(), pixel => pixel
-                           .AddClass("facebookPixel")
-                           .Id("facebookPixel")
-                           .Action("Index", "Admin", s_routeValues)
-                           .Permission(FacebookConstants.ManageFacebookPixelPermission)
-                           .LocalNav()
-                       )
-                   )
-               );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Integrations"], S["Integrations"].PrefixPosition(), integrations => integrations

--- a/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
@@ -22,20 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Features"], S["Features"].PrefixPosition(), deployment => deployment
-                        .Action("Features", "Admin", s_routeValues)
-                        .Permission(FeaturesPermissions.ManageFeatures)
-                        .LocalNav()
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Features"], S["Features"].PrefixPosition(), deployment => deployment

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/AdminMenuGitHubLogin.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/AdminMenuGitHubLogin.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenuGitHubLogin : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Security"], security => security
-                .Add(S["Authentication"], authentication => authentication
-                    .Add(S["GitHub"], S["GitHub"].PrefixPosition(), settings => settings
-                        .AddClass("github")
-                        .Id("github")
-                        .Action("Index", "Admin", s_routeValues)
-                        .Permission(Permissions.ManageGitHubAuthentication)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Google/GoogleAnalyticsAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/GoogleAnalyticsAdminMenu.cs
@@ -21,23 +21,6 @@ public sealed class GoogleAnalyticsAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Configuration"], configuration => configuration
-                .Add(S["Settings"], settings => settings
-                    .Add(S["Google Analytics"], S["Google Analytics"].PrefixPosition(), google => google
-                        .AddClass("googleAnalytics").Id("googleAnalytics")
-                        .Action("Index", "Admin", s_routeValues)
-                        .Permission(Permissions.ManageGoogleAnalytics)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Integrations"], S["Integrations"].PrefixPosition(), integrations => integrations

--- a/src/OrchardCore.Modules/OrchardCore.Google/GoogleAuthenticationAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/GoogleAuthenticationAdminMenu.cs
@@ -21,24 +21,6 @@ public sealed class GoogleAuthenticationAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Authentication"], authentication => authentication
-                    .Add(S["Google"], S["Google"].PrefixPosition(), google => google
-                        .AddClass("google")
-                        .Id("google")
-                        .Action("Index", "Admin", s_routeValues)
-                        .Permission(Permissions.ManageGoogleAuthentication)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Google/GoogleTagManagerAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/GoogleTagManagerAdminMenu.cs
@@ -21,24 +21,6 @@ public sealed class GoogleTagManagerAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Configuration"], configuration => configuration
-                .Add(S["Settings"], settings => settings
-                    .Add(S["Google Tag Manager"], S["Google Tag Manager"].PrefixPosition(), google => google
-                        .AddClass("googleTagManager")
-                        .Id("googleTagManager")
-                        .Action("Index", "Admin", s_routeValues)
-                        .Permission(Permissions.ManageGoogleTagManager)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Integrations"], S["Integrations"].PrefixPosition(), integrations => integrations

--- a/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
@@ -22,22 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                        .Add(S["HTTPS"], S["HTTPS"].PrefixPosition(), https => https
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(Permissions.ManageHttps)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/AdminMenu.cs
@@ -16,7 +16,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
         builder
-            .Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
+            .Add(S["Search"], S["Search"].PrefixPosition(), search => search
                 .AddClass("search")
                 .Id("search")
                 .Add(S["Indexes"], S["Indexes"].PrefixPosition(), indexes => indexes

--- a/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
@@ -22,27 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Design"], design => design
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["Zones"], S["Zones"].PrefixPosition(), zones => zones
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(Permissions.ManageLayers)
-                            .LocalNav()
-                        )
-                    )
-                    .Add(S["Widgets"], S["Widgets"].PrefixPosition(), widgets => widgets
-                        .Permission(Permissions.ManageLayers)
-                        .Action("Index", "Admin", "OrchardCore.Layers")
-                        .LocalNav()
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Design"], design => design
                 .Add(S["Widgets"], S["Widgets"].PrefixPosition(), widgets => widgets

--- a/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
@@ -30,28 +30,6 @@ public sealed class AdminMenu : AdminNavigationProvider
     /// <inheritdocs />
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Configuration"], configuration => configuration
-                   .Add(S["Settings"], settings => settings
-                       .Add(S["Localization"], localization => localization
-                           .AddClass("localization")
-                           .Id("localization")
-                           .Add(S["Cultures"], S["Cultures"].PrefixPosition(), cultures => cultures
-                               .AddClass("cultures")
-                               .Id("cultures")
-                               .Action("Index", "Admin", s_routeValues)
-                               .Permission(LocalizationPermissions.ManageCultures)
-                               .LocalNav()
-                           )
-                       )
-                   )
-               );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Localization"], S["Localization"].PrefixPosition(), localization => localization

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Views/NavigationItemText-localization.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Views/NavigationItemText-localization.Id.cshtml
@@ -1,15 +1,3 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-globe" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none">
 </span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
@@ -15,7 +15,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
         builder
-            .Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
+            .Add(S["Search"], S["Search"].PrefixPosition(), search => search
                 .Add(S["Queries"], S["Queries"].PrefixPosition(), import => import
                     .Add(S["Run Lucene Query"], S["Run Lucene Query"].PrefixPosition(), queries => queries
                         .Action("Query", "Admin", "OrchardCore.Lucene")

--- a/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/AdminMenu.cs
@@ -14,21 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder.Add(S["Configuration"], configuration => configuration
-                .Add(S["Media"], S["Media"].PrefixPosition(), media => media
-                    .Add(S["Amazon S3 Options"], S["Amazon S3 Options"].PrefixPosition(), options => options
-                        .Action("Options", "Admin", "OrchardCore.Media.AmazonS3")
-                        .Permission(Permissions.ViewAmazonS3MediaOptions)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder.Add(S["Settings"], settings => settings
             .Add(S["Media"], S["Media"].PrefixPosition(), media => media
                 .Add(S["Amazon S3 Options"], S["Amazon S3 Options"].PrefixPosition(), options => options

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/AdminMenu.cs
@@ -14,22 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Media"], S["Media"].PrefixPosition(), media => media
-                        .Add(S["Azure Blob Options"], S["Azure Blob Options"].PrefixPosition(), options => options
-                            .Action("Options", "Admin", "OrchardCore.Media.Azure")
-                            .Permission(Permissions.ViewAzureMediaOptions)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Media"], S["Media"].PrefixPosition(), media => media

--- a/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
@@ -14,45 +14,8 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Content"], content => content
-                    .AddClass("media")
-                    .Id("media")
-                    .Add(S["Media Library"], S["Media Library"].PrefixPosition(), media => media
-                        .Permission(MediaPermissions.ManageMedia)
-                        .Action("Index", "Admin", "OrchardCore.Media")
-                        .LocalNav()
-                    )
-                );
-
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Media"], S["Media"].PrefixPosition(), media => media
-                        .Add(S["Media Options"], S["Media Options"].PrefixPosition(), options => options
-                            .Action("Options", "Admin", "OrchardCore.Media")
-                            .Permission(MediaPermissions.ViewMediaOptions)
-                            .LocalNav()
-                        )
-                        .Add(S["Media Profiles"], S["Media Profiles"].PrefixPosition(), mediaProfiles => mediaProfiles
-                            .Action("Index", "MediaProfiles", "OrchardCore.Media")
-                            .Permission(MediaPermissions.ManageMediaProfiles)
-                            .LocalNav()
-                        )
-                        .Add(S["Media API"], S["Media API"].PrefixPosition(), api => api
-                            .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = MediaApiSettings.GroupId })
-                            .Permission(MediaPermissions.ManageMediaApiSettings)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
-            .Add(S["Media"], "after.15", media => media
+            .Add(S["Media"], S["Media"].PrefixPosition(), media => media
                 .AddClass("media")
                 .Id("media")
                 .Add(S["Library"], S["Library"].PrefixPosition("1"), library => library

--- a/src/OrchardCore.Modules/OrchardCore.Media/MediaCacheAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/MediaCacheAdminMenu.cs
@@ -14,22 +14,6 @@ public sealed class MediaCacheAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Media"], S["Media"].PrefixPosition(), media => media
-                        .Add(S["Media Cache"], S["Media Cache"].PrefixPosition(), cache => cache
-                            .Action("Index", "MediaCache", "OrchardCore.Media")
-                            .Permission(MediaPermissions.ManageAssetCache)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Media"], S["Media"].PrefixPosition(), media => media

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuAAD.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuAAD.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenuAAD : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Authentication"], authentication => authentication
-                        .Add(S["Microsoft Entra ID"], S["Microsoft Entra ID"].PrefixPosition(), entraId => entraId
-                            .AddClass("microsoft-entra-id")
-                            .Id("microsoftentraid")
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(Permissions.ManageMicrosoftAuthentication)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuMicrosoftAccount.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuMicrosoftAccount.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenuMicrosoftAccount : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Authentication"], authentication => authentication
-                        .Add(S["Microsoft"], S["Microsoft"].PrefixPosition(), microsoft => microsoft
-                            .AddClass("microsoft")
-                            .Id("microsoft")
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(Permissions.ManageMicrosoftAuthentication)
-                            .LocalNav()
-                        )
-                    )
-               );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ClientAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ClientAdminMenu.cs
@@ -22,26 +22,6 @@ public sealed class ClientAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Security"], security => security
-                   .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId
-                       .AddClass("openid")
-                       .Id("openid")
-                       .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                           .Add(S["Authentication Client"], S["Authentication Client"].PrefixPosition(), client => client
-                               .Action("Index", "Admin", s_clientRouteValues)
-                               .Permission(OpenIdPermissions.ManageClientSettings)
-                               .LocalNav()
-                           )
-                       )
-                   )
-               );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ManagementAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ManagementAdminMenu.cs
@@ -14,31 +14,6 @@ public sealed class ManagementAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Security"], security => security
-                .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId
-                    .AddClass("openid")
-                    .Id("openid")
-                    .Add(S["Management"], S["Management"].PrefixPosition(), management => management
-                        .Add(S["Applications"], S["Applications"].PrefixPosition(), applications => applications
-                            .Action("Index", "Application", "OrchardCore.OpenId")
-                            .Permission(OpenIdPermissions.ManageApplications)
-                            .LocalNav()
-                        )
-                        .Add(S["Scopes"], S["Scopes"].PrefixPosition(), applications => applications
-                            .Action("Index", "Scope", "OrchardCore.OpenId")
-                            .Permission(OpenIdPermissions.ManageScopes)
-                            .LocalNav()
-                        )
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Access Control"], accessControl => accessControl
                 .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ServerAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ServerAdminMenu.cs
@@ -14,26 +14,6 @@ public sealed class ServerAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Security"], security => security
-                   .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId
-                       .AddClass("openid")
-                       .Id("openid")
-                       .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                            .Add(S["Authorization Server"], S["Authorization Server"].PrefixPosition(), server => server
-                                .Action("Index", "ServerConfiguration", "OrchardCore.OpenId")
-                                .Permission(OpenIdPermissions.ManageServerSettings)
-                                .LocalNav()
-                            )
-                       )
-                   )
-               );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ValidationAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ValidationAdminMenu.cs
@@ -14,26 +14,6 @@ public sealed class ValidationAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Security"], security => security
-                   .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId
-                       .AddClass("openid")
-                       .Id("openid")
-                       .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                            .Add(S["Token Validation"], S["Token Validation"].PrefixPosition(), validation => validation
-                                .Action("Index", "ValidationConfiguration", "OrchardCore.OpenId")
-                                .Permission(OpenIdPermissions.ManageValidationSettings)
-                                .LocalNav()
-                            )
-                       )
-                   )
-               );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), openId => openId

--- a/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
@@ -15,7 +15,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
         builder
-            .Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
+            .Add(S["Search"], S["Search"].PrefixPosition(), search => search
                 .AddClass("search")
                 .Id("search")
                 .Add(S["Queries"], S["Queries"].PrefixPosition(), queries => queries

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
@@ -15,7 +15,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
         builder
-            .Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
+            .Add(S["Search"], S["Search"].PrefixPosition(), search => search
                 .Add(S["Queries"], S["Queries"].PrefixPosition(), queries => queries
                     .Add(S["Run SQL Query"], S["Run SQL Query"].PrefixPosition(), sql => sql
                          .Action("Query", "Admin", "OrchardCore.Queries")

--- a/src/OrchardCore.Modules/OrchardCore.RateLimits/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.RateLimits/AdminMenu.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Navigation;
 using OrchardCore.RateLimits.Core;
@@ -15,20 +14,6 @@ internal sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Tools"], tools => tools
-                    .Add(S["Rate Limits"], S["Rate Limits"].PrefixPosition(), rateLimits => rateLimits
-                        .Action("Index", "Admin", "OrchardCore.RateLimits")
-                        .Permission(RateLimitsPermissions.ManageRateLimits)
-                        .LocalNav()
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Rate Limits"], S["Rate Limits"].PrefixPosition(), rateLimits => rateLimits

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/AdminMenu.cs
@@ -22,22 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                        .Add(S["reCaptcha"], S["reCaptcha"].PrefixPosition(), reCaptcha => reCaptcha
-                            .Permission(ReCaptchaPermissions.ManageReCaptchaSettings)
-                            .Action("Index", "Admin", s_routeValues)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
@@ -14,22 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Recipes"], S["Recipes"].PrefixPosition(), recipes => recipes
-                        .AddClass("recipes")
-                        .Id("recipes")
-                        .Permission(RecipePermissions.ManageRecipes)
-                        .Action("Index", "Admin", "OrchardCore.Recipes")
-                        .LocalNav()
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Recipes"], S["Recipes"].PrefixPosition(), recipes => recipes

--- a/src/OrchardCore.Modules/OrchardCore.ReverseProxy/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReverseProxy/AdminMenu.cs
@@ -22,24 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["Reverse Proxy"], S["Reverse Proxy"].PrefixPosition(), entry => entry
-                        .AddClass("reverseproxy")
-                        .Id("reverseproxy")
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(Permissions.ManageReverseProxySettings)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Reverse Proxy"], S["Reverse Proxy"].PrefixPosition(), proxy => proxy

--- a/src/OrchardCore.Modules/OrchardCore.ReverseProxy/Views/NavigationItemText-reverseproxy.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ReverseProxy/Views/NavigationItemText-reverseproxy.Id.cshtml
@@ -1,15 +1,3 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-sync" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none">
 </span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
@@ -14,22 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Roles"], S["Roles"].PrefixPosition(), roles => roles
-                        .AddClass("roles")
-                        .Id("roles")
-                        .Action("Index", "Admin", "OrchardCore.Roles")
-                        .Permission(RolesPermissions.ViewRoles)
-                        .LocalNav()
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Access Control"], accessControl => accessControl
                 .Add(S["Roles"], S["Roles"].PrefixPosition(), roles => roles

--- a/src/OrchardCore.Modules/OrchardCore.Search/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/AdminMenu.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
-                    .AddClass("search")
-                    .Id("search")
-                    .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                        .Action("Index", "Admin", s_routeValues)
-                        .AddClass("searchsettings")
-                        .Id("searchsettings")
-                        .Permission(SearchPermissions.ManageSearchSettings)
-                        .LocalNav()
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Search"], S["Search"].PrefixPosition(), search => search

--- a/src/OrchardCore.Modules/OrchardCore.Security/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Security/AdminMenu.cs
@@ -22,24 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], NavigationConstants.AdminMenuSecurityPosition, security => security
-                    .AddClass("security")
-                    .Id("security")
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["Security Headers"], S["Security Headers"].PrefixPosition(), headers => headers
-                            .Permission(SecurityPermissions.ManageSecurityHeadersSettings)
-                            .Action("Index", "Admin", s_routeValues)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Seo/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/AdminMenu.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                       .Add(S["SEO"], S["SEO"].PrefixPosition(), seo => seo
-                           .AddClass("seo")
-                           .Id("seo")
-                           .Action("Index", "Admin", s_routeValues)
-                           .Permission(SeoConstants.ManageSeoSettings)
-                           .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Search"], S["Search"].PrefixPosition(), search => search

--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -28,36 +28,8 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], NavigationConstants.AdminMenuConfigurationPosition, configuration => configuration
-                    .AddClass("menu-configuration")
-                    .Id("configuration")
-                    .Add(S["Settings"], "1", settings => settings
-                        .Add(S["General"], "1", entry => entry
-                            .AddClass("general")
-                            .Id("general")
-                            .Action("Index", "Admin", s_generalRouteValues)
-                            .Permission(SettingsPermissions.ManageGeneralSettings)
-                            .LocalNav()
-                        )
-                        .Add(S["Debugging"], "2", entry => entry
-                            .AddClass("debugging")
-                            .Id("debugging")
-                            .Action("Index", "Admin", s_debuggingRouteValues)
-                            .Permission(SettingsPermissions.ManageDebuggingSettings)
-                            .LocalNav()
-                        ),
-                    priority: 1)
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
-            .Add(S["Tools"], "end.50", tools => tools
+            .Add(S["Tools"], S["Tools"].PrefixPosition(), tools => tools
                 .Id("tools")
                 .AddClass("tools")
             , priority: 1)

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/NavigationItemText-general.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/NavigationItemText-general.Id.cshtml
@@ -1,15 +1,3 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-gears" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none">
 </span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/AdminMenu.cs
@@ -14,29 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Configuration"], configuration => configuration
-                   .Add(S["SEO"], S["SEO"].PrefixPosition(), seo => seo
-                       .Permission(SitemapsPermissions.ManageSitemaps)
-                       .Add(S["Sitemaps"], S["Sitemaps"].PrefixPosition("1"), sitemaps => sitemaps
-                           .Action("List", "Admin", "OrchardCore.Sitemaps")
-                           .LocalNav()
-                       )
-                       .Add(S["Sitemap Indexes"], S["Sitemap Indexes"].PrefixPosition("2"), indexes => indexes
-                           .Action("List", "SitemapIndex", "OrchardCore.Sitemaps")
-                           .LocalNav()
-                       )
-                       .Add(S["Sitemaps Cache"], S["Sitemaps Cache"].PrefixPosition("3"), cache => cache
-                           .Action("List", "SitemapCache", "OrchardCore.Sitemaps")
-                           .LocalNav()
-                       )
-                   )
-               );
-
-            return ValueTask.CompletedTask;
-        }
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["Search Engine Optimization"], S["Search Engine Optimization"].PrefixPosition(), seo => seo

--- a/src/OrchardCore.Modules/OrchardCore.Sms/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/AdminMenu.cs
@@ -23,31 +23,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["SMS"], S["SMS"].PrefixPosition(), sms => sms
-                            .AddClass("sms")
-                            .Id("sms")
-                            .Action("Index", "Admin", s_routeValues)
-                            .Permission(SmsPermissions.ManageSmsSettings)
-                            .LocalNav()
-                        )
-                        .Add(S["SMS Test"], S["SMS Test"].PrefixPosition(), sms => sms
-                            .AddClass("smstest")
-                            .Id("smstest")
-                            .Action(nameof(AdminController.Test), typeof(AdminController).ControllerName(), "OrchardCore.Sms")
-                            .Permission(SmsPermissions.ManageSmsSettings)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Communication"], S["Communication"].PrefixPosition(), communication => communication

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/AdminMenu.cs
@@ -22,24 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Configuration"], configuration => configuration
-                .Add(S["Settings"], "1", settings => settings
-                    .Add(S["Taxonomy Filters"], S["Taxonomy Filters"].PrefixPosition(), filters => filters
-                        .AddClass("taxonomyfilters")
-                        .Id("taxonomyfilters")
-                        .Permission(Permissions.ManageTaxonomies)
-                        .Action("Index", "Admin", s_routeValues)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Taxonomy Filters"], S["Taxonomy Filters"].PrefixPosition(), filters => filters

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/NavigationItemText-taxonomyfilters.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/NavigationItemText-taxonomyfilters.Id.cshtml
@@ -1,15 +1,3 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-tags" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none">
 </span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/AdminMenu.cs
@@ -27,7 +27,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         }
 
         builder
-            .Add(S["Multi-Tenancy"], "after.25", tenancy => tenancy
+            .Add(S["Multi-Tenancy"], S["Multi-Tenancy"].PrefixPosition(), tenancy => tenancy
                 .AddClass("menu-multitenancy")
                 .Id("multitenancy")
                 .Add(S["Tenants"], S["Tenants"].PrefixPosition(), tenant => tenant

--- a/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
@@ -15,7 +15,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
         builder
-            .Add(S["Design"], NavigationConstants.AdminMenuDesignPosition, design => design
+            .Add(S["Design"], S["Design"].PrefixPosition(), design => design
                 .AddClass("design")
                 .Id("design")
                 .Add(S["Themes"], S["Themes"].PrefixPosition(), themes => themes

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
@@ -21,23 +21,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-            .Add(S["Configuration"], configuration => configuration
-                .Add(S["Settings"], settings => settings
-                    .Add(S["X (Twitter)"], S["X (Twitter)"].PrefixPosition(), twitter => twitter
-                        .AddClass("twitter").Id("twitter")
-                        .Action("Index", "Admin", s_routeValues)
-                        .Permission(Permissions.ManageTwitter)
-                        .LocalNav()
-                    )
-                )
-            );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Integrations"], S["Integrations"].PrefixPosition(), integrations => integrations

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenuSignin.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenuSignin.cs
@@ -21,24 +21,6 @@ public sealed class AdminMenuSignIn : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-           .Add(S["Security"], security => security
-               .Add(S["Authentication"], authentication => authentication
-
-               .Add(S["Sign In with X (Twitter)"], S["Sign In with X (Twitter)"].PrefixPosition(), twitter => twitter
-                   .AddClass("twitter")
-                   .Id("twitter")
-                   .Action("Index", "Admin", s_routeValues)
-                   .Permission(Permissions.ManageTwitterSignin)
-                   .LocalNav())
-               )
-           );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/AdminMenu.cs
@@ -14,22 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Configuration"], configuration => configuration
-                    .Add(S["URL Rewriting"], S["URL Rewriting"].PrefixPosition(), rewriting => rewriting
-                        .AddClass("url-rewriting")
-                        .Id("urlRewriting")
-                        .Permission(UrlRewritingPermissions.ManageUrlRewritingRules)
-                        .Action("Index", "Admin", "OrchardCore.UrlRewriting")
-                        .LocalNav()
-                     )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Tools"], tools => tools
                 .Add(S["URL Rewriting"], S["URL Rewriting"].PrefixPosition(), rewriting => rewriting

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/NavigationItemText-urlrewriting.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/NavigationItemText-urlrewriting.Id.cshtml
@@ -1,14 +1,2 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-shuffle" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none"></span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
@@ -23,34 +23,8 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], NavigationConstants.AdminMenuSecurityPosition, security => security
-                    .AddClass("security")
-                    .Id("security")
-                    .Add(S["Users"], S["Users"].PrefixPosition(), users => users
-                        .AddClass("users")
-                        .Id("users")
-                        .Action("Index", "Admin", UserConstants.Features.Users)
-                        .Permission(UsersPermissions.ListUsers)
-                        .Resource(new User())
-                        .LocalNav()
-                    )
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["User Login"], S["User Login"].PrefixPosition(), login => login
-                            .Permission(UsersPermissions.ManageUsers)
-                            .Action("Index", "Admin", s_routeValues)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
-            .Add(S["Access Control"], NavigationConstants.AdminMenuAccessControlPosition, accessControl => accessControl
+            .Add(S["Access Control"], S["Access Control"].PrefixPosition(), accessControl => accessControl
                 .AddClass("accessControl")
                 .Id("accessControl")
                 .Add(S["Users"], S["Users"].PrefixPosition(), users => users

--- a/src/OrchardCore.Modules/OrchardCore.Users/ChangeEmailAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/ChangeEmailAdminMenu.cs
@@ -22,22 +22,6 @@ public sealed class ChangeEmailAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["User Change Email"], S["User Change Email"].PrefixPosition(), email => email
-                            .Permission(UsersPermissions.ManageUsers)
-                            .Action("Index", "Admin", s_routeValues)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Users/RegistrationAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/RegistrationAdminMenu.cs
@@ -22,22 +22,6 @@ public sealed class RegistrationAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Settings"], S["Settings"].PrefixPosition(), settings => settings
-                        .Add(S["User Registration"], S["User Registration"].PrefixPosition(), registration => registration
-                            .Permission(UsersPermissions.ManageUsers)
-                            .Action("Index", "Admin", s_routeValues)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Users/ResetPasswordAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/ResetPasswordAdminMenu.cs
@@ -22,22 +22,6 @@ public sealed class ResetPasswordAdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Security"], security => security
-                    .Add(S["Settings"], settings => settings
-                        .Add(S["User Reset Password"], S["User Reset Password"].PrefixPosition(), password => password
-                            .Permission(UsersPermissions.ManageUsers)
-                            .Action("Index", "Admin", s_routeValues)
-                            .LocalNav()
-                        )
-                    )
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Security"], S["Security"].PrefixPosition(), security => security

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/AdminMenu.cs
@@ -14,20 +14,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-                .Add(S["Workflows"], NavigationConstants.AdminMenuWorkflowsPosition, workflow => workflow
-                    .AddClass("workflows")
-                    .Id("workflows")
-                    .Action("Index", "WorkflowType", "OrchardCore.Workflows")
-                    .Permission(WorkflowsPermissions.ManageWorkflows)
-                    .LocalNav()
-                );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Design"], design => design
                 .Add(S["Workflows"], S["Workflows"].PrefixPosition(), workflow => workflow

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Trimming/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Trimming/AdminMenu.cs
@@ -22,22 +22,6 @@ public sealed class AdminMenu : AdminNavigationProvider
 
     protected override ValueTask BuildAsync(NavigationBuilder builder)
     {
-        if (NavigationHelper.UseLegacyFormat())
-        {
-            builder
-               .Add(S["Configuration"], configuration => configuration
-                   .Add(S["Settings"], settings => settings
-                       .Add(S["Workflow Trimming"], S["Workflow Trimming"], trimming => trimming
-                           .Action("Index", "Admin", s_routeValues)
-                           .Permission(WorkflowsPermissions.ManageWorkflowSettings)
-                           .LocalNav()
-                       )
-                   )
-               );
-
-            return ValueTask.CompletedTask;
-        }
-
         builder
             .Add(S["Settings"], settings => settings
                 .Add(S["Workflow Trimming"], S["Workflow Trimming"].PrefixPosition(), trimming => trimming

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/NavigationItemText-workflows.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/NavigationItemText-workflows.Id.cshtml
@@ -1,14 +1,2 @@
-@using OrchardCore.Navigation
-
-@if (NavigationHelper.UseLegacyFormat())
-{
-    <span class="icon">
-        <i class="fa-solid fa-sitemap fa-rotate-270" aria-hidden="true"></i>
-    </span>
-    <span class="title">@Model.Text</span>
-
-    return;
-}
-
 <span class="icon icon-none"></span>
 <span class="title">@Model.Text</span>

--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationConstants.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationConstants.cs
@@ -7,6 +7,4 @@ public static class NavigationConstants
     public const string AdminId = "admin";
 
     public const string AdminMenuId = "adminMenu";
-
-    public const string LegacyAdminMenuNavigationSwitchKey = "LegacyAdminMenuNavigation";
 }

--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationConstants.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationConstants.cs
@@ -4,22 +4,6 @@ public static class NavigationConstants
 {
     public const string CssClassPrefix = "icon-class-";
 
-    public const string AdminMenuContentPosition = "1";
-
-    public const string AdminMenuDesignPosition = "2";
-
-    public const string AdminMenuSearchPosition = "6";
-
-    public const string AdminMenuAccessControlPosition = "7";
-
-    public const string AdminMenuSecurityPosition = AdminMenuAccessControlPosition;
-
-    public const string AdminMenuAuditTrailPosition = "7.5";
-
-    public const string AdminMenuWorkflowsPosition = "8";
-
-    public const string AdminMenuConfigurationPosition = "100";
-
     public const string AdminId = "admin";
 
     public const string AdminMenuId = "adminMenu";

--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationHelper.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationHelper.cs
@@ -9,12 +9,6 @@ namespace OrchardCore.Navigation;
 
 public static class NavigationHelper
 {
-
-    public static bool UseLegacyFormat()
-    {
-        return AppContext.TryGetSwitch(NavigationConstants.LegacyAdminMenuNavigationSwitchKey, out var enable) && enable;
-    }
-
     /// <summary>
     /// Populates the menu shapes.
     /// </summary>
@@ -345,7 +339,7 @@ public static class NavigationHelper
     {
         if (string.IsNullOrEmpty(parentHash))
         {
-            return XxHash32.HashToUInt32(MemoryMarshal.AsBytes(value.AsSpan())).ToString(CultureInfo.InvariantCulture); 
+            return XxHash32.HashToUInt32(MemoryMarshal.AsBytes(value.AsSpan())).ToString(CultureInfo.InvariantCulture);
         }
 
         var hash = new XxHash32();

--- a/src/docs/releases/4.0.0.md
+++ b/src/docs/releases/4.0.0.md
@@ -44,6 +44,35 @@ If your own settings UI updates values that feed those options, register Orchard
 
 The former Media admin AJAX endpoints on `AdminController` (`MediaApplication`, `Upload`, `DeleteMedia`, `DeleteMediaList`, `MoveMedia`, `MoveMediaList`, `DeleteFolder`, …) have been removed and replaced by the `api/media` minimal-API endpoints described above. Custom code or themes calling those admin routes directly must migrate to the Media API (and account for its authentication scheme — cookie with antiforgery by default).
 
+### Admin Menu Navigation
+
+The legacy admin menu layout has been removed. The `LegacyAdminMenuNavigation` `AppContext` switch, introduced in 3.0 as a transitional aid, no longer has any effect and should be deleted from your startup project:
+
+```csharp
+// No longer supported, remove this line.
+AppContext.SetSwitch("LegacyAdminMenuNavigation", true);
+```
+
+Along with it, the `NavigationHelper.UseLegacyFormat()` helper and the fixed top-level position constants on `NavigationConstants` (`AdminMenuContentPosition`, `AdminMenuDesignPosition`, `AdminMenuSearchPosition`, `AdminMenuAccessControlPosition`, `AdminMenuSecurityPosition`, `AdminMenuAuditTrailPosition`, `AdminMenuWorkflowsPosition`, and `AdminMenuConfigurationPosition`) have been removed.
+
+The main admin menu is no longer ordered by a predefined set of positions. Top-level menus now sort **alphabetically** so that new menus flow naturally into place without needing a reserved position. The only exception is **Settings**, which stays pinned to the very bottom.
+
+This is achieved by giving each top-level menu a free-text position produced by `PrefixPosition()` (which sorts in the free-text tier, after numbers and after `before`/`after` anchors) instead of a hard-coded numeric position. If your module registers a top-level admin menu via an `AdminNavigationProvider` (or `INavigationProvider`), update it to follow the same convention:
+
+```csharp
+// Before
+builder.Add(S["Reports"], "after.15", reports => reports
+    // …
+);
+
+// After — sorts alphabetically among the built-in top-level menus.
+builder.Add(S["Reports"], S["Reports"].PrefixPosition(), reports => reports
+    // …
+);
+```
+
+To keep a menu pinned last (like **Settings**), use the `end` terminal sentinel, e.g. `"end.100"`. Child (sub-menu) items are unaffected and continue to use `PrefixPosition()` with sub-levels or the `before`/`after` anchors as before.
+
 ### Queries Module
 
 `QueryApiController`'s `api/queries/{name}` endpoint previously handled both `GET` and `POST` through a single action sharing one `operationId` (`ApiExecuteQuery`), which OpenAPI does not allow to be reused across operations. It is now split into two actions — `ApiExecuteQueryGet` and `ApiExecuteQueryPost` — with no change to the endpoint's route, verbs, or parameters. If you generate an API client (e.g., with NSwag) against this endpoint, the generated method name(s) will change on your next regeneration.

--- a/test/OrchardCore.Tests/Navigation/NavigationHelperTests.cs
+++ b/test/OrchardCore.Tests/Navigation/NavigationHelperTests.cs
@@ -1,10 +1,7 @@
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.Extensions.Localization;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Implementation;
-using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Navigation;
@@ -42,31 +39,6 @@ public class NavigationHelperTests
         NavigationHelper.ApplySelection(parentShape);
 
     #endregion
-
-    // -----------------------------------------------------------------------
-    // UseLegacyFormat
-    // -----------------------------------------------------------------------
-
-    [Fact]
-    public void UseLegacyFormat_WhenSwitchDisabled_ReturnsFalse()
-    {
-        AppContext.SetSwitch(NavigationConstants.LegacyAdminMenuNavigationSwitchKey, false);
-        Assert.False(NavigationHelper.UseLegacyFormat());
-    }
-
-    [Fact]
-    public void UseLegacyFormat_WhenSwitchEnabled_ReturnsTrue()
-    {
-        AppContext.SetSwitch(NavigationConstants.LegacyAdminMenuNavigationSwitchKey, true);
-        try
-        {
-            Assert.True(NavigationHelper.UseLegacyFormat());
-        }
-        finally
-        {
-            AppContext.SetSwitch(NavigationConstants.LegacyAdminMenuNavigationSwitchKey, false);
-        }
-    }
 
     // -----------------------------------------------------------------------
     // CountPathSegments


### PR DESCRIPTION
## Summary

- Removes the legacy admin menu layout: the `LegacyAdminMenuNavigation` `AppContext` switch (introduced in 3.0 as a transitional aid), `NavigationHelper.UseLegacyFormat()`, and the fixed top-level position constants on `NavigationConstants` (`AdminMenuContentPosition`, `AdminMenuDesignPosition`, `AdminMenuSearchPosition`, `AdminMenuAccessControlPosition`, `AdminMenuSecurityPosition`, `AdminMenuAuditTrailPosition`, `AdminMenuWorkflowsPosition`, `AdminMenuConfigurationPosition`).
- Top-level admin menus now sort **alphabetically** via `PrefixPosition()` instead of predefined positions, so new menus flow into place naturally. **Settings** is the only menu pinned to the bottom (via the `end` terminal sentinel, `end.100`).
- Every `AdminNavigationProvider` implementation was reviewed to ensure all top-level menus use `PrefixPosition()` except Settings. The Demo module's top-level menu was updated from a hard-coded `"10"` to `PrefixPosition()` for consistency.
- Documented the change in `src/docs/releases/4.0.0.md` under Breaking Changes, including a before/after migration snippet for module authors.

## Scope of the ordering change

This does **not** touch every menu. Only the **top-level** menus that previously carried a fixed position were switched to alphabetical ordering. Sub-menu (child) items, and any menus that already used `PrefixPosition()`, keep their existing behavior.

The top-level menus whose position changed:

| Top-level menu | Old position | New position | Owner module |
|---|---|---|---|
| Content | `AdminMenuContentPosition` (`"1"`) | `PrefixPosition()` (alphabetical) | Contents |
| Design | `AdminMenuDesignPosition` (`"2"`) | `PrefixPosition()` (alphabetical) | Themes |
| Search | `AdminMenuSearchPosition` (`"6"`) | `PrefixPosition()` (alphabetical) | Search modules |
| Access Control | `AdminMenuAccessControlPosition` (`"7"`) | `PrefixPosition()` (alphabetical) | Users |
| Media | `"after.15"` | `PrefixPosition()` (alphabetical) | Media |
| Multi-Tenancy | `"after.25"` | `PrefixPosition()` (alphabetical) | Tenants |
| Tools | `"end.50"` | `PrefixPosition()` (alphabetical) | Settings |
| Demo | `"10"` | `PrefixPosition()` (alphabetical) | Demo |
| **Settings** | `"end.100"` | `"end.100"` (**unchanged** — stays pinned last) | Settings |

The removed constants `AdminMenuSecurityPosition` (`"7"`), `AdminMenuAuditTrailPosition` (`"7.5"`), `AdminMenuWorkflowsPosition` (`"8"`), and `AdminMenuConfigurationPosition` (`"100"`) were tied to menus that are no longer top level (Audit Trail now lives under **Tools**; Security/Workflows are sub-items; the **Configuration** menu was removed).

## Notes

- Child (sub-menu) items are unaffected and continue to use `PrefixPosition()` sub-levels / `before`/`after` anchors.
- No remaining references to the removed constants or `UseLegacyFormat()` exist in `src/` or `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)