### PR TITLE
Remove transliterate option from slugify filter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/SlugifyFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/SlugifyFilter.cs
@@ -12,6 +12,7 @@ public class SlugifyFilter : ILiquidFilter
     {
         _slugService = slugService;
     }
+
     public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext ctx)
     {
         var slug = _slugService.Slugify(input.ToStringValue());

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -102,23 +102,6 @@ Output
 this-is-some-text
 ```
 
-There is an option to transliterate (by default `true`) which first transliterates and slugifies afterwards:
-
-```liquid
-{{ "Ελληνικά" | slugify }}
-```
-or 
-```liquid
-{{ "Ελληνικά" | slugify: transliterate: true}}
-```
-
-Output
-
-```text
-ellinika
-```
-
-
 ### `local`
 
 Converts a UTC date and time to the local date and time based on the site settings.


### PR DESCRIPTION
This option has been removed. We can pipe `transliterate` with `slugify` to make this work 