### PR TITLE
Update Scalar to fix OpenAPI reference rendering

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,7 +64,7 @@
     <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="7.6.0" />
     <PackageVersion Include="OrchardCore.Translations.All" Version="3.0.0" />
     <PackageVersion Include="PdfPig" Version="0.1.16" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.0.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.12.9" />
     <PackageVersion Include="Shortcodes" Version="1.3.6" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="NetVips" Version="3.2.0" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenApi/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenApi/Startup.cs
@@ -331,7 +331,7 @@ public sealed class ScalarUIStartup : StartupBase
                 .WithTitle("OrchardCore OpenAPI Documentation")
                 // Disable Scalar's default external proxy so all requests (token + API)
                 // go directly from the browser to this server.
-                .WithProxyUrl("");
+                .WithProxy("");
 
             // Inject the self-bootstrapping silent-auth bundle; it wraps window.fetch on load so
             // the bearer token is attached to API calls (spec/UI fetches keep the cookie).

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/OpenApiTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/OpenApiTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using OrchardCore.Tests.Functional.Helpers;
@@ -405,16 +406,44 @@ public sealed class OpenApiTests : CmsTestBase, IClassFixture<CmsSetupFixture>
         await EnableOpenApiAsync(page);
         await FeatureHelper.EnableFeatureAsync(page, $"/{Tenant.Prefix}", "OrchardCore.OpenApi.ScalarUI");
 
-        var response = await page.RunAndWaitForResponseAsync(
-            async () =>
+        var pageErrors = new ConcurrentQueue<string>();
+        var consoleErrors = new ConcurrentQueue<string>();
+        page.PageError += (_, error) => pageErrors.Enqueue(error);
+        page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
             {
-                await page.GotoAsync($"/{Tenant.Prefix}/scalar/v1");
-                await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
-            },
+                consoleErrors.Enqueue(message.Text);
+            }
+        };
+
+        var response = await page.RunAndWaitForResponseAsync(
+            async () => await page.GotoAsync($"/{Tenant.Prefix}/scalar/v1"),
             r => r.Url.Contains("/swagger/v1/swagger.json"));
 
         Assert.Equal(200, response.Status);
-        await Assertions.Expect(page.Locator(".sidebar").First).ToContainTextAsync("GetEndpoint");
+        Assert.Equal($"/{Tenant.Prefix}/swagger/v1/swagger.json", new Uri(response.Url).AbsolutePath);
+
+        // Exercise the full Blog reference with Scalar's default configuration. Vue's
+        // deferred Teleport regression could unmount the sidebar after the schema loaded.
+        var sidebar = page.GetByRole(AriaRole.Navigation, new() { Name = "Sidebar for OpenApi V1", Exact = true });
+        var getEndpoint = sidebar.GetByRole(AriaRole.Button, new() { Name = "Open Group GetEndpoint", Exact = true });
+        await Assertions.Expect(getEndpoint).ToBeVisibleAsync();
+        await getEndpoint.ClickAsync();
+
+        var operation = page.GetByRole(AriaRole.Region, new() { Name = "GetEndpoint", Exact = true })
+            .GetByRole(AriaRole.Region, new() { Name = "/api/content/{contentItemId}", Exact = true });
+        await Assertions.Expect(operation).ToBeVisibleAsync();
+        await operation.GetByRole(AriaRole.Button, new() { Name = "Test Request (get /api/content/{contentItemId})", Exact = true }).ClickAsync();
+        var apiClient = page.GetByRole(AriaRole.Dialog, new() { Name = "API Client", Exact = true });
+        await Assertions.Expect(apiClient.GetByRole(AriaRole.Button, new() { Name = "Send Request" })).ToBeVisibleAsync();
+        await page.Keyboard.PressAsync("Escape");
+        await Assertions.Expect(apiClient).Not.ToBeVisibleAsync();
+        await Assertions.Expect(sidebar).ToBeVisibleAsync();
+        await Assertions.Expect(sidebar.GetByRole(AriaRole.Button, new() { Name = "Close Group GetEndpoint", Exact = true })).ToBeVisibleAsync();
+
+        Assert.Empty(pageErrors);
+        Assert.DoesNotContain(consoleErrors, error => error.Contains("TypeError", StringComparison.Ordinal));
 
         await page.CloseAsync();
     }
@@ -482,12 +511,15 @@ public sealed class OpenApiTests : CmsTestBase, IClassFixture<CmsSetupFixture>
         // the protected "Api"-scheme endpoint to prove the token is attached: an unauthenticated
         // request to it returns 401. The unfilled {contentItemId} placeholder is sent as a
         // literal segment, which still matches the route and exercises authentication.
