### PR TITLE
Remove IDataResourceStringProvider

### DIFF
--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/Data/IDataResourceStringProvider.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/Data/IDataResourceStringProvider.cs
@@ -1,6 +1,0 @@
-namespace OrchardCore.Localization.Data;
-
-public interface IDataResourceStringProvider
-{
-    IEnumerable<CultureDictionaryRecordKey> GetAllResourceStrings();
-}


### PR DESCRIPTION
Deprecate `IDataResourceStringProvider`  because it's no longer needed and to avoid breaking changes