### PR TITLE
Secure application static file resolution

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/ApplicationStaticFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/ApplicationStaticFileProvider.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.Modules.FileProviders;
+
+namespace OrchardCore.Modules;
+
+/// <summary>
+/// Provides the application's physical web-root files through its module URL prefix.
+/// </summary>
+public sealed class ApplicationStaticFileProvider : IStaticFileProvider
+{
+    private readonly string _applicationPath;
+    private readonly IFileProvider _webRootFileProvider;
+
+    public ApplicationStaticFileProvider(
+        IApplicationContext applicationContext,
+        IWebHostEnvironment environment)
+    {
+        _applicationPath = applicationContext.Application.Name + '/';
+        _webRootFileProvider = environment.WebRootFileProvider;
+    }
+
+    public IDirectoryContents GetDirectoryContents(string subpath)
+    {
+        return NotFoundDirectoryContents.Singleton;
+    }
+
+    public IFileInfo GetFileInfo(string subpath)
+    {
+        if (subpath == null)
+        {
+            return new NotFoundFileInfo(subpath);
+        }
+
+        var path = NormalizePath(subpath);
+
+        if (path.StartsWith(_applicationPath, StringComparison.Ordinal))
+        {
+            return _webRootFileProvider.GetFileInfo(path[_applicationPath.Length..]);
+        }
+
+        return new NotFoundFileInfo(subpath);
+    }
+
+    public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
+
+    private static string NormalizePath(string path)
+    {
+        if (!path.Contains('\\') &&
+            !path.StartsWith('/') &&
+            !path.EndsWith('/') &&
+            !path.Contains("//", StringComparison.Ordinal))
+        {
+            return path;
+        }
+
+        return path.Replace('\\', '/').Trim('/').Replace("//", "/");
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/ModuleEmbeddedStaticFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/ModuleEmbeddedStaticFileProvider.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.FileProviders.Physical;
 using Microsoft.Extensions.Primitives;
 
 namespace OrchardCore.Modules;
@@ -44,16 +43,8 @@ public class ModuleEmbeddedStaticFileProvider : IModuleStaticFileProvider
                 // Resolve the embedded file subpath: "wwwroot/**/*.*"
                 var fileSubPath = Module.WebRoot + path[(index + 1)..];
 
-                if (module != application.Name)
-                {
-                    // Get the embedded file info from the module assembly.
-                    return application.GetModule(module).GetFileInfo(fileSubPath);
-                }
-
-                // Application static files can be still requested in a regular way "/**/*.*".
-                // Here, it's done through the Application's module "{ApplicationName}/**/*.*".
-                // But we still serve them from the same physical files "{WebRootPath}/**/*.*".
-                return new PhysicalFileInfo(new FileInfo(application.Root + fileSubPath));
+                // Get the embedded file info from the module assembly.
+                return application.GetModule(module).GetFileInfo(fileSubPath);
             }
         }
 

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -242,26 +242,32 @@ public static class ServiceCollectionExtensions
     {
         builder.ConfigureServices(services =>
         {
+            // Serves the application's physical web-root files through the application module prefix.
+            services.AddSingleton<ApplicationStaticFileProvider>();
+
+            // Serves static files embedded in module assemblies under their module prefixes.
+            services.AddSingleton<ModuleEmbeddedStaticFileProvider>();
+
+            // Serves physical module project files during development so asset changes are available without repackaging.
+            services.AddSingleton<ModuleProjectStaticFileProvider>();
+
             services.AddSingleton<IModuleStaticFileProvider>(serviceProvider =>
             {
                 var env = serviceProvider.GetRequiredService<IHostEnvironment>();
-                var appContext = serviceProvider.GetRequiredService<IApplicationContext>();
+                var fileProviders = new List<IStaticFileProvider>();
 
-                IModuleStaticFileProvider fileProvider;
                 if (env.IsDevelopment())
                 {
-                    var fileProviders = new List<IStaticFileProvider>
-                    {
-                        new ModuleProjectStaticFileProvider(appContext),
-                        new ModuleEmbeddedStaticFileProvider(appContext),
-                    };
-                    fileProvider = new ModuleCompositeStaticFileProvider(fileProviders);
+                    // Prefer project files while developing, then fall back to packaged embedded assets.
+                    fileProviders.Add(serviceProvider.GetRequiredService<ModuleProjectStaticFileProvider>());
                 }
-                else
-                {
-                    fileProvider = new ModuleEmbeddedStaticFileProvider(appContext);
-                }
-                return fileProvider;
+
+                fileProviders.Add(serviceProvider.GetRequiredService<ModuleEmbeddedStaticFileProvider>());
+
+                // Application files are physical rather than embedded, so resolve them last through the configured web root.
+                fileProviders.Add(serviceProvider.GetRequiredService<ApplicationStaticFileProvider>());
+
+                return new ModuleCompositeStaticFileProvider(fileProviders);
             });
 
             services.AddSingleton<IStaticFileProvider>(serviceProvider =>

--- a/test/OrchardCore.Abstractions.Tests/Modules/ApplicationStaticFileProviderTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/ApplicationStaticFileProviderTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Moq;
+using Xunit;
+
+namespace OrchardCore.Modules;
+
+public sealed class ApplicationStaticFileProviderTests : IDisposable
+{
+    private readonly string _applicationName = typeof(ApplicationStaticFileProviderTests).Assembly.GetName().Name;
+    private readonly string _root = Directory.CreateTempSubdirectory("application-static-file-provider-tests").FullName;
+
+    [Fact]
+    public void GetFileInfo_ApplicationFile_DelegatesWithoutModulePrefix()
+    {
+        var expected = Mock.Of<IFileInfo>();
+        var webRootFileProvider = new Mock<IFileProvider>();
+        webRootFileProvider
+            .Setup(provider => provider.GetFileInfo("assets/site.css"))
+            .Returns(expected);
+
+        var fileInfo = CreateProvider(webRootFileProvider.Object)
+            .GetFileInfo($"/{_applicationName}/assets/site.css");
+
+        Assert.Same(expected, fileInfo);
+        webRootFileProvider.Verify(
+            provider => provider.GetFileInfo("assets/site.css"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetFileInfo_DifferentModule_ReturnsNotFound()
+    {
+        var webRootFileProvider = new Mock<IFileProvider>();
+
+        var fileInfo = CreateProvider(webRootFileProvider.Object)
+            .GetFileInfo("/Different.Module/assets/site.css");
+
+        Assert.False(fileInfo.Exists);
+        webRootFileProvider.Verify(
+            provider => provider.GetFileInfo(It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void GetFileInfo_CustomWebRoot_ReturnsFile()
+    {
+        var webRoot = Directory.CreateDirectory(Path.Combine(_root, "custom-web-root"));
+        var filePath = Path.Combine(webRoot.FullName, "test.txt");
+        File.WriteAllText(filePath, "content");
+
+        using var webRootFileProvider = new PhysicalFileProvider(webRoot.FullName);
+        var fileInfo = CreateProvider(webRootFileProvider)
+            .GetFileInfo($"/{_applicationName}/test.txt");
+
+        Assert.True(fileInfo.Exists);
+        Assert.Equal(filePath, fileInfo.PhysicalPath);
+    }
+
+    [Theory]
+    [InlineData("../outside.txt")]
+    [InlineData("..\\outside.txt")]
+    public void GetFileInfo_PathOutsideWebRoot_ReturnsNotFound(string subpath)
+    {
+        var webRoot = Directory.CreateDirectory(Path.Combine(_root, Module.WebRootPath));
+        File.WriteAllText(Path.Combine(_root, "outside.txt"), "sensitive content");
+
+        using var webRootFileProvider = new PhysicalFileProvider(webRoot.FullName);
+        var fileInfo = CreateProvider(webRootFileProvider)
+            .GetFileInfo($"/{_applicationName}/{subpath}");
+
+        Assert.False(fileInfo.Exists);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_root, true);
+        GC.SuppressFinalize(this);
+    }
+
+    private ApplicationStaticFileProvider CreateProvider(IFileProvider webRootFileProvider)
+    {
+        var environment = Mock.Of<IWebHostEnvironment>(e =>
+            e.ApplicationName == _applicationName &&
+            e.ContentRootPath == _root &&
+            e.WebRootFileProvider == webRootFileProvider);
+
+        var application = new Application(environment, [new Module(_applicationName)]);
+        var applicationContext = Mock.Of<IApplicationContext>(c => c.Application == application);
+
+        return new ApplicationStaticFileProvider(applicationContext, environment);
+    }
+}

--- a/test/OrchardCore.Abstractions.Tests/Modules/ModuleEmbeddedStaticFileProviderTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/ModuleEmbeddedStaticFileProviderTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace OrchardCore.Modules;
+
+public sealed class ModuleEmbeddedStaticFileProviderTests : IDisposable
+{
+    private readonly string _applicationName = typeof(ModuleEmbeddedStaticFileProviderTests).Assembly.GetName().Name;
+    private readonly string _root = Directory.CreateTempSubdirectory("module-static-file-provider-tests").FullName;
+
+    [Fact]
+    public void GetFileInfo_ApplicationPhysicalFile_ReturnsNotFound()
+    {
+        var webRoot = Directory.CreateDirectory(Path.Combine(_root, Module.WebRootPath));
+        var filePath = Path.Combine(webRoot.FullName, "test.txt");
+        File.WriteAllText(filePath, "content");
+
+        var fileInfo = CreateProvider().GetFileInfo($"/{_applicationName}/test.txt");
+
+        Assert.False(fileInfo.Exists);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_root, true);
+        GC.SuppressFinalize(this);
+    }
+
+    private ModuleEmbeddedStaticFileProvider CreateProvider()
+    {
+        var environment = Mock.Of<IHostEnvironment>(e =>
+            e.ApplicationName == _applicationName &&
+            e.ContentRootPath == _root);
+
+        var application = new Application(environment, [new Module(_applicationName)]);
+        var applicationContext = Mock.Of<IApplicationContext>(c => c.Application == application);
+
+        return new ModuleEmbeddedStaticFileProvider(applicationContext);
+    }
+}


### PR DESCRIPTION
## Summary
- separate application web-root files from embedded module asset resolution
- delegate application-prefixed static files to `IWebHostEnvironment.WebRootFileProvider`
- prevent application-module paths from resolving outside the configured web root
- document provider registration and resolution order

## Validation
- `dotnet build OrchardCore.slnx -c Release`
- `dotnet test test/OrchardCore.Abstractions.Tests/OrchardCore.Abstractions.Tests.csproj -c Release --no-build --no-restore` (47 passed)
- `dotnet test test/OrchardCore.Tests/OrchardCore.Tests.csproj -c Release --no-build --no-restore` (2,848 passed, 1 skipped)
- live Kestrel check: application-prefixed asset returned 200; encoded-backslash traversal returned 404
- representative functional test passed in isolation; the complete functional suite reproduces its existing parallel setup-view failure on an untouched `main` worktree