### PR TITLE
Add copy buttons to documentation code samples

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ theme:
   logo: assets/images/orchard-logo.png
   favicon: assets/images/favicon.png
   features:
+    - content.code.copy
     - content.tabs.link
     - header.autohide
     - navigation.footer


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

## Summary

Enable Material for MkDocs' built-in `content.code.copy` feature globally so documentation code blocks include a copy-to-clipboard button. No additional plugin, dependency upgrade, or custom JavaScript is needed.

Fixes #19846.

## Screenshot

![Documentation code sample with the native copy-to-clipboard button](https://github.com/user-attachments/assets/386c5e9c-d216-462d-80ac-f0dec0707222)

## Validation

- Documentation builds successfully with `python -m mkdocs build --strict`.
- Confirmed clipboard content, indentation, and success feedback for regular and tabbed samples, keyboard and mouse activation in light/dark themes, and copying after instant navigation.