### PR TITLE
Add 'Content Items' breadcrumb for listable content types (Fixes #6666)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
@@ -20,7 +20,8 @@
     <zone name="Breadcrumbs">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin" asp-route-contentTypeId="@contentItem.ContentType">@T["Content Items"]</a></li>
+                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin">@T["Content Items"]</a></li>
+                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin" asp-route-contentTypeId="@contentItem.ContentType">@localizedTypeDisplayName</a></li>
                 <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["New {0}", localizedTypeDisplayName])</li>
             </ol>
         </nav>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
@@ -12,11 +12,35 @@
     var contentTypeDefinition = await ContentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
     var typeDisplayName = contentTypeDefinition?.DisplayName ?? contentItem.ContentType.CamelFriendly();
     string localizedTypeDisplayName = D[typeDisplayName, DataLocalizationContext.ContentType];
+    var returnUrl = Context.Request.Query["ReturnUrl"];
+}
+
+@if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
+{
+    <zone name="Breadcrumbs">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="@returnUrl">@T["Back"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["New {0}", localizedTypeDisplayName])</li>
+            </ol>
+        </nav>
+    </zone>
+}
+else if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Listable)
+{
+    <zone name="Breadcrumbs">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin" asp-route-contentTypeId="@contentItem.ContentType">@T["Content Items"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["New {0}", localizedTypeDisplayName])</li>
+            </ol>
+        </nav>
+    </zone>
 }
 
 <zone Name="Title"><h1>@RenderTitleSegments(T["New {0}", localizedTypeDisplayName])</h1></zone>
 
-<form asp-action="Create" asp-route-returnUrl="@Context.Request.Query["ReturnUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
+<form asp-action="Create" asp-route-returnUrl="@returnUrl" method="post" enctype="multipart/form-data" class="no-multisubmit">
     @if (!ViewContext.ModelState.IsValid)
     {
         @Html.ValidationSummary()

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Create.cshtml
@@ -15,18 +15,7 @@
     var returnUrl = Context.Request.Query["ReturnUrl"];
 }
 
-@if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
-{
-    <zone name="Breadcrumbs">
-        <nav aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="@returnUrl">@T["Back"]</a></li>
-                <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["New {0}", localizedTypeDisplayName])</li>
-            </ol>
-        </nav>
-    </zone>
-}
-else if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Listable)
+@if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Listable)
 {
     <zone name="Breadcrumbs">
         <nav aria-label="breadcrumb">

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
@@ -12,11 +12,35 @@
     var contentTypeDefinition = await ContentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
     var typeDisplayName = contentTypeDefinition?.DisplayName ?? contentItem.ContentType.CamelFriendly();
     string localizedTypeDisplayName = D[typeDisplayName, DataLocalizationContext.ContentType];
+    var returnUrl = Context.Request.Query["returnUrl"];
+}
+
+@if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
+{
+    <zone name="Breadcrumbs">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="@returnUrl">@T["Back"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["Edit {0}", localizedTypeDisplayName])</li>
+            </ol>
+        </nav>
+    </zone>
+}
+else if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Listable)
+{
+    <zone name="Breadcrumbs">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin" asp-route-contentTypeId="@contentItem.ContentType">@T["Content Items"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["Edit {0}", localizedTypeDisplayName])</li>
+            </ol>
+        </nav>
+    </zone>
 }
 
 <zone Name="Title"><h1>@RenderTitleSegments(T["Edit {0}", localizedTypeDisplayName])</h1></zone>
 
-<form asp-action="Edit" asp-route-contentitemid="@contentItem.ContentItemId" asp-route-returnUrl="@Context.Request.Query["returnUrl"]" method="post" enctype="multipart/form-data" class="no-multisubmit">
+<form asp-action="Edit" asp-route-contentitemid="@contentItem.ContentItemId" asp-route-returnUrl="@returnUrl" method="post" enctype="multipart/form-data" class="no-multisubmit">
     @if (!ViewContext.ModelState.IsValid)
     {
         @Html.ValidationSummary()

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
@@ -15,18 +15,7 @@
     var returnUrl = Context.Request.Query["returnUrl"];
 }
 
-@if (!string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
-{
-    <zone name="Breadcrumbs">
-        <nav aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="@returnUrl">@T["Back"]</a></li>
-                <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["Edit {0}", localizedTypeDisplayName])</li>
-            </ol>
-        </nav>
-    </zone>
-}
-else if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Listable)
+@if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Listable)
 {
     <zone name="Breadcrumbs">
         <nav aria-label="breadcrumb">

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/Edit.cshtml
@@ -20,7 +20,8 @@
     <zone name="Breadcrumbs">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin" asp-route-contentTypeId="@contentItem.ContentType">@T["Content Items"]</a></li>
+                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin">@T["Content Items"]</a></li>
+                <li class="breadcrumb-item"><a asp-action="List" asp-controller="Admin" asp-route-contentTypeId="@contentItem.ContentType">@localizedTypeDisplayName</a></li>
                 <li class="breadcrumb-item active" aria-current="page">@RenderTitleSegments(T["Edit {0}", localizedTypeDisplayName])</li>
             </ol>
         </nav>


### PR DESCRIPTION
﻿Fixes #6666.

This PR adds a breadcrumb back link exclusively for **listable content types**. 

### Addressing previous maintainer feedback
In a previous attempt by another user to fix this (#19491), the maintainers pointed out two issues:
1. Using the generic 'returnUrl' to render a 'Back' button is redundant because the 'Cancel' button already does that.
2. The breadcrumb should be smart and display a meaningful label (like 'Content Items'), or be omitted entirely.

**This PR explicitly resolves those concerns:**
- It intentionally does **not** rely on 'returnUrl'.
- It only renders the breadcrumb if the content type is explicitly 'Listable'.
- It explicitly labels the breadcrumb **Content Items**.
- For any edge cases, unknown navigation sources, or non-listable types, the breadcrumb is intentionally omitted (falling back to the native Cancel button).

This is a minimal, low-risk change that directly addresses the open issue while respecting the maintainers' previous feedback.