-        await page.Locator(".sidebar a", new() { HasText = "GetEndpoint" }).First.ClickAsync();
-        var operation = page.Locator("[id='tag/getendpoint/GET/api/content/{contentItemId}']");
-        await operation.Locator("button.show-api-client-button").ClickAsync();
+        var sidebar = page.GetByRole(AriaRole.Navigation, new() { Name = "Sidebar for OpenApi V1", Exact = true });
+        await sidebar.GetByRole(AriaRole.Button, new() { Name = "Open Group GetEndpoint", Exact = true }).ClickAsync();
+        var operation = page.GetByRole(AriaRole.Region, new() { Name = "GetEndpoint", Exact = true })
+            .GetByRole(AriaRole.Region, new() { Name = "/api/content/{contentItemId}", Exact = true });
+        await operation.GetByRole(AriaRole.Button, new() { Name = "Test Request (get /api/content/{contentItemId})", Exact = true }).ClickAsync();
 
+        var apiClient = page.GetByRole(AriaRole.Dialog, new() { Name = "API Client", Exact = true });
         var response = await page.RunAndWaitForResponseAsync(
-            async () => await page.GetByRole(AriaRole.Button, new() { Name = "Send Request", Exact = true }).ClickAsync(),
+            async () => await apiClient.GetByRole(AriaRole.Button, new() { Name = "Send Request" }).ClickAsync(),
             r => r.Url.Contains("/api/content/"));
 
         Assert.NotEqual(401, response.Status);


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

## Summary

- Update `Scalar.AspNetCore` from **2.0.0 to 2.12.9**, the first verified package with the fixed Vue runtime. Actual NuGet resources for net8.0/net9.0/net10.0 embed Vue **3.5.26**; 2.12.8 still embeds **3.5.21**.
- Replace obsolete `WithProxyUrl("")` with equivalent `WithProxy("")`. Keep `MapScalarApiReference`, the intentionally unprefixed `/swagger/v1/swagger.json` route pattern, title, injected authentication head content, and unset `BundleUrl`.
- Strengthen the existing Blog-tenant regression to exercise visible/clickable GetEndpoint, operation rendering, opening/closing the API client, retained sidebar, exact tenant-prefixed schema URL, and absence of page errors/console TypeErrors. Update both Scalar tests to the new accessible navigation/button/region/dialog names, including the Send Request button's platform shortcut suffix.

No observer/history changes, force clicks, schema reductions, or timing workarounds were added. The existing network-idle wait in the rendering regression is no longer needed.

Fixes #19834.

## Validation

- Restored and built `src/OrchardCore.Modules/OrchardCore.OpenApi/OrchardCore.OpenApi.csproj` and `test/OrchardCore.Tests.Functional/OrchardCore.Tests.Functional.csproj` for **net10.0**.
- **17/17 OpenApi functional tests passed in Chromium**, no skips, including Scalar's silently authenticated protected API request (149.148 seconds):
  ```sh
  ORCHARD_TEST_DOCKER_SERVICES=false PLAYWRIGHT_TRACING=1 \
    dotnet test/OrchardCore.Tests.Functional/bin/Debug/net10.0/OrchardCore.Tests.Functional.dll \
    -class '*OpenApiTests'
  ```
- An additional out-of-repo Chromium **145.0.7632.18** replay used the exact original **50,869-byte** Blog schema (32 paths, 15 schemas; SHA-256 `e3396cef8f4d49580d4b63464c7d7dfc209a01b8f69bd506fc7e6c0d4e691be3`), unchanged HTML/configuration captured from Orchard, and the actual packaged Scalar assets. The page, both Scalar scripts, and schema returned **200**; GetEndpoint and its operation/client rendered; the sidebar survived opening/closing the client; there were **zero page errors and no console TypeErrors/null.style errors**. Native observers and history were untouched.
- An out-of-repo API/configuration smoke project restored and compiled the retained Scalar API calls for **net8.0, net9.0, and net10.0**, with runtime assertions passing on installed .NET 8 and 10. Both proxy methods assign the same `ProxyUrl` property. The package adds no NuGet dependencies.

## Scope and limitations

This checkout supports net10.0 only. SDK roll-forward selected the installed .NET 11 RC SDK; functional tests ran on .NET 10.0.11. Its `dotnet test` MTP handshake failed before discovery, so the same built tests were run successfully through the native xUnit executable. No .NET 9 runtime is installed, so net9.0 package compatibility was compile-only.

The standalone replay intentionally has no OpenID server and therefore logs the expected missing-discovery/silent-sign-in errors, not Vue errors; the real Orchard authentication test passes. The fresh Blog functional fixture's unmodified schema is 35,923 bytes, so the separately recorded 50,869-byte reproduction schema was also exercised explicitly.

Scalar assets are supplied by the NuGet package. Orchard's generated frontend assets, NSwag clients, schema/API implementation, and documented configuration are unchanged, so no asset/client regeneration or documentation change is needed.