### PR TITLE
[release/3.0] Backport tenant media isolation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
@@ -2,13 +2,14 @@ using System.Text.Json.Nodes;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
+using OrchardCore.Media.Services;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Recipes.Services;
 
 namespace OrchardCore.Media.Recipes;
 
 /// <summary>
-/// This recipe step creates a set of queries.
+/// Imports files into the tenant's media store using relative target paths.
 /// </summary>
 public sealed class MediaStep : NamedRecipeStepHandler
 {
@@ -37,6 +38,13 @@ public sealed class MediaStep : NamedRecipeStepHandler
 
         foreach (var file in model.Files)
         {
+            if (!MediaFileStorePathHelper.IsValidRelativePath(file.TargetPath))
+            {
+                context.Errors.Add(S["Media target path must be a relative file path without traversal segments: '{0}'", file.TargetPath]);
+
+                continue;
+            }
+
             if (!_allowedFileExtensions.Contains(Path.GetExtension(file.TargetPath), StringComparer.OrdinalIgnoreCase))
             {
                 context.Errors.Add(S["File extension not allowed: '{0}'", file.TargetPath]);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStorePathHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStorePathHelper.cs
@@ -1,0 +1,21 @@
+namespace OrchardCore.Media.Services;
+
+internal static class MediaFileStorePathHelper
+{
+    public static bool IsValidRelativePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path) ||
+            path[0] is '/' or '\\' ||
+            path.Contains(':') ||
+            path.Contains('\0'))
+        {
+            return false;
+        }
+
+        // Apply the same rules on every platform, including Windows path aliases.
+        return path.Split(PathExtensions.PathSeparators).All(segment =>
+            !string.IsNullOrWhiteSpace(segment) &&
+            !segment.EndsWith('.') &&
+            !segment.EndsWith(' '));
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsValidator.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Options;
+
+namespace OrchardCore.Media.Services;
+
+internal sealed class MediaOptionsValidator : IValidateOptions<MediaOptions>
+{
+    public ValidateOptionsResult Validate(string name, MediaOptions options)
+    {
+        if (!MediaFileStorePathHelper.IsValidRelativePath(options.AssetsPath?.TrimEnd(PathExtensions.PathSeparators)))
+        {
+            return ValidateOptionsResult.Fail(
+                "The OrchardCore_Media setting AssetsPath must be a relative subdirectory of the tenant's data directory, " +
+                "without empty, '.' or '..' segments, drive prefixes, or segments ending in a dot or space.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -87,6 +87,7 @@ public sealed class Startup : StartupBase
         services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddTransient<IConfigureOptions<MediaOptions>, MediaOptionsConfiguration>();
+        services.AddSingleton<IValidateOptions<MediaOptions>, MediaOptionsValidator>();
 
         services.AddSingleton<IMediaFileProvider>(serviceProvider =>
         {
@@ -226,9 +227,21 @@ public sealed class Startup : StartupBase
         app.UseStaticFiles(mediaOptions.StaticFileOptions);
     }
 
-    private static string GetMediaPath(ShellOptions shellOptions, ShellSettings shellSettings, string assetsPath)
+    internal static string GetMediaPath(ShellOptions shellOptions, ShellSettings shellSettings, string assetsPath)
     {
-        return PathExtensions.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellSettings.Name, assetsPath);
+        assetsPath = assetsPath?.TrimEnd(PathExtensions.PathSeparators);
+
+        if (!MediaFileStorePathHelper.IsValidRelativePath(assetsPath))
+        {
+            throw new ArgumentException("The media assets path must be a relative subdirectory of the tenant's data directory.", nameof(assetsPath));
+        }
+
+        return Path.GetFullPath(Path.Combine(
+            shellOptions.ShellsApplicationDataPath,
+            shellOptions.ShellsContainerName,
+            shellSettings.Name,
+            assetsPath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar)
+        ));
     }
 }
 

--- a/src/OrchardCore/OrchardCore.FileStorage.FileSystem/FileSystemStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.FileSystem/FileSystemStore.cs
@@ -11,7 +11,7 @@ public class FileSystemStore : IFileStore
     public FileSystemStore(string fileSystemPath, ILogger<FileSystemStore> logger)
     {
         _logger = logger;
-        _fileSystemPath = Path.GetFullPath(fileSystemPath);
+        _fileSystemPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(fileSystemPath));
     }
 
     public Task<IFileStoreEntry> GetFileInfoAsync(string path)
@@ -356,10 +356,12 @@ public class FileSystemStore : IFileStore
         {
             path = this.NormalizePath(path);
 
-            var physicalPath = string.IsNullOrEmpty(path) ? _fileSystemPath : Path.Combine(_fileSystemPath, path);
+            var physicalPath = string.IsNullOrEmpty(path) ? _fileSystemPath : Path.GetFullPath(Path.Combine(_fileSystemPath, path));
 
             // Verify that the resulting path is inside the root file system path.
-            var pathIsAllowed = Path.GetFullPath(physicalPath).StartsWith(_fileSystemPath, StringComparison.OrdinalIgnoreCase);
+            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            var rootPrefix = Path.EndsInDirectorySeparator(_fileSystemPath) ? _fileSystemPath : _fileSystemPath + Path.DirectorySeparatorChar;
+            var pathIsAllowed = physicalPath.Equals(_fileSystemPath, comparison) || physicalPath.StartsWith(rootPrefix, comparison);
             if (!pathIsAllowed)
             {
                 throw new FileStoreException($"The path '{path}' resolves to a physical path outside the file system store root.");

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/MediaOptions.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/MediaOptions.cs
@@ -64,7 +64,9 @@ public class MediaOptions
     public PathString AssetsRequestPath { get; set; }
 
     /// <summary>
-    /// The name of the folder used to store media assets inside the App_Data folder.
+    /// The relative subdirectory used to store media assets inside the tenant's data directory
+    /// (by default, App_Data/Sites/{tenant}/Media). Absolute paths, drive prefixes, empty segments,
+    /// and segments ending in a dot or space (including "." and "..") are not allowed.
     /// </summary>
     public string AssetsPath { get; set; }
 

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -341,7 +341,7 @@ The following configuration values are used by default and can be customized:
     "CdnBaseUrl": "https://your-cdn.com",
     // The path used when serving media assets.
     "AssetsRequestPath": "/media",
-    // The name of the folder used to store media assets inside the App_Data folder.
+    // The relative subdirectory used to store media assets inside the tenant's data directory.
     "AssetsPath": "Media",
     // Whether to use a token in the query string to prevent disc filling.
     "UseTokenizedQueryString": true,
@@ -403,6 +403,29 @@ The following configuration values are used by default and can be customized:
   }
 }
 ```
+
+### Media storage location
+
+`AssetsPath` is relative to the current tenant's data directory, which defaults to `App_Data/Sites/{tenant}`.
+The default value `Media` therefore stores files in `App_Data/Sites/{tenant}/Media`. Nested directories such as
+`Assets/Media` are supported, and both `/` and `\` can be used as separators.
+
+Absolute paths, drive prefixes (including drive-relative paths such as `C:Media`), empty paths or segments,
+and segments ending in a dot or space (including `.` and `..`) are rejected. A trailing directory separator is
+allowed. Invalid configuration fails Media options validation instead of exposing another tenant's data or
+the application directory through the media store or static file provider.
+
+To relocate tenant data to another volume, configure the host's application data location (for example, with
+the `ORCHARD_APP_DATA` environment variable) rather than using an absolute path or traversal in `AssetsPath`.
+
+### Recipe media imports
+
+Recipe media imports only accept extensions configured in `AllowedFileExtensions`.
+The `TargetPath` (or its `Path` alias) must be a relative file path within the media store. Rooted paths,
+drive prefixes, empty segments, and segments ending in a dot or space (including `.` and `..`) are rejected
+before any source is read or file is overwritten. This applies equally to `Base64`, `SourcePath`, and `SourceUrl`
+imports. Valid imports can overwrite existing media files, but cannot target application assemblies or files
+outside the tenant's media directory.
 
 To configure the `StaticFileOptions` in more detail, including event handlers, for the Media Library `StaticFileMiddleware` apply:
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.FileStorage/FileSystemStoreTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.FileStorage/FileSystemStoreTests.cs
@@ -1,0 +1,117 @@
+using OrchardCore.FileStorage;
+using OrchardCore.FileStorage.FileSystem;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.FileStorage;
+
+public class FileSystemStoreTests : IDisposable
+{
+    private readonly string _root;
+    private readonly FileSystemStore _store;
+
+    public FileSystemStoreTests()
+    {
+        _root = Directory.CreateTempSubdirectory("fs-store-tests").FullName;
+        _store = new FileSystemStore(_root, NullLogger<FileSystemStore>.Instance);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_root, true);
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<string> CreateFileAsync(string path, string content = "test content")
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+        return await _store.CreateFileFromStreamAsync(path, stream);
+    }
+
+    private async Task<string> ReadFileContentAsync(string path)
+    {
+        using var stream = await _store.GetFileStreamAsync(path);
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync();
+    }
+
+    [Fact]
+    public async Task CreateFile_ValidFolder_RoundTrips()
+    {
+        var result = await CreateFileAsync("folder/file.txt", "hello");
+
+        Assert.Equal("folder/file.txt", result);
+        Assert.Equal("hello", await ReadFileContentAsync("folder/file.txt"));
+
+        var info = await _store.GetFileInfoAsync("folder/file.txt");
+        Assert.NotNull(info);
+        Assert.Equal("file.txt", info.Name);
+    }
+
+    [Theory]
+    [InlineData("Media", "Media-other")]
+    [InlineData("Media/", "Media-other")]
+    [InlineData("Media", "MediaSibling")]
+    public async Task FileOperations_SiblingWithMatchingRootPrefix_RejectAccess(string storePath, string siblingPath)
+    {
+        var storeRoot = Directory.CreateDirectory(Path.Combine(_root, storePath)).FullName;
+        var siblingRoot = Directory.CreateDirectory(Path.Combine(_root, siblingPath)).FullName;
+        var assemblyPath = Path.Combine(siblingRoot, "Application.dll");
+        await File.WriteAllTextAsync(assemblyPath, "original", TestContext.Current.CancellationToken);
+        var store = new FileSystemStore(Path.Combine(_root, storePath), NullLogger<FileSystemStore>.Instance);
+        var outsidePath = $"../{siblingPath}/Application.dll";
+        using var stream = new MemoryStream("replacement"u8.ToArray());
+
+        await Assert.ThrowsAsync<FileStoreException>(() => store.CreateFileFromStreamAsync(outsidePath, stream, overwrite: true));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.GetFileInfoAsync(outsidePath));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.GetDirectoryInfoAsync($"../{siblingPath}"));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.GetFileStreamAsync(outsidePath));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.TryDeleteFileAsync(outsidePath));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.TryDeleteDirectoryAsync($"../{siblingPath}"));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.TryCreateDirectoryAsync($"../{siblingPath}/new"));
+
+        using var source = new MemoryStream("media"u8.ToArray());
+        await store.CreateFileFromStreamAsync("source.dll", source);
+        await Assert.ThrowsAsync<FileStoreException>(() => store.CopyFileAsync("source.dll", $"../{siblingPath}/copy.dll"));
+        await Assert.ThrowsAsync<FileStoreException>(() => store.MoveFileAsync("source.dll", $"../{siblingPath}/moved.dll"));
+
+        Assert.Equal("original", await File.ReadAllTextAsync(assemblyPath, TestContext.Current.CancellationToken));
+        Assert.Single(Directory.GetFiles(siblingRoot));
+        Assert.Empty(Directory.GetDirectories(siblingRoot));
+        Assert.True(File.Exists(Path.Combine(storeRoot, "source.dll")));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetFileInfo_PathResolvingInsideRoot_PreservesEntryPath(bool trailingSeparator)
+    {
+        var store = new FileSystemStore(
+            trailingSeparator ? _root + Path.DirectorySeparatorChar : _root,
+            NullLogger<FileSystemStore>.Instance);
+        using var stream = new MemoryStream("media"u8.ToArray());
+        await store.CreateFileFromStreamAsync("folder/../file.txt", stream);
+
+        var info = await store.GetFileInfoAsync("folder/../file.txt");
+
+        Assert.Equal("folder/../file.txt", info.Path);
+        Assert.Equal("media", await File.ReadAllTextAsync(Path.Combine(_root, "file.txt"), TestContext.Current.CancellationToken));
+        Assert.False(Directory.Exists(Path.Combine(_root, "folder")));
+        Assert.NotNull(await store.GetDirectoryInfoAsync(string.Empty));
+        Assert.NotNull(await store.GetDirectoryInfoAsync("."));
+        Assert.NotNull(await store.GetDirectoryInfoAsync("folder/.."));
+    }
+
+    [Fact]
+    public async Task CreateFile_CaseVariantRootEscapeOnNonWindows_RejectsWrite()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(Path.Combine(_root, "Media"));
+        var store = new FileSystemStore(Path.Combine(_root, "Media"), NullLogger<FileSystemStore>.Instance);
+        using var stream = new MemoryStream("replacement"u8.ToArray());
+
+        await Assert.ThrowsAsync<FileStoreException>(() => store.CreateFileFromStreamAsync("../media/file.txt", stream));
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaPathTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaPathTests.cs
@@ -1,0 +1,130 @@
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Media;
+using OrchardCore.Media.Services;
+using MediaStartup = OrchardCore.Media.Startup;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+public class MediaPathTests
+{
+    public static TheoryData<string> InvalidAssetsPaths => new()
+    {
+        null,
+        "",
+        " ",
+        ".",
+        "..",
+        "/",
+        "/application",
+        @"\application",
+        @"\\server\share",
+        "C:/application",
+        @"C:\application",
+        "C:application",
+        "../../../",
+        "../OtherTenant/Media",
+        "Media/../../../../",
+        @"Media\..\..\..\..",
+        "Media/../Media2",
+        "Media/./Images",
+        "Media//Images",
+        "Media/.. /Images",
+        "Media/.../Images",
+        "Media /Images",
+        "Media\0",
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidAssetsPaths))]
+    public void Validate_InvalidAssetsPath_Fails(string assetsPath)
+    {
+        var options = new MediaOptions
+        {
+            AssetsPath = assetsPath,
+            AllowedFileExtensions = [],
+        };
+
+        var result = new MediaOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains("AssetsPath", result.FailureMessage);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidAssetsPaths))]
+    public void GetMediaPath_InvalidAssetsPath_Throws(string assetsPath)
+    {
+        using var settings = new ShellSettings { Name = "Tenant" };
+
+        Assert.Throws<ArgumentException>(() => MediaStartup.GetMediaPath(CreateShellOptions(), settings, assetsPath));
+    }
+
+    [Theory]
+    [InlineData("Media", "Media")]
+    [InlineData("Media/", "Media")]
+    [InlineData(@"Media\", "Media")]
+    [InlineData("Assets/Media", "Assets/Media")]
+    [InlineData(@"Assets\Media", "Assets/Media")]
+    [InlineData("My Assets/Media", "My Assets/Media")]
+    public void GetMediaPath_ValidAssetsPath_ResolvesInsideEachTenant(string assetsPath, string relativePath)
+    {
+        var shellOptions = CreateShellOptions();
+        var options = new MediaOptions
+        {
+            AssetsPath = assetsPath,
+            AllowedFileExtensions = [],
+        };
+
+        Assert.True(new MediaOptionsValidator().Validate(Options.DefaultName, options).Succeeded);
+
+        foreach (var tenant in new[] { "Default", "OtherTenant" })
+        {
+            using var settings = new ShellSettings { Name = tenant };
+            var expected = Path.GetFullPath(Path.Combine(
+                shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, tenant, relativePath));
+
+            Assert.Equal(expected, MediaStartup.GetMediaPath(shellOptions, settings, assetsPath));
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResolveMediaServices_InvalidConfiguredRoot_FailsOptionsValidation(bool resolveFileProvider)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["OrchardCore_Media:AssetsPath"] = "../../../../",
+                ["OrchardCore_Media:AllowedFileExtensions:0"] = ".dll",
+            })
+            .Build();
+        var shellConfiguration = new Mock<IShellConfiguration>();
+        shellConfiguration.Setup(c => c.GetSection("OrchardCore_Media"))
+            .Returns(configuration.GetSection("OrchardCore_Media"));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(shellConfiguration.Object);
+        using var settings = new ShellSettings { Name = "Tenant" };
+        services.AddSingleton(settings);
+        services.Configure<ShellOptions>(options =>
+        {
+            options.ShellsApplicationDataPath = CreateShellOptions().ShellsApplicationDataPath;
+            options.ShellsContainerName = "Sites";
+        });
+        new MediaStartup(settings).ConfigureServices(services);
+
+        using var provider = services.BuildServiceProvider();
+        var exception = Assert.Throws<OptionsValidationException>(() =>
+            provider.GetRequiredService(resolveFileProvider ? typeof(IMediaFileProvider) : typeof(IMediaFileStore)));
+
+        Assert.Contains("AssetsPath", exception.Message);
+    }
+
+    private static ShellOptions CreateShellOptions() => new()
+    {
+        ShellsApplicationDataPath = Path.Combine(Path.GetTempPath(), "media-path-tests", "App_Data"),
+        ShellsContainerName = "Sites",
+    };
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaStepTests.cs
@@ -1,0 +1,192 @@
+using System.Text.Json.Nodes;
+using OrchardCore.Environment.Shell;
+using OrchardCore.FileStorage;
+using OrchardCore.FileStorage.FileSystem;
+using OrchardCore.Media;
+using OrchardCore.Media.Core;
+using OrchardCore.Media.Recipes;
+using OrchardCore.Recipes.Models;
+using MediaStartup = OrchardCore.Media.Startup;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media;
+
+public class MediaStepTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("../Application.dll")]
+    [InlineData(@"..\Application.dll")]
+    [InlineData("images/../../Application.dll")]
+    [InlineData(@"images\..\..\Application.dll")]
+    [InlineData("/Application.dll")]
+    [InlineData(@"\Application.dll")]
+    [InlineData("C:/Application.dll")]
+    [InlineData(@"C:\Application.dll")]
+    [InlineData("C:Application.dll")]
+    [InlineData(@"\\server\share\Application.dll")]
+    [InlineData("images/../Application.dll")]
+    [InlineData("images/./Application.dll")]
+    [InlineData("images//Application.dll")]
+    [InlineData("images/.. /Application.dll")]
+    [InlineData("images/.../Application.dll")]
+    [InlineData("images /Application.dll")]
+    [InlineData("images/Application.dll ")]
+    [InlineData("images/Application.dll.")]
+    [InlineData("images/Application.dll/")]
+    [InlineData("images/\0Application.dll")]
+    public async Task ExecuteAsync_InvalidTarget_RejectsBeforeReadingAnySource(string targetPath)
+    {
+        foreach (var source in new[] { "Base64", "SourcePath", "SourceUrl" })
+        {
+            var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+            var httpClientFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+            var fileProvider = new Mock<IFileProvider>(MockBehavior.Strict);
+            var step = CreateStep(store.Object, httpClientFactory.Object);
+            var context = CreateContext(targetPath, source, "must not be read");
+            context.RecipeDescriptor = new RecipeDescriptor { FileProvider = fileProvider.Object };
+
+            await step.ExecuteAsync(context);
+
+            Assert.Contains("relative file path", Assert.Single(context.Errors));
+            store.VerifyNoOtherCalls();
+            httpClientFactory.VerifyNoOtherCalls();
+            fileProvider.VerifyNoOtherCalls();
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidPathAlias_RejectsBeforeWriting()
+    {
+        var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+        var context = CreateContext("../Application.dll", "Base64", "must not be read", usePathAlias: true);
+
+        await CreateStep(store.Object).ExecuteAsync(context);
+
+        Assert.Contains("relative file path", Assert.Single(context.Errors));
+        store.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("image.JPG")]
+    [InlineData("images/image.jpg")]
+    [InlineData(@"images\image.jpg")]
+    [InlineData("styles/site.css")]
+    [InlineData("scripts/site.js")]
+    [InlineData("images/icon.SVG")]
+    public async Task ExecuteAsync_AllowedRelativeTarget_WritesToMediaStore(string targetPath)
+    {
+        var bytes = "media content"u8.ToArray();
+        var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+        store.Setup(s => s.CreateFileFromStreamAsync(targetPath, It.IsAny<Stream>(), true))
+            .Callback<string, Stream, bool>((_, stream, _) =>
+            {
+                using var copy = new MemoryStream();
+                stream.CopyTo(copy);
+                Assert.Equal(bytes, copy.ToArray());
+            })
+            .ReturnsAsync(targetPath);
+        var context = CreateContext(targetPath, "Base64", Convert.ToBase64String(bytes));
+
+        await CreateStep(store.Object).ExecuteAsync(context);
+
+        Assert.Empty(context.Errors);
+        store.Verify(s => s.CreateFileFromStreamAsync(targetPath, It.IsAny<Stream>(), true), Times.Once);
+        store.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnconfiguredExtension_RejectsBeforeReadingSource()
+    {
+        var store = new Mock<IMediaFileStore>(MockBehavior.Strict);
+        var context = CreateContext("application.exe", "Base64", "must not be read");
+
+        await CreateStep(store.Object).ExecuteAsync(context);
+
+        Assert.Contains("File extension not allowed", Assert.Single(context.Errors));
+        store.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AssemblyExtensionAllowed_OnlyOverwritesTenantMedia()
+    {
+        var root = Directory.CreateTempSubdirectory("media-step-tests").FullName;
+
+        try
+        {
+            var applicationAssembly = Path.Combine(root, "Application.dll");
+            await File.WriteAllTextAsync(applicationAssembly, "application assembly", TestContext.Current.CancellationToken);
+            using var settings = new ShellSettings { Name = "Tenant" };
+            var mediaRoot = MediaStartup.GetMediaPath(new ShellOptions
+            {
+                ShellsApplicationDataPath = Path.Combine(root, "App_Data"),
+                ShellsContainerName = "Sites",
+            }, settings, "Media");
+            var siblingDirectory = Directory.CreateDirectory(mediaRoot + "-other").FullName;
+            var siblingAssembly = Path.Combine(siblingDirectory, "Application.dll");
+            await File.WriteAllTextAsync(siblingAssembly, "other directory", TestContext.Current.CancellationToken);
+            Directory.CreateDirectory(mediaRoot);
+            var mediaFile = Path.Combine(mediaRoot, "Application.dll");
+            await File.WriteAllTextAsync(mediaFile, "old media", TestContext.Current.CancellationToken);
+
+            var store = new DefaultMediaFileStore(
+                new FileSystemStore(mediaRoot, NullLogger<FileSystemStore>.Instance),
+                "/media", "", [], [],
+                NullLogger<DefaultMediaFileStore>.Instance);
+            var context = CreateContext("Application.dll", "Base64", Convert.ToBase64String("new media"u8));
+            var files = (JsonArray)context.Step["Files"];
+            foreach (var target in new[] { "../../../../Application.dll", "../Media-other/Application.dll", applicationAssembly })
+            {
+                files.Insert(0, new JsonObject
+                {
+                    ["TargetPath"] = target,
+                    ["Base64"] = Convert.ToBase64String("replacement"u8),
+                });
+            }
+
+            await CreateStep(store).ExecuteAsync(context);
+
+            Assert.Equal(3, context.Errors.Count);
+            Assert.Equal("application assembly", await File.ReadAllTextAsync(applicationAssembly, TestContext.Current.CancellationToken));
+            Assert.Equal("other directory", await File.ReadAllTextAsync(siblingAssembly, TestContext.Current.CancellationToken));
+            Assert.Equal("new media", await File.ReadAllTextAsync(mediaFile, TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static MediaStep CreateStep(
+        IMediaFileStore store,
+        IHttpClientFactory httpClientFactory = null)
+    {
+        var localizer = new Mock<IStringLocalizer<MediaStep>>();
+        localizer.Setup(l => l[It.IsAny<string>(), It.IsAny<object[]>()])
+            .Returns((string key, object[] args) => new LocalizedString(key, string.Format(key, args)));
+
+        return new MediaStep(
+            store,
+            Options.Create(new MediaOptions
+            {
+                AssetsPath = "Media",
+                AllowedFileExtensions = new(StringComparer.OrdinalIgnoreCase) { ".jpg", ".dll", ".css", ".js", ".svg" },
+            }),
+            httpClientFactory ?? Mock.Of<IHttpClientFactory>(),
+            localizer.Object);
+    }
+
+    private static RecipeExecutionContext CreateContext(string targetPath, string source, string value, bool usePathAlias = false) => new()
+    {
+        Name = "media",
+        Step = new JsonObject
+        {
+            ["Files"] = new JsonArray(new JsonObject
+            {
+                [usePathAlias ? "Path" : "TargetPath"] = targetPath,
+                [source] = value,
+            }),
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Backports #19840 (source commit ecb09216cd2eac6a8feeab446bd4740893a99934) to **release/3.0**.

- Validate `AssetsPath` before resolving the media store or static file provider, keeping media roots beneath the tenant data directory.
- Reject unsafe recipe `TargetPath`/`Path` values before reading Base64, local, or HTTP sources while retaining valid overwrites.
- Enforce canonical, directory-separator-aware filesystem containment, including sibling-prefix and non-Windows case-variant escapes.
- Update media configuration documentation and add regression coverage.

## Release adaptations

Preserves release/3.0's `AllowedFileExtensions` checks, direct media-store write/event pipeline, existing service constructors, and file entry path semantics. Adds only the shared relative-path validator and root-only options validator registration. Does not import main-only restricted-extension options, file-creation services, authorization refactors, or dependencies. The release already uses xUnit v3.

## Validation

Passed **204 tests**, with no failures or skips, covering `MediaPathTests`, `MediaStepTests`, `FileSystemStoreTests`, `DefaultMediaFileStoreTests`, `MediaEventTests`, and `ViewMediaFolderAuthorizationHandlerTests` on macOS ARM64 / net10.0.

```sh
dotnet test --project test/OrchardCore.Tests/OrchardCore.Tests.csproj --no-restore --filter-class '*MediaPathTests' '*MediaStepTests' '*FileSystemStoreTests' '*DefaultMediaFileStoreTests' '*MediaEventTests' '*ViewMediaFolderAuthorizationHandlerTests' --verbosity quiet
```

This is a separate release backport; do not merge the main branch into release/3.0.