### PR TITLE
Fix 'This class is deprecated. Use FileSizeHelper instead.' build error (Lombiq Technologies: OCORE-288)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/GetPermittedStorageEndpoint.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Endpoints/Api/GetPermittedStorageEndpoint.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -30,7 +29,8 @@ public static class GetPermittedStorageEndpoint
         HttpContext httpContext,
         IAuthorizationService authorizationService,
         IMediaFileStore mediaFileStore,
-        IStringLocalizer<MediaApiEndpoints> localizer)
+        IStringLocalizer<MediaApiEndpoints> localizer,
+        FileSizeHelper fileSizeHelper)
     {
         if (!await authorizationService.AuthorizeAsync(httpContext.User, MediaPermissions.ManageMedia)
             || !await authorizationService.AuthorizeAsync(httpContext.User, MediaPermissions.ManageMediaFolder, (object)string.Empty))
@@ -39,7 +39,7 @@ public static class GetPermittedStorageEndpoint
         }
 
         var bytes = await mediaFileStore.GetPermittedStorageAsync();
-        var text = bytes == null ? localizer["Unspecified"] : FileSizeHelpers.FormatAsBytes(bytes.Value);
+        var text = bytes == null ? localizer["Unspecified"] : fileSizeHelper.FormatSize(bytes.Value);
 
         return TypedResults.Ok(new PermittedStorageDto { Bytes = bytes, Text = text });
     }

--- a/src/OrchardCore/OrchardCore.Media.Core/Helpers/FileSizeHelper.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/Helpers/FileSizeHelper.cs
@@ -18,13 +18,13 @@ public sealed class FileSizeHelper
     /// Formats the given file size in bytes into a human-readable string with appropriate units.
     /// </summary>
     /// <param name="bytes">The file size in bytes.</param>
-    /// <param name="decimalPlaces">The number of decimal places to include in the formatted string.</param>
+    /// <param name="digits">The number of fractional digits in the size value..</param>
     /// <returns>A human-readable string representing the file size.</returns>
-    public string FormatSize(long bytes, int decimalPlaces = 2)
+    public string FormatSize(long bytes, int digits = 2)
     {
         if (bytes < 0)
         {
-            return "-" + FormatSize(-bytes, decimalPlaces);
+            return "-" + FormatSize(-bytes, digits);
         }
 
         if (bytes == 0)
@@ -33,7 +33,7 @@ public sealed class FileSizeHelper
         }
 
         var magnitude = (int)Math.Log(bytes, 1024);
-        var adjustedSize = Math.Round(bytes / Math.Pow(1024, magnitude), decimalPlaces);
+        var adjustedSize = Math.Round(bytes / Math.Pow(1024, magnitude), digits);
 
         return magnitude switch
         {

--- a/src/OrchardCore/OrchardCore.Media.Core/Helpers/FileSizeHelper.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/Helpers/FileSizeHelper.cs
@@ -33,7 +33,7 @@ public sealed class FileSizeHelper
         }
 
         var magnitude = (int)Math.Log(bytes, 1024);
-        var adjustedSize = bytes / Math.Pow(1024, magnitude);
+        var adjustedSize = Math.Round(bytes / Math.Pow(1024, magnitude), decimalPlaces);
 
         return magnitude switch
         {

--- a/test/OrchardCore.Tests/Media/FileSizerHelperTests.cs
+++ b/test/OrchardCore.Tests/Media/FileSizerHelperTests.cs
@@ -108,8 +108,8 @@ public class FileSizeHelperTests
         var fileSizeHelper = new FileSizeHelper(_stringLocalizerMock.Object);
 
         // Act & Assert
-        var a = fileSizeHelper.FormatSize(1536, decimalPlaces: 0);
-        var b = fileSizeHelper.FormatSize(1536, decimalPlaces: 5);
+        var a = fileSizeHelper.FormatSize(1536, digits: 0);
+        var b = fileSizeHelper.FormatSize(1536, digits: 5);
 
         Assert.Equal(a, b);
     }

--- a/test/OrchardCore.Tests/Media/FileSizerHelperTests.cs
+++ b/test/OrchardCore.Tests/Media/FileSizerHelperTests.cs
@@ -50,7 +50,7 @@ public class FileSizeHelperTests
 
         // Act & Assert
         Assert.Equal("1 B", fileSizeHelper.FormatSize(1));
-        Assert.Equal("1.5 B", fileSizeHelper.FormatSize(1536));
+        Assert.Equal($"{Math.Round(1536d / 1024, 2).ToString(CultureInfo.CurrentCulture)} B", fileSizeHelper.FormatSize(1536));
         Assert.Equal("2 B", fileSizeHelper.FormatSize(2048));
     }
 
@@ -92,7 +92,7 @@ public class FileSizeHelperTests
             6 => "PB",
             _ => "EB"
         };
-        var expected = string.Format(CultureInfo.InvariantCulture, "{0} " + unit, adjustedSize);
+        var expected = $"{Math.Round(adjustedSize, 2).ToString(CultureInfo.CurrentCulture)} {unit}";
 
         // Act
         var result = fileSizeHelper.FormatSize(bytes);
@@ -102,15 +102,13 @@ public class FileSizeHelperTests
     }
 
     [Fact]
-    public void DecimalPlacesParameter_IsIgnored_ByCurrentImplementation()
+    public void DigitsParameter_IsHandledCorrectly()
     {
         // Arrange
         var fileSizeHelper = new FileSizeHelper(_stringLocalizerMock.Object);
 
         // Act & Assert
-        var a = fileSizeHelper.FormatSize(1536, digits: 0);
-        var b = fileSizeHelper.FormatSize(1536, digits: 5);
-
-        Assert.Equal(a, b);
+        Assert.Equal("2 B", fileSizeHelper.FormatSize(1536, digits: 0));
+        Assert.Equal($"{Math.Round(1536d / 1024, 5).ToString(CultureInfo.CurrentCulture)} B", fileSizeHelper.FormatSize(1536, digits: 5));
     }
 }


### PR DESCRIPTION
Fix #19832.

Also fixing that file size formatting wasn't taking decimal places into account.