### PR TITLE
Constrain media roots and recipe writes to tenant-owned directories

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
@@ -10,7 +10,7 @@ using OrchardCore.Recipes.Services;
 namespace OrchardCore.Media.Recipes;
 
 /// <summary>
-/// This recipe step creates a set of queries.
+/// Imports files into the tenant's media store using relative target paths.
 /// </summary>
 public sealed class MediaStep : NamedRecipeStepHandler
 {
@@ -42,6 +42,13 @@ public sealed class MediaStep : NamedRecipeStepHandler
 
         foreach (var file in model.Files)
         {
+            if (!MediaFileStorePathHelper.IsValidRelativePath(file.TargetPath))
+            {
+                context.Errors.Add(S["Media target path must be a relative file path without traversal segments: '{0}'", file.TargetPath]);
+
+                continue;
+            }
+
             if (!_mediaOptions.IsFileExtensionAllowed(Path.GetExtension(file.TargetPath), hasAdditionalPermission: true))
             {
                 context.Errors.Add(S["File extension not allowed: '{0}'", file.TargetPath]);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStorePathHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStorePathHelper.cs
@@ -4,6 +4,23 @@ namespace OrchardCore.Media.Services;
 
 internal static class MediaFileStorePathHelper
 {
+    public static bool IsValidRelativePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) ||
+            path[0] is '/' or '\\' ||
+            path.Contains(':') ||
+            path.Contains('\0'))
+        {
+            return false;
+        }
+
+        // Apply the same rules on every platform, including Windows path aliases.
+        return path.Split(PathExtensions.PathSeparators).All(segment =>
+            !string.IsNullOrWhiteSpace(segment) &&
+            !segment.EndsWith('.') &&
+            !segment.EndsWith(' '));
+    }
+
     /// <summary>
     /// Resolves and sanitizes a media path, collapsing any path-traversal segments (e.g. <c>..</c>)
     /// against the actual file store so that the returned path can be safely used in authorization checks.

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsValidator.cs
@@ -6,6 +6,13 @@ internal sealed class MediaOptionsValidator : IValidateOptions<MediaOptions>
 {
     public ValidateOptionsResult Validate(string name, MediaOptions options)
     {
+        if (!MediaFileStorePathHelper.IsValidRelativePath(options.AssetsPath?.TrimEnd(PathExtensions.PathSeparators)))
+        {
+            return ValidateOptionsResult.Fail(
+                "The OrchardCore_Media setting AssetsPath must be a relative subdirectory of the tenant's data directory, " +
+                "without empty, '.' or '..' segments, drive prefixes, or segments ending in a dot or space.");
+        }
+
         var overlappingExtensions = options.AllowedFileExtensions
             .Intersect(options.RestrictedFileExtensions, StringComparer.OrdinalIgnoreCase)
             .Order(StringComparer.OrdinalIgnoreCase)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -272,18 +272,25 @@ public sealed class Startup : StartupBase
 
     }
 
-    private static string GetMediaPath(
+    internal static string GetMediaPath(
         ShellOptions shellOptions,
         ShellSettings shellSettings,
         string assetsPath
     )
     {
-        return PathExtensions.Combine(
+        assetsPath = assetsPath?.TrimEnd(PathExtensions.PathSeparators);
+
+        if (!MediaFileStorePathHelper.IsValidRelativePath(assetsPath))
+        {
+            throw new ArgumentException("The media assets path must be a relative subdirectory of the tenant's data directory.", nameof(assetsPath));
+        }
+
+        return Path.GetFullPath(Path.Combine(
             shellOptions.ShellsApplicationDataPath,
             shellOptions.ShellsContainerName,
             shellSettings.Name,
-            assetsPath
-        );
+            assetsPath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar)
+        ));
     }
 }
 

--- a/src/OrchardCore/OrchardCore.FileStorage.FileSystem/FileSystemStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.FileSystem/FileSystemStore.cs
@@ -15,7 +15,7 @@ public class FileSystemStore : IFileStore
     public FileSystemStore(string fileSystemPath, ILogger<FileSystemStore> logger)
     {
         _logger = logger;
-        _fileSystemPath = Path.GetFullPath(fileSystemPath);
+        _fileSystemPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(fileSystemPath));
     }
 
     public Task<IFileStoreEntry> GetFileInfoAsync(string path)
