### PR TITLE
Fix Data Localization when Admin Menu is disabled

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -305,6 +305,17 @@ public sealed class DataLocalizationStartup : StartupBase
     {
         services.AddScoped<ILocalizationDataProvider, ContentTypeDataLocalizationProvider>();
         services.AddScoped<ILocalizationDataProvider, ContentFieldDataLocalizationProvider>();
+    }
+}
+
+/// <summary>
+/// Registers content-type admin menu localization when both supporting features are enabled.
+/// </summary>
+[RequireFeatures("OrchardCore.DataLocalization", "OrchardCore.AdminMenu")]
+public sealed class AdminMenuDataLocalizationStartup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
         services.AddScoped<ILocalizationDataProvider, ContentTypesAdminNodeDataLocalizationProvider>();
     }
 }

--- a/src/docs/reference/modules/DataLocalization/README.md
+++ b/src/docs/reference/modules/DataLocalization/README.md
@@ -92,6 +92,8 @@ The module includes these built-in `ILocalizationDataProvider` implementations:
 
 Provides admin menu display names for translation.
 
+Admin menu providers, including content-type admin menu nodes, require both `OrchardCore.DataLocalization` and `OrchardCore.AdminMenu`. Content type and content field display names remain available for translation when `OrchardCore.Contents` and `OrchardCore.DataLocalization` are enabled, even if `OrchardCore.AdminMenu` is disabled.
+
 - **Context**: `Admin Menus` or `Admin Menus:{menuName}`
 - **Strings**: Display names of all admin menu / sub menu items
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/DataLocalizationStartupTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/DataLocalizationStartupTests.cs
@@ -1,0 +1,87 @@
+using OrchardCore.AdminMenu.Services;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Contents;
+using OrchardCore.Contents.Services;
+using OrchardCore.Environment.Extensions;
+using OrchardCore.Environment.Extensions.Features;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Builders;
+using OrchardCore.Environment.Shell.Descriptor.Models;
+using OrchardCore.Localization.Data;
+using OrchardCore.Modules;
+using StartupBase = OrchardCore.Modules.StartupBase;
+
+namespace OrchardCore.DataLocalization.Services.Tests;
+
+public sealed class DataLocalizationStartupTests
+{
+    [Theory]
+    [InlineData(false, false, 0)]
+    [InlineData(false, true, 0)]
+    [InlineData(true, false, 2)]
+    [InlineData(true, true, 3)]
+    public async Task ConfigureServices_FeatureCombinations_ResolvesExpectedProviders(
+        bool dataLocalizationEnabled,
+        bool adminMenuEnabled,
+        int expectedProviderCount)
+    {
+        var contentsFeature = Mock.Of<IFeatureInfo>(feature => feature.Id == "OrchardCore.Contents");
+        var extensionManager = new Mock<IExtensionManager>();
+        extensionManager.Setup(manager => manager.LoadFeaturesAsync(It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync([contentsFeature]);
+        extensionManager.Setup(manager => manager.GetFeatures()).Returns([contentsFeature]);
+
+        // Discover the Contents module's data-localization startups so the real feature
+        // composition applies their RequireFeatures attributes before registration.
+        var startupTypes = typeof(DataLocalizationStartup).Assembly.GetExportedTypes()
+            .Where(type => typeof(StartupBase).IsAssignableFrom(type)
+                && RequireFeaturesAttribute.GetRequiredFeatureNamesForType(type)
+                    .Contains("OrchardCore.DataLocalization"))
+            .ToArray();
+        var typeFeatureProvider = new Mock<ITypeFeatureProvider>();
+        typeFeatureProvider.Setup(provider => provider.GetTypesForFeature(contentsFeature)).Returns(startupTypes);
+
+        var descriptor = new ShellDescriptor
+        {
+            Features = [new ShellFeature { Id = contentsFeature.Id }],
+        };
+        if (dataLocalizationEnabled)
+        {
+            descriptor.Features.Add(new ShellFeature { Id = "OrchardCore.DataLocalization" });
+        }
+
+        if (adminMenuEnabled)
+        {
+            descriptor.Features.Add(new ShellFeature { Id = "OrchardCore.AdminMenu" });
+        }
+
+        var strategy = new CompositionStrategy(extensionManager.Object, typeFeatureProvider.Object, Mock.Of<ILogger<CompositionStrategy>>());
+        var blueprint = await strategy.ComposeAsync(new ShellSettings { Name = "Test" }, descriptor);
+        var services = new ServiceCollection();
+        services.AddSingleton(Mock.Of<IContentDefinitionManager>());
+        if (adminMenuEnabled)
+        {
+            services.AddSingleton(Mock.Of<IAdminMenuAccessor>());
+        }
+
+        foreach (var startupType in blueprint.Dependencies.Keys)
+        {
+            ((StartupBase)Activator.CreateInstance(startupType)).ConfigureServices(services);
+        }
+
+        using var serviceProvider = services.BuildServiceProvider(validateScopes: true);
+        using var scope = serviceProvider.CreateScope();
+        // The Data Localization admin controller resolves this same provider collection.
+        var providers = scope.ServiceProvider.GetServices<ILocalizationDataProvider>().ToArray();
+
+        Assert.Equal(expectedProviderCount, providers.Length);
+        if (dataLocalizationEnabled)
+        {
+            Assert.Single(providers.OfType<ContentTypeDataLocalizationProvider>());
+            Assert.Single(providers.OfType<ContentFieldDataLocalizationProvider>());
+        }
+
+        Assert.Equal(dataLocalizationEnabled && adminMenuEnabled,
+            providers.Any(provider => provider is ContentTypesAdminNodeDataLocalizationProvider));
+    }
+}


### PR DESCRIPTION
Fixes #19828.

## Change

`OrchardCore.Contents` currently registers `ContentTypesAdminNodeDataLocalizationProvider` whenever Data Localization is enabled. Without Admin Menu, its `IAdminMenuAccessor` dependency cannot be resolved, preventing the Data Localization admin controller from activating.

Move only this provider to an `AdminMenuDataLocalizationStartup` that requires **both** features. Keep `ContentTypeDataLocalizationProvider` and `ContentFieldDataLocalizationProvider` in the existing Data Localization startup. No new manifest dependency or tenant configuration workaround is needed.

The module documentation now explains that admin-menu translation is optional and ordinary content-type/field translation remains available without it.

## Regression coverage

The test uses Orchard's actual `CompositionStrategy` to apply the startup feature gates, then resolves `IEnumerable<ILocalizationDataProvider>` through a scoped service provider, as the admin controller does. `IAdminMenuAccessor` is registered in the test only when Admin Menu is enabled.

With Contents enabled:

| Data Localization | Admin Menu | Expected Contents providers |
|---|---|---|
| Disabled | Disabled | None |
| Disabled | Enabled | None |
| Enabled | Disabled | Content types and content fields |
| Enabled | Enabled | Content types, content fields and admin-menu nodes |

Before the production fix, the regression test produced **3 passed / 1 failed**, with the exact `IAdminMenuAccessor` activation exception reported in the issue.

## Validation

- Test project build: **0 warnings / 0 errors**.
- Focused regression and related data-localization, data-localizer, shell-composition and shell-container tests: **40 passed / 0 failed / 0 skipped**.
- `git diff --check`: clean.
- Scope: automated tests; no new browser walkthrough or full test-board run is claimed.

```powershell
dotnet build test/OrchardCore.Tests/OrchardCore.Tests.csproj --no-restore -m:4
dotnet test/OrchardCore.Tests/bin/Debug/net10.0/OrchardCore.Tests.dll -class '*DataLocalization*' -class '*DataLocalizer*' -class '*CompositionStrategyTests' -class '*ShellContainerFactoryTests' -noColor
```