@@ -424,10 +424,12 @@ public class FileSystemStore : IFileStore
         {
             path = this.NormalizePath(path);
 
-            var physicalPath = string.IsNullOrEmpty(path) ? _fileSystemPath : Path.Combine(_fileSystemPath, path);
+            var physicalPath = string.IsNullOrEmpty(path) ? _fileSystemPath : Path.GetFullPath(Path.Combine(_fileSystemPath, path));
 
             // Verify that the resulting path is inside the root file system path.
-            var pathIsAllowed = Path.GetFullPath(physicalPath).StartsWith(_fileSystemPath, StringComparison.OrdinalIgnoreCase);
+            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            var rootPrefix = Path.EndsInDirectorySeparator(_fileSystemPath) ? _fileSystemPath : _fileSystemPath + Path.DirectorySeparatorChar;
+            var pathIsAllowed = physicalPath.Equals(_fileSystemPath, comparison) || physicalPath.StartsWith(rootPrefix, comparison);
             if (!pathIsAllowed)
             {
                 throw new FileStoreException($"The path '{path}' resolves to a physical path outside the file system store root.");

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/MediaOptions.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/MediaOptions.cs
@@ -70,7 +70,9 @@ public class MediaOptions
     public PathString AssetsRequestPath { get; set; }
 
     /// <summary>
-    /// The name of the folder used to store media assets inside the App_Data folder.
+    /// The relative subdirectory used to store media assets inside the tenant's data directory
+    /// (by default, App_Data/Sites/{tenant}/Media). Absolute paths, drive prefixes, empty segments,
+    /// and segments ending in a dot or space (including "." and "..") are not allowed.
     /// </summary>
     public string AssetsPath { get; set; }
 

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -341,7 +341,7 @@ The following configuration values are used by default and can be customized:
     "CdnBaseUrl": "https://your-cdn.com",
     // The path used when serving media assets.
     "AssetsRequestPath": "/media",
-    // The name of the folder used to store media assets inside the App_Data folder.
+    // The relative subdirectory used to store media assets inside the tenant's data directory.
     "AssetsPath": "Media",
     // Whether to use a token in the query string to prevent disc filling.
     "UseTokenizedQueryString": true,
@@ -409,6 +409,20 @@ The following configuration values are used by default and can be customized:
 }
 ```
 
+### Media storage location
+
+`AssetsPath` is relative to the current tenant's data directory, which defaults to `App_Data/Sites/{tenant}`.
+The default value `Media` therefore stores files in `App_Data/Sites/{tenant}/Media`. Nested directories such as
+`Assets/Media` are supported, and both `/` and `\` can be used as separators.
+
+Absolute paths, drive prefixes (including drive-relative paths such as `C:Media`), empty paths or segments,
+and segments ending in a dot or space (including `.` and `..`) are rejected. A trailing directory separator is
+allowed. Invalid configuration fails Media options validation instead of exposing another tenant's data or
+the application directory through the media store or static file provider.
+
+To relocate tenant data to another volume, configure the host's application data location (for example, with
+the `ORCHARD_APP_DATA` environment variable) rather than using an absolute path or traversal in `AssetsPath`.
+
 ### Temporary upload storage location
 
 When files are uploaded, in-progress data (chunked uploads, resumable TUS uploads) is written to a temporary
@@ -431,6 +445,11 @@ Users need the existing media upload and folder permissions for all uploads. The
     Permission-gating risky or active file types is defense in depth, not file sanitization. Validate file contents separately, use a restrictive content security policy, and configure the web server and storage provider appropriately for the file types you accept.
 
 Recipe media imports are trusted system operations and do not use an ambient HTTP user. They may import extensions from either configured list, but extensions absent from both lists are rejected.
+The `TargetPath` (or its `Path` alias) must be a relative file path within the media store. Rooted paths,
+drive prefixes, empty segments, and segments ending in a dot or space (including `.` and `..`) are rejected
+before any source is read or file is overwritten. This applies equally to `Base64`, `SourcePath`, and `SourceUrl`
+imports. Valid imports can overwrite existing media files, but cannot target application assemblies or files
+outside the tenant's media directory.
 
 To configure the `StaticFileOptions` in more detail, including event handlers, for the Media Library `StaticFileMiddleware` apply:
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.FileStorage/FileSystemStoreTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.FileStorage/FileSystemStoreTests.cs
@@ -99,4 +99,71 @@ public class FileSystemStoreTests : IDisposable
             Assert.Contains(entries, e => e.IsDirectory && e.Name == NtfsInvalidFolder);
         }
     }
+
+    [Theory]
+    [InlineData("Media", "Media-other")]
+    [InlineData("Media/", "Media-other")]
+    [InlineData("Media", "MediaSibling")]
+    public async Task FileOperations_SiblingWithMatchingRootPrefix_RejectAccess(string storePath, string siblingPath)
+    {
+        var storeRoot = Directory.CreateDirectory(Path.Combine(_root, storePath)).FullName;
+        var siblingRoot = Directory.CreateDirectory(Path.Combine(_root, siblingPath)).FullName;
+        var assemblyPath = Path.Combine(siblingRoot, "Application.dll");
+        await File.WriteAllTextAsync(assemblyPath, "original", TestContext.Current.CancellationToken);
+        var store = new FileSystemStore(Path.Combine(_root, storePath), NullLogger<FileSystemStore>.Instance);
+        var outsidePath = $"../{siblingPath}/Application.dll";
+        using var stream = new MemoryStream("replacement"u8.ToArray());
+
+        await Assert.ThrowsAsync<FileStoreException>(() => store.CreateFileFromStreamAsync(outsidePath, stream, overwrite: true));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.GetFileInfoAsync(outsidePath));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.GetDirectoryInfoAsync($"../{siblingPath}"));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.GetFileStreamAsync(outsidePath));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.TryDeleteFileAsync(outsidePath));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.TryDeleteDirectoryAsync($"../{siblingPath}"));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.TryCreateDirectoryAsync($"../{siblingPath}/new"));
+
+        using var source = new MemoryStream("media"u8.ToArray());
+        await store.CreateFileFromStreamAsync("source.dll", source);
+        await Assert.ThrowsAsync<FileStoreException>(() => store.CopyFileAsync("source.dll", $"../{siblingPath}/copy.dll"));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.MoveFileAsync("source.dll", $"../{siblingPath}/moved.dll"));
+
+        Assert.Equal("original", await File.ReadAllTextAsync(assemblyPath, TestContext.Current.CancellationToken));
+        Assert.Single(Directory.GetFiles(siblingRoot));
+        Assert.Empty(Directory.GetDirectories(siblingRoot));
+        Assert.True(File.Exists(Path.Combine(storeRoot, "source.dll")));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetFileInfo_PathResolvingInsideRoot_ReturnsCanonicalRelativePath(bool trailingSeparator)
+    {
+        var store = new FileSystemStore(
+            trailingSeparator ? _root + Path.DirectorySeparatorChar : _root,
+            NullLogger<FileSystemStore>.Instance);
+        using var stream = new MemoryStream("media"u8.ToArray());
+        await store.CreateFileFromStreamAsync("folder/../file.txt", stream);
+
+        var info = await store.GetFileInfoAsync("folder/../file.txt");
+
+        Assert.Equal("file.txt", info.Path);
+        Assert.NotNull(await store.GetDirectoryInfoAsync(null));
+        Assert.NotNull(await store.GetDirectoryInfoAsync("."));
+        Assert.NotNull(await store.GetDirectoryInfoAsync("folder/.."));
+    }
+
+    [Fact]
+    public async Task CreateFile_CaseVariantRootEscapeOnNonWindows_RejectsWrite()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(Path.Combine(_root, "Media"));
+        var store = new FileSystemStore(Path.Combine(_root, "Media"), NullLogger<FileSystemStore>.Instance);
+        using var stream = new MemoryStream("replacement"u8.ToArray());
+
+        await Assert.ThrowsAsync<FileStoreException>(() => store.CreateFileFromStreamAsync("../media/file.txt", stream));
+    }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaOptionsExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaOptionsExtensionsTests.cs
@@ -60,6 +60,7 @@ public class MediaOptionsExtensionsTests
 
     private static MediaOptions CreateOptions() => new()
     {
+        AssetsPath = "Media",
         AllowedFileExtensions = new(StringComparer.OrdinalIgnoreCase) { ".jpg" },
         RestrictedFileExtensions = new(StringComparer.OrdinalIgnoreCase) { ".svg" },
     };

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaPathTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaPathTests.cs
@@ -1,0 +1,132 @@
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Media;
+using OrchardCore.Media.Services;
+using MediaStartup = OrchardCore.Media.Startup;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+public class MediaPathTests
+{
+    public static TheoryData<string> InvalidAssetsPaths => new()
+    {
+        null,
+        "",
+        " ",
+        ".",
+        "..",
+        "/",
+        "/application",
+        @"\application",
+        @"\\server\share",
+        "C:/application",
+        @"C:\application",
+        "C:application",
+        "../../../",
+        "../OtherTenant/Media",
+        "Media/../../../../",
+        @"Media\..\..\..\..",
+        "Media/../Media2",
+        "Media/./Images",
+        "Media//Images",
+        "Media/.. /Images",
+        "Media/.../Images",
+        "Media /Images",
+        "Media\0",
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidAssetsPaths))]
+    public void Validate_InvalidAssetsPath_Fails(string assetsPath)
+    {
+        var options = new MediaOptions
+        {
+            AssetsPath = assetsPath,
+            AllowedFileExtensions = [],
+            RestrictedFileExtensions = [],
+        };
+
+        var result = new MediaOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains("AssetsPath", result.FailureMessage);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidAssetsPaths))]
+    public void GetMediaPath_InvalidAssetsPath_Throws(string assetsPath)
+    {
+        using var settings = new ShellSettings { Name = "Tenant" };
+
+        Assert.Throws<ArgumentException>(() => MediaStartup.GetMediaPath(CreateShellOptions(), settings, assetsPath));
+    }
+
+    [Theory]
+    [InlineData("Media", "Media")]
+    [InlineData("Media/", "Media")]
+    [InlineData(@"Media\", "Media")]
+    [InlineData("Assets/Media", "Assets/Media")]
+    [InlineData(@"Assets\Media", "Assets/Media")]
+    [InlineData("My Assets/Media", "My Assets/Media")]
+    public void GetMediaPath_ValidAssetsPath_ResolvesInsideEachTenant(string assetsPath, string relativePath)
+    {
+        var shellOptions = CreateShellOptions();
+        var options = new MediaOptions
+        {
+            AssetsPath = assetsPath,
+            AllowedFileExtensions = [],
+            RestrictedFileExtensions = [],
+        };
+
+        Assert.True(new MediaOptionsValidator().Validate(Options.DefaultName, options).Succeeded);
+
+        foreach (var tenant in new[] { "Default", "OtherTenant" })
+        {
+            using var settings = new ShellSettings { Name = tenant };
+            var expected = Path.GetFullPath(Path.Combine(
+                shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, tenant, relativePath));
+
+            Assert.Equal(expected, MediaStartup.GetMediaPath(shellOptions, settings, assetsPath));
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResolveMediaServices_InvalidConfiguredRoot_FailsOptionsValidation(bool resolveFileProvider)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["OrchardCore_Media:AssetsPath"] = "../../../../",
+                ["OrchardCore_Media:AllowedFileExtensions:0"] = ".dll",
+            })
+            .Build();
+        var shellConfiguration = new Mock<IShellConfiguration>();
+        shellConfiguration.Setup(c => c.GetSection("OrchardCore_Media"))
+            .Returns(configuration.GetSection("OrchardCore_Media"));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(shellConfiguration.Object);
+        using var settings = new ShellSettings { Name = "Tenant" };
+        services.AddSingleton(settings);
+        services.Configure<ShellOptions>(options =>
+        {
+            options.ShellsApplicationDataPath = CreateShellOptions().ShellsApplicationDataPath;
+            options.ShellsContainerName = "Sites";
+        });
+        new MediaStartup().ConfigureServices(services);
+
+        using var provider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService(resolveFileProvider ? typeof(IMediaFileProvider) : typeof(IMediaFileStore)));
+
+        Assert.Contains("AssetsPath", exception.Message);
+    }
+
+    private static ShellOptions CreateShellOptions() => new()
+    {
+        ShellsApplicationDataPath = Path.Combine(Path.GetTempPath(), "media-path-tests", "App_Data"),
+        ShellsContainerName = "Sites",
+    };
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaStepTests.cs
@@ -1,0 +1,202 @@
+using System.Text.Json.Nodes;
+using OrchardCore.Environment.Shell;
+using OrchardCore.FileStorage;
+using OrchardCore.FileStorage.FileSystem;
+using OrchardCore.Media;
+using OrchardCore.Media.Core;
+using OrchardCore.Media.Core.Helpers;
+using OrchardCore.Media.Recipes;
+using OrchardCore.Recipes.Models;
+using MediaStartup = OrchardCore.Media.Startup;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+public class MediaStepTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("../Application.dll")]
+    [InlineData(@"..\Application.dll")]
+    [InlineData("images/../../Application.dll")]
+    [InlineData(@"images\..\..\Application.dll")]
+    [InlineData("/Application.dll")]
+    [InlineData(@"\Application.dll")]
+    [InlineData("C:/Application.dll")]
+    [InlineData(@"C:\Application.dll")]
+    [InlineData("C:Application.dll")]
+    [InlineData(@"\\server\share\Application.dll")]
+    [InlineData("images/../Application.dll")]
+    [InlineData("images/./Application.dll")]
+    [InlineData("images//Application.dll")]
+    [InlineData("images/.. /Application.dll")]
+    [InlineData("images/.../Application.dll")]
+    [InlineData("images /Application.dll")]
+    [InlineData("images/Application.dll ")]
+    [InlineData("images/Application.dll.")]
+    [InlineData("images/Application.dll/")]
+    [InlineData("images/\0Application.dll")]
+    public async Task ExecuteAsync_InvalidTarget_RejectsBeforeReadingAnySource(string targetPath)
+    {
+        foreach (var source in new[] { "Base64", "SourcePath", "SourceUrl" })
+        {
+            var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+            var httpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+            var fileProvider = new Mock<IFileProvider>(MockBehavior.Strict);
+            var step = CreateStep(store.Object, httpClientFactory.Object);
+            var context = CreateContext(targetPath, source, "must not be read");
+            context.RecipeDescriptor = new RecipeDescriptor { FileProvider = fileProvider.Object };
+
+            await step.ExecuteAsync(context);
+
+            Assert.Contains("relative file path", Assert.Single(context.Errors));
+            store.VerifyNoOtherCalls();
+            httpClientFactory.VerifyNoOtherCalls();
+            fileProvider.VerifyNoOtherCalls();
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidPathAlias_RejectsBeforeWriting()
+    {
+        var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+        var context = CreateContext("../Application.dll", "Base64", "must not be read", usePathAlias: true);
+
+        await CreateStep(store.Object).ExecuteAsync(context);
+
+        Assert.Contains("relative file path", Assert.Single(context.Errors));
+        store.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("image.JPG")]
+    [InlineData("images/image.jpg")]
+    [InlineData(@"images\image.jpg")]
+    [InlineData("styles/site.css")]
+    [InlineData("scripts/site.js")]
+    [InlineData("images/icon.SVG")]
+    public async Task ExecuteAsync_AllowedRelativeTarget_WritesThroughFilePipeline(string targetPath)
+    {
+        var bytes = "media content"u8.ToArray();
+        var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+        var fileHandler = new Mock<IFileEventHandler>();
+        fileHandler.Setup(h => h.CreatingAsync(It.IsAny<FileCreatingContext>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((FileCreatingContext _, Stream stream, CancellationToken _) => FileCreatingResult.Success(stream));
+        store.Setup(s => s.CreateFileFromStreamAsync(targetPath, It.IsAny<Stream>(), true))
+            .Callback<string, Stream, bool>((_, stream, _) =>
+            {
+                using var copy = new MemoryStream();
+                stream.CopyTo(copy);
+                Assert.Equal(bytes, copy.ToArray());
+            })
+            .ReturnsAsync(targetPath);
+        store.Setup(s => s.GetFileInfoAsync(targetPath)).ReturnsAsync(Mock.Of<IFileStoreEntry>());
+        var context = CreateContext(targetPath, "Base64", Convert.ToBase64String(bytes));
+
+        await CreateStep(store.Object, fileCreationService: new FileCreationService([fileHandler.Object])).ExecuteAsync(context);
+
+        Assert.Empty(context.Errors);
+        store.Verify(s => s.CreateFileFromStreamAsync(targetPath, It.IsAny<Stream>(), true), Times.Once);
+        fileHandler.Verify(h => h.CreatingAsync(It.IsAny<FileCreatingContext>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()), Times.Once);
+        fileHandler.Verify(h => h.CreatedAsync(It.IsAny<IFileStoreEntry>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnconfiguredExtension_RejectsBeforeReadingSource()
+    {
+        var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+        var context = CreateContext("application.exe", "Base64", "must not be read");
+
+        await CreateStep(store.Object).ExecuteAsync(context);
+
+        Assert.Contains("File extension not allowed", Assert.Single(context.Errors));
+        store.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AssemblyExtensionAllowed_OnlyOverwritesTenantMedia()
+    {
+        var root = Directory.CreateTempSubdirectory("media-step-tests").FullName;
+
+        try
+        {
+            var applicationAssembly = Path.Combine(root, "Application.dll");
+            await File.WriteAllTextAsync(applicationAssembly, "application assembly", TestContext.Current.CancellationToken);
+            using var settings = new ShellSettings { Name = "Tenant" };
+            var mediaRoot = MediaStartup.GetMediaPath(new ShellOptions
+            {
+                ShellsApplicationDataPath = Path.Combine(root, "App_Data"),
+                ShellsContainerName = "Sites",
+            }, settings, "Media");
+            var siblingDirectory = Directory.CreateDirectory(mediaRoot + "-other").FullName;
+            var siblingAssembly = Path.Combine(siblingDirectory, "Application.dll");
+            await File.WriteAllTextAsync(siblingAssembly, "other directory", TestContext.Current.CancellationToken);
+            Directory.CreateDirectory(mediaRoot);
+            var mediaFile = Path.Combine(mediaRoot, "Application.dll");
+            await File.WriteAllTextAsync(mediaFile, "old media", TestContext.Current.CancellationToken);
+
+            var store = new DefaultMediaFileStore(
+                new FileSystemStore(mediaRoot, NullLogger<FileSystemStore>.Instance),
+                "/media", "", [], [],
+                new FileSizeHelper(Mock.Of<IStringLocalizer<FileSizeHelper>>()),
+                NullLogger<DefaultMediaFileStore>.Instance);
+            var context = CreateContext("Application.dll", "Base64", Convert.ToBase64String("new media"u8));
+            var files = (JsonArray)context.Step["Files"];
+            foreach (var target in new[] { "../../../../Application.dll", "../Media-other/Application.dll", applicationAssembly })
+            {
+                files.Insert(0, new JsonObject
+                {
+                    ["TargetPath"] = target,
+                    ["Base64"] = Convert.ToBase64String("replacement"u8),
+                });
+            }
+
+            await CreateStep(store).ExecuteAsync(context);
+
+            Assert.Equal(3, context.Errors.Count);
+            Assert.Equal("application assembly", await File.ReadAllTextAsync(applicationAssembly, TestContext.Current.CancellationToken));
+            Assert.Equal("other directory", await File.ReadAllTextAsync(siblingAssembly, TestContext.Current.CancellationToken));
+            Assert.Equal("new media", await File.ReadAllTextAsync(mediaFile, TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static MediaStep CreateStep(
+        IMediaFileStore store,
+        IHttpClientFactory httpClientFactory = null,
+        FileCreationService fileCreationService = null)
+    {
+        var localizer = new Mock<IStringLocalizer<MediaStep>>();
+        localizer.Setup(l => l[It.IsAny<string>(), It.IsAny<object[]>()])
+            .Returns((string key, object[] args) => new LocalizedString(key, string.Format(key, args)));
+
+        return new MediaStep(
+            store,
+            fileCreationService ?? new FileCreationService([]),
+            Options.Create(new MediaOptions
+            {
+                AssetsPath = "Media",
+                AllowedFileExtensions = new(StringComparer.OrdinalIgnoreCase) { ".jpg", ".dll" },
+                RestrictedFileExtensions = new(StringComparer.OrdinalIgnoreCase) { ".css", ".js", ".svg" },
+            }),
+            httpClientFactory ?? Mock.Of<IHttpClientFactory>(),
+            localizer.Object);
+    }
+
+    private static RecipeExecutionContext CreateContext(string targetPath, string source, string value, bool usePathAlias = false) => new()
+    {
+        Name = "media",
+        Step = new JsonObject
+        {
+            ["Files"] = new JsonArray(new JsonObject
+            {
+                [usePathAlias ? "Path" : "TargetPath"] = targetPath,
+                [source] = value,
+            }),
+        },
+    };
+}


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

## Summary

- Require `AssetsPath` to be a relative subdirectory of the current tenant's data directory, with validation applied to both the media store and static file provider.
- Reject unsafe recipe `TargetPath`/`Path` values before reading Base64, file-provider, or remote sources. Preserve valid overwrites within the tenant media store.
- Canonicalize filesystem paths and enforce separator-aware, platform-appropriate containment so sibling directories cannot pass the root-prefix check.
- Document valid media-root configuration and recipe destination requirements.

## Regression coverage

- Invalid roots, rooted and drive-relative paths, traversal, and Windows path aliases.
- Application assembly and sibling-directory overwrite protection even when `.dll` is explicitly allowed.
- Valid nested media paths, existing-media overwrites, restricted extensions, and the file event pipeline.

## Validation

- 122 targeted media-root, recipe, filesystem, and media-pipeline tests passed.
- 137 adjacent media authorization and cache tests passed.

## Compatibility

Configurations that use absolute paths or traversal in `AssetsPath` now fail options validation. To relocate storage, configure the host's application data location instead.